### PR TITLE
Added employment & education history to public profile

### DIFF
--- a/api/src/components/user/service.ts
+++ b/api/src/components/user/service.ts
@@ -115,6 +115,8 @@ export const get = async (id: string) => {
             role: true,
             createdAt: true,
             updatedAt: true,
+            employment: true,
+            education: true,
             Publication: {
                 select: {
                     id: true,

--- a/ui/src/components/Avatar/index.tsx
+++ b/ui/src/components/Avatar/index.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import * as Interfaces from '@interfaces';
 
 type Props = {
-    user: Interfaces.User;
+    user: Interfaces.CoreUser;
     className?: string;
 };
 

--- a/ui/src/components/Users/HistoryTable/index.tsx
+++ b/ui/src/components/Users/HistoryTable/index.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+import * as Interfaces from '@interfaces';
+
+type Props = {
+    heads: string[];
+    records: Interfaces.OrcidHistoryRecord[];
+};
+
+const HistoryTable: React.FC<Props> = (props) => (
+    <div className="mt-8 flex flex-col">
+        <div className="-my-2 -mx-4 overflow-x-auto sm:-mx-6 lg:-mx-8">
+            <div className="inline-block min-w-full py-2 align-middle md:px-6 lg:px-8">
+                <div className="overflow-hidden shadow ring-1 ring-black ring-opacity-5 dark:ring-transparent md:rounded-lg">
+                    <table className="min-w-full divide-y divide-grey-100 dark:divide-teal-300">
+                        <thead className="bg-grey-50 transition-colors duration-500 dark:bg-grey-700">
+                            <tr>
+                                {props.heads.map((head, index) => (
+                                    <th
+                                        key={head}
+                                        scope="col"
+                                        className={`whitespace-pre py-3.5 text-left text-sm font-semibold text-grey-900 transition-colors duration-500 dark:text-grey-50 ${
+                                            index === 0 ? 'pl-4 pr-3 sm:pl-6' : 'px-3'
+                                        }`}
+                                    >
+                                        {head}
+                                    </th>
+                                ))}
+                            </tr>
+                        </thead>
+                        <tbody className="divide-y divide-grey-100 bg-white transition-colors duration-500 dark:divide-teal-300 dark:bg-grey-600">
+                            {props.records.map((record, index) => (
+                                <tr key={index}>
+                                    <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-grey-900 transition-colors duration-500 dark:text-white sm:pl-6">
+                                        {record.organisation}
+                                    </td>
+                                    <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-grey-500 transition-colors duration-500 dark:text-grey-100">
+                                        {record.role ?? 'Not specified'}
+                                    </td>
+                                    <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-grey-500 transition-colors duration-500 dark:text-grey-100">
+                                        {record.department ?? 'Not specified'}
+                                    </td>
+                                    <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-grey-500 transition-colors duration-500 dark:text-grey-100">
+                                        {record.startDate.day &&
+                                            record.startDate.month &&
+                                            record.startDate.year &&
+                                            `${record.startDate.day}/${record.startDate.month}/${record.startDate.year}`}
+                                    </td>
+                                    <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-grey-500 transition-colors duration-500 dark:text-grey-100">
+                                        {record.endDate.day &&
+                                            record.endDate.month &&
+                                            record.endDate.year &&
+                                            `${record.endDate.day}/${record.endDate.month}/${record.endDate.year}`}
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+);
+
+export default HistoryTable;

--- a/ui/src/components/Users/SearchResult/index.tsx
+++ b/ui/src/components/Users/SearchResult/index.tsx
@@ -7,7 +7,7 @@ import * as Components from '@components';
 import * as Config from '@config';
 
 type Props = {
-    user: Interfaces.User;
+    user: Interfaces.CoreUser;
     className?: string;
 };
 

--- a/ui/src/components/index.tsx
+++ b/ui/src/components/index.tsx
@@ -41,6 +41,7 @@ export { default as CommandPalette } from './CommandPalette';
 export { default as CommandPaletteResult } from './CommandPalette/Result';
 export { default as Overlay } from './Overlay';
 export { default as UserSearchResult } from './Users/SearchResult';
+export { default as UserHistoryTable } from './Users/HistoryTable';
 export { default as PageTitle } from './PageTitle';
 export { default as Alert } from './Alert';
 export { default as Accordion } from './Accordion';

--- a/ui/src/lib/interfaces.ts
+++ b/ui/src/lib/interfaces.ts
@@ -81,11 +81,34 @@ export interface Publication extends CorePublication {
     conflictOfInterestText: string | null;
 }
 
-export interface User {
+export interface CoreUser {
     id: string;
     firstName: string;
     lastName: string;
     orcid: string;
+}
+
+export interface OrcidDateRecord {
+    day: string | null;
+    month: string | null;
+    year: string | null;
+}
+
+export interface OrcidHistoryRecord {
+    department: string | null;
+    organisation: string | null;
+    role: string | null;
+    startDate: OrcidDateRecord;
+    endDate: OrcidDateRecord;
+}
+
+export interface EmploymentRecord extends OrcidHistoryRecord {}
+
+export interface EducationRecord extends OrcidHistoryRecord {}
+
+export interface User extends CoreUser {
+    education: EducationRecord[];
+    employment: EmploymentRecord[];
     Publication: Publication[];
 }
 

--- a/ui/src/pages/authors/[id]/index.tsx
+++ b/ui/src/pages/authors/[id]/index.tsx
@@ -79,6 +79,42 @@ const Author: Types.NextPage<Props> = (props): JSX.Element => {
                         <Components.PublicationBreakdown publications={props.user.Publication} />
                     </section>
 
+                    <section className="container mx-auto px-8 pb-12 lg:pb-24">
+                        <h2 className="mb-4 font-montserrat text-xl font-semibold text-grey-800 transition-colors duration-500 dark:text-white lg:mb-8">
+                            Employment
+                        </h2>
+                        <div className="2xl:w-2/3">
+                            {props.user.employment.length ? (
+                                <Components.UserHistoryTable
+                                    heads={['Organisation', 'Role', 'Department', 'Start date', 'End date']}
+                                    records={props.user.employment}
+                                />
+                            ) : (
+                                <p className="text-grey-800 transition-colors duration-500 dark:text-white">
+                                    No history available.
+                                </p>
+                            )}
+                        </div>
+                    </section>
+
+                    <section className="container mx-auto px-8 pb-12 lg:pb-24">
+                        <h2 className="mb-4 font-montserrat text-xl font-semibold text-grey-800 transition-colors duration-500 dark:text-white lg:mb-8">
+                            Education
+                        </h2>
+                        <div className="2xl:w-2/3">
+                            {props.user.education.length ? (
+                                <Components.UserHistoryTable
+                                    heads={['Organisation', 'Degree/title', 'Department', 'Start date', 'End date']}
+                                    records={props.user.education}
+                                />
+                            ) : (
+                                <p className="text-grey-800 transition-colors duration-500 dark:text-white">
+                                    No history available.
+                                </p>
+                            )}
+                        </div>
+                    </section>
+
                     <section className="container mx-auto mb-16 px-8">
                         <h2 className="mb-4 font-montserrat text-xl font-semibold text-grey-800 transition-colors duration-500 dark:text-white lg:mb-8">
                             Octopus publications

--- a/ui/src/pages/search.tsx
+++ b/ui/src/pages/search.tsx
@@ -24,7 +24,7 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
     let orderDirection: string | string[] | null = null;
 
     // defaults to results
-    let results: Interfaces.Publication[] | Interfaces.User[] | [] = [];
+    let results: Interfaces.Publication[] | Interfaces.CoreUser[] | [] = [];
     let metadata: Interfaces.SearchResultMeta | {} = {};
 
     // default error


### PR DESCRIPTION
The purpose of this PR was display an orcid users education & employment history on their public profile page.

[For Jira ticket: 184](https://jiscdev.atlassian.net/jira/software/projects/OCT/boards/836?selectedIssue=OCT-184)

---

### Acceptance Criteria:

Now that the api / database is storing user data from orcid on the users employment & educational history. This information needs to be displayed on the users (authors) public page.

- If author has employment history from orcid, it should be made visible on their author page
- If author has education history from oricd, it should be made visible on their author page

---

### Tests:

![Screenshot 2022-03-14 at 12 02 59](https://user-images.githubusercontent.com/81176162/158168358-9fb7e702-6723-4a5a-a1db-0c97e4747327.png)


---

### Screenshots:

https://user-images.githubusercontent.com/81176162/158167581-cca02a20-428c-42e2-b279-5a0ea5009dc7.mov


