### PR TITLE
Add publishedDate to Publication (OCT 147)

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -70,13 +70,14 @@ enum LicenceType {
 }
 
 model Publication {
-    id       String          @id @default(cuid())
-    url_slug String          @unique @default(cuid())
-    type     PublicationType
-    title    String?
-    licence  LicenceType?
-    content  String?
-    doi      String?
+    id            String          @id @default(cuid())
+    url_slug      String          @unique @default(cuid())
+    type          PublicationType
+    title         String?
+    licence       LicenceType?
+    content       String?
+    doi           String?
+    publishedDate DateTime?
 
     currentStatus PublicationStatusEnum @default(DRAFT)
 

--- a/api/prisma/seeds/publications.ts
+++ b/api/prisma/seeds/publications.ts
@@ -40,6 +40,7 @@ const publicationSeeds = [
         licence: 'CC_BY',
         content: 'Publication PROBLEM-LIVE',
         currentStatus: 'LIVE',
+        publishedDate: '2022-01-22T15:51:42.523Z',
         user: {
             connect: {
                 id: 'test-user-1'
@@ -88,6 +89,7 @@ const publicationSeeds = [
         licence: 'CC_BY',
         content: 'Publication HYPOTHESIS-LIVE',
         currentStatus: 'LIVE',
+        publishedDate: '2022-01-22T15:51:42.523Z',
         user: {
             connect: {
                 id: 'test-user-1'
@@ -135,6 +137,7 @@ const publicationSeeds = [
         licence: 'CC_BY',
         content: 'Publication PROTOCOL-LIVE',
         currentStatus: 'LIVE',
+        publishedDate: '2022-01-22T15:51:42.523Z',
         user: {
             connect: {
                 id: 'test-user-1'
@@ -182,6 +185,7 @@ const publicationSeeds = [
         licence: 'CC_BY',
         content: 'Publication DATA-LIVE',
         currentStatus: 'LIVE',
+        publishedDate: '2022-01-22T15:51:42.523Z',
         user: {
             connect: {
                 id: 'test-user-1'
@@ -229,6 +233,7 @@ const publicationSeeds = [
         licence: 'CC_BY',
         content: 'Publication ANALYSIS-LIVE',
         currentStatus: 'LIVE',
+        publishedDate: '2022-01-22T15:51:42.523Z',
         user: {
             connect: {
                 id: 'test-user-1'
@@ -276,6 +281,7 @@ const publicationSeeds = [
         licence: 'CC_BY',
         content: 'Publication INTERPRETATION-LIVE',
         currentStatus: 'LIVE',
+        publishedDate: '2022-01-22T15:51:42.523Z',
         user: {
             connect: {
                 id: 'test-user-1'
@@ -323,6 +329,7 @@ const publicationSeeds = [
         licence: 'CC_BY',
         content: 'Publication REAL_WORLD_APPLICATION-LIVE',
         currentStatus: 'LIVE',
+        publishedDate: '2022-01-22T15:51:42.523Z',
         user: {
             connect: {
                 id: 'test-user-1'

--- a/api/src/components/publication/__tests__/createPublication.ts
+++ b/api/src/components/publication/__tests__/createPublication.ts
@@ -110,4 +110,20 @@ describe('Create publication', () => {
 
         expect(createPublicationRequest.status).toEqual(422);
     });
+
+    test('Valid publication created by real user with content does not have a publishedDate (200)', async () => {
+        const createPublicationRequest = await testUtils.agent
+            .post('/publications')
+            .query({
+                apiKey: '123456789'
+            })
+            .send({
+                type: 'PEER_REVIEW',
+                title: 'Publication test 2',
+                content: 'Content'
+            });
+
+        expect(createPublicationRequest.status).toEqual(200);
+        expect(createPublicationRequest.body.publishedDate).toBeNull();
+    });
 });

--- a/api/src/components/publication/__tests__/updateStatus.ts
+++ b/api/src/components/publication/__tests__/updateStatus.ts
@@ -74,6 +74,7 @@ describe('Update publication status', () => {
 
         expect(updatedPublication.status).toEqual(404);
     });
+
     test('User with permissions cannot update their publication to LIVE from DRAFT if there is no licence.', async () => {
         const updatedPublication = await testUtils.agent
             .put('/publications/publication-hypothesis-draft/status/LIVE')
@@ -82,5 +83,16 @@ describe('Update publication status', () => {
             });
 
         expect(updatedPublication.status).toEqual(404);
+    });
+
+    test('User with permissions can update their publication to LIVE from DRAFT and a publishedDate is created', async () => {
+        const updatedPublication = await testUtils.agent
+            .put('/publications/publication-hypothesis-draft-problem-live/status/LIVE')
+            .query({
+                apiKey: '123456789'
+            });
+
+        expect(updatedPublication.status).toEqual(200);
+        expect(updatedPublication.body.publishedDate).toBeTruthy();
     });
 });

--- a/api/src/components/publication/controller.ts
+++ b/api/src/components/publication/controller.ts
@@ -129,9 +129,12 @@ export const updateStatus = async (
             });
         }
 
+        const shouldPublishedDateBeUpdated = !!!publication.publishedDate && event.pathParameters.status === 'LIVE';
+
         const updatedPublication = await publicationService.updateStatus(
             event.pathParameters.id,
-            event.pathParameters.status
+            event.pathParameters.status,
+            shouldPublishedDateBeUpdated
         );
 
         return response.json(200, updatedPublication);

--- a/api/src/components/publication/schema/getAll.ts
+++ b/api/src/components/publication/schema/getAll.ts
@@ -19,7 +19,7 @@ const getAllSchema: I.Schema = {
         },
         orderBy: {
             type: 'string',
-            enum: ['id', 'createdAt', 'updatedAt', 'title'],
+            enum: ['id', 'createdAt', 'updatedAt', 'publishedDate', 'title'],
             default: 'updatedAt'
         },
         orderDirection: {

--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -196,8 +196,8 @@ export const create = async (e: I.CreatePublicationRequestBody, user: I.User) =>
     return publication;
 };
 
-export const updateStatus = async (id: string, status: I.PublicationStatus) => {
-    const updatedPublication = await prisma.publication.update({
+export const updateStatus = async (id: string, status: I.PublicationStatus, updatePublishedDate: boolean) => {
+    const query = {
         where: {
             id
         },
@@ -228,7 +228,15 @@ export const updateStatus = async (id: string, status: I.PublicationStatus) => {
                 }
             }
         }
-    });
+    };
+
+    if (updatePublishedDate) {
+        // @ts-ignore
+        query.data.publishedDate = new Date().toISOString();
+    }
+
+    // @ts-ignore
+    const updatedPublication = await prisma.publication.update(query);
 
     return updatedPublication;
 };


### PR DESCRIPTION
The purpose of this PR was to add publishedDate field to Publication

---

### Acceptance Criteria:

- When a publication goes to live, it should either create a publishedDate (if one doesn't exist). If one does, do not update.

---

### Tests:

- Valid publication created by real user with content does not have a publishedDate (200)
- User with permissions can update their publication to LIVE from DRAFT and a publishedDate is created
