### PR TITLE
When viewing publications, draft links should be hidden (OCT-173)

### DIFF
--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -138,6 +138,11 @@ export const get = async (id: string) => {
                 }
             },
             linkedTo: {
+                where: {
+                    publicationToRef: {
+                        currentStatus: 'LIVE'
+                    }
+                },
                 select: {
                     id: true,
                     publicationToRef: {
@@ -160,6 +165,11 @@ export const get = async (id: string) => {
                 }
             },
             linkedFrom: {
+                where: {
+                    publicationFromRef: {
+                        currentStatus: 'LIVE'
+                    }
+                },
                 select: {
                     id: true,
                     publicationFromRef: {


### PR DESCRIPTION
The purpose of this PR was to fix an issue raised by @shaunajisc and @CarlyRich. Currently, publications can only be viewed publically that are live, this is good. However, if those publications have publications linked from it in `DRAFT`, those are visible.

When a publication is created and updated, links can be created from that publication (in `DRAFT`) to other "correct" publications (in `LIVE`). This means that although a connection exists in the database, it can be considered "inactive" and should not be displayed. Only when a publication's status is updated to `LIVE` (i.e published), should those links be visible.

To achieve this I added a `where` statement inside the `include` query in Prisma. I'm not an expert at Prisma, so I'm hoping that @CarlyRich can help validate this fix has worked, as she has more context on the seed data than I do.

---

### Acceptance Criteria:

- When hitting `GET /publications/{id}`, only linked publications that are `LIVE` should be shown.

---
