### PR TITLE
Update seed data (OCT 154)

### DIFF
--- a/api/prisma/seeds/publicationsDevSeedData.ts
+++ b/api/prisma/seeds/publicationsDevSeedData.ts
@@ -1114,7 +1114,8 @@ const newPublicationSeeds = [
         title: 'Peer Review of Analysis of the data from a retrospective cohort study of 191 inpatients in Wuhan with COVID-19',
         type: PublicationTypes.peerReview,
         licence: 'CC_BY',
-        content: '<h2>Title</h2><p>TBC</p>',
+        content:
+            '<h2>Peer Review of Analysis of the data from a retrospective cohort study of 191 inpatients in Wuhan with COVID-19</h2><p>This is the first comprehensive review in this field.</p>',
         currentStatus: PublicationStatus.live,
         createdAt: '2021-09-25T16:51:42.523Z',
         updatedAt: '2021-09-25T16:51:42.523Z',


### PR DESCRIPTION
The purpose of this PR was: because the shape of a publication has changed, the seed data needs to be updated to reflect this.


Issues picked up from the more complex seed data:

- Display on UI of linked Problems and linked Peer Reviews are not showing in the correct sections at the moment, and all Peer Review links from are showing as Real-World Applications.
- can only have one publicationTo and one publicationFrom at the moment on each seed/publication as they are both strings. So for example you couldn't link data to two protocols or data to a protocol and problem.
- The links that are created on the draft publications to live publications are shown up on the UI, but clicking through to the draft will not show the draft-just the link is shown.

---

### Acceptance Criteria:

- To update the seed data with publishDate, licence and conflict of interest.
- To add more seed data entries from publications that have been chosen.

---

