### PR TITLE
Fix issue where ORCID login was not working because of null values

### DIFF
--- a/api/src/components/authorization/controller.ts
+++ b/api/src/components/authorization/controller.ts
@@ -42,14 +42,14 @@ export const authorize = async (event: I.APIRequest<I.AuthorizeRequestBody>): Pr
                 role: employmentItem.summaries[0]['employment-summary']['role-title'] || null,
                 department: employmentItem.summaries[0]['department-name'] || null,
                 startDate: {
-                    day: employmentItem.summaries[0]['employment-summary']['start-date']?.day.value || null,
-                    month: employmentItem.summaries[0]['employment-summary']['start-date']?.month.value || null,
-                    year: employmentItem.summaries[0]['employment-summary']['start-date']?.year.value || null
+                    day: employmentItem.summaries[0]['employment-summary']['start-date']?.day?.value || null,
+                    month: employmentItem.summaries[0]['employment-summary']['start-date']?.month?.value || null,
+                    year: employmentItem.summaries[0]['employment-summary']['start-date']?.year?.value || null
                 },
                 endDate: {
-                    day: employmentItem.summaries[0]['employment-summary']['end-date']?.day.value || null,
-                    month: employmentItem.summaries[0]['employment-summary']['end-date']?.month.value || null,
-                    year: employmentItem.summaries[0]['employment-summary']['end-date']?.year.value || null
+                    day: employmentItem.summaries[0]['employment-summary']['end-date']?.day?.value || null,
+                    month: employmentItem.summaries[0]['employment-summary']['end-date']?.month?.value || null,
+                    year: employmentItem.summaries[0]['employment-summary']['end-date']?.year?.value || null
                 }
             })
         );
@@ -60,14 +60,14 @@ export const authorize = async (event: I.APIRequest<I.AuthorizeRequestBody>): Pr
                 role: educationItem.summaries[0]['education-summary']['role-title'] || null,
                 department: educationItem.summaries[0]['department-name'] || null,
                 startDate: {
-                    day: educationItem.summaries[0]['education-summary']['start-date']?.day.value || null,
-                    month: educationItem.summaries[0]['education-summary']['start-date']?.month.value || null,
-                    year: educationItem.summaries[0]['education-summary']['start-date']?.year.value || null
+                    day: educationItem.summaries[0]['education-summary']['start-date']?.day?.value || null,
+                    month: educationItem.summaries[0]['education-summary']['start-date']?.month?.value || null,
+                    year: educationItem.summaries[0]['education-summary']['start-date']?.year?.value || null
                 },
                 endDate: {
-                    day: educationItem.summaries[0]['education-summary']['end-date']?.day.value || null,
-                    month: educationItem.summaries[0]['education-summary']['end-date']?.month.value || null,
-                    year: educationItem.summaries[0]['education-summary']['end-date']?.year.value || null
+                    day: educationItem.summaries[0]['education-summary']['end-date']?.day?.value || null,
+                    month: educationItem.summaries[0]['education-summary']['end-date']?.month?.value || null,
+                    year: educationItem.summaries[0]['education-summary']['end-date']?.year?.value || null
                 }
             })
         );

--- a/ui/src/pages/publications/[id]/index.tsx
+++ b/ui/src/pages/publications/[id]/index.tsx
@@ -151,7 +151,7 @@ const Publication: Types.NextPage<Props> = (props): JSX.Element => {
                             {/* Linked publications */}
                             <Components.PublicationContentSection id="linked-publications" title="Linked publications">
                                 <>
-                                    {linkedPublicationsTo.length ? (
+                                    {linkedPublicationsTo.length || linkedPublicationsFrom.length ? (
                                         <Components.List ordered={false}>
                                             <>
                                                 {linkedPublicationsTo.map((link) => (


### PR DESCRIPTION
The purpose of this PR was to fix the issue that was causing certain users to not be able to login. This was caused by possible null values for `{ day: null }`.

This was fixed with more optional chaining.

Also fixed the issue where certain publications were not displaying. This was an easy fix, i needed to display if either `linkedTo` or `linkedFrom` have length, previously I was only checking `linkedTo`.