### PR TITLE
Exclude ids from GET /publications

### DIFF
--- a/api/src/components/publication/schema/getAll.ts
+++ b/api/src/components/publication/schema/getAll.ts
@@ -20,6 +20,10 @@ const getAllSchema: I.Schema = {
         search: {
             type: 'string',
             default: ''
+        },
+        exclude: {
+            type: 'string',
+            default: ''
         }
     },
     additionalProperties: false

--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -180,6 +180,11 @@ export const getOpenSearchRecords = async (filters: I.PublicationFilters) => {
                             fields: ['title^3', 'cleanContent', 'keywords^2', 'description^2']
                         }
                     },
+                    must_not: {
+                        terms: {
+                            _id: filters.exclude.split(',')
+                        }
+                    },
                     filter: {
                         terms: {
                             type: (filters.type

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -110,6 +110,7 @@ export interface PublicationFilters {
     limit?: string;
     offset?: string;
     type: string;
+    exclude: string;
 }
 
 /**


### PR DESCRIPTION
The purpose of this PR was to modify the `GET /publications` to include an `exclude` query parameter.

> GET /publications?exclude=id1,id2

This endpoint is primarily used for finding a list of "linkable" publications. We will pass in a comma seperated list of ids that should not be returned from the DB.
