### PR TITLE
Updated search result page filtering to align with api (oct-185)

### DIFF
--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -63,7 +63,7 @@ export const search = async (
     publicationType: string | null = null,
     limit: number | null = null,
     offset: number | null = null,
-    orderBy: Types.OrderBySearchOption | null = null,
+    orderBy: Types.PublicationOrderBySearchOption | Types.UserOrderBySearchOption | null = null,
     orderDirection: Types.OrderDirectionSearchOption | null = null
 ): Promise<Interfaces.SearchResults> => {
     let endpoint: string = searchType === 'users' ? Config.endpoints.users : Config.endpoints.publications;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -45,7 +45,9 @@ export type JSONValue = string | number | boolean | { [x: string]: JSONValue } |
 
 export type SearchType = 'publications' | 'users';
 
-export type OrderBySearchOption = 'createdAt' | 'updatedAt' | 'publishedDate';
+export type PublicationOrderBySearchOption = 'title' | 'publishedDate';
+
+export type UserOrderBySearchOption = 'updatedAt' | 'createdAt';
 
 export type OrderDirectionSearchOption = 'asc' | 'desc';
 

--- a/ui/src/pages/search.tsx
+++ b/ui/src/pages/search.tsx
@@ -87,7 +87,7 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
     const swrKey = `/${searchType}?search=${query || ''}${
         searchType === 'publications' ? `&type=${publicationTypes}` : ''
     }&limit=${limit || '10'}&offset=${offset || '0'}&orderBy=${orderBy || 'createdAt'}&orderDirection=${
-        orderDirection || 'asc'
+        orderDirection || 'desc'
     }`;
 
     return {
@@ -139,7 +139,7 @@ const Search: Types.NextPage<Props> = (props): JSX.Element => {
     const swrKey = `/${searchType}?search=${query || ''}${
         searchType === 'publications' ? `&type=${publicationTypes}` : ''
     }&limit=${limit || '10'}&offset=${offset || '0'}&orderBy=${orderBy || 'publishedDate'}&orderDirection=${
-        orderDirection || 'asc'
+        orderDirection || 'desc'
     }`;
 
     const { data: { data: results = [] } = {}, error, isValidating } = useSWR(swrKey);
@@ -189,7 +189,7 @@ const Search: Types.NextPage<Props> = (props): JSX.Element => {
     const resetFilters = (e: React.MouseEvent<HTMLButtonElement>) => {
         setQuery('');
         searchInputRef.current && (searchInputRef.current.value = '');
-        setOrderDirection('asc');
+        setOrderDirection('desc');
         setOffset(0);
         setLimit(10);
         if (searchType === 'publications') {


### PR DESCRIPTION
The purpose of this PR was to update the UI so that the search filtering options better align with the octopus api as the search functionality has been updated to use OpenSearch. 

[For jira ticket 185](https://jiscdev.atlassian.net/jira/software/projects/OCT/boards/836?selectedIssue=OCT-185)

---

### Acceptance Criteria:

User should only be able to order publications results by title or published date
