### PR TITLE
Fix total number of users (OCT-172)

### DIFF
--- a/api/src/components/user/service.ts
+++ b/api/src/components/user/service.ts
@@ -49,7 +49,7 @@ export const getAll = async (filters: I.UserFilters) => {
     return {
         data: users,
         metadata: {
-            total: 2,
+            total: totalUsers,
             limit: Number(filters.limit) || 10,
             offset: Number(filters.offset) || 0
         }


### PR DESCRIPTION
The purpose of this PR was to fix a bug where the total number of users was being returned as 2. 

I changed the total value in the metadata object to accurately reflect the total user count based on filtering.