### PR TITLE
Create an API endpoint for a flagging dispute process

### DIFF
--- a/api/prisma/migrations/20220412125234_init/migration.sql
+++ b/api/prisma/migrations/20220412125234_init/migration.sql
@@ -1,0 +1,29 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `comments` on the `PublicationFlags` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX "PublicationFlags_publicationId_category_createdBy_key";
+
+-- AlterTable
+ALTER TABLE "PublicationFlags" DROP COLUMN "comments",
+ADD COLUMN     "resolved" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateTable
+CREATE TABLE "FlagComments" (
+    "id" TEXT NOT NULL,
+    "flagId" TEXT NOT NULL,
+    "comment" TEXT NOT NULL,
+    "createdBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "FlagComments_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "FlagComments" ADD CONSTRAINT "FlagComments_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FlagComments" ADD CONSTRAINT "FlagComments_flagId_fkey" FOREIGN KEY ("flagId") REFERENCES "PublicationFlags"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -1,156 +1,166 @@
 generator client {
-  provider        = "prisma-client-js"
-  previewFeatures = ["fullTextSearch"]
-  binaryTargets   = ["native", "rhel-openssl-1.0.x"]
+    provider        = "prisma-client-js"
+    previewFeatures = ["fullTextSearch"]
+    binaryTargets   = ["native", "rhel-openssl-1.0.x"]
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+    provider = "postgresql"
+    url      = env("DATABASE_URL")
 }
 
 model User {
-  id                 String               @id @default(cuid())
-  orcid              String               @unique
-  firstName          String
-  lastName           String?
-  email              String?
-  role               Role                 @default(USER)
-  locked             Boolean              @default(false)
-  apiKey             String               @unique @default(uuid())
-  createdAt          DateTime             @default(now())
-  updatedAt          DateTime             @updatedAt
-  employment         Json[]
-  works              Json[]
-  education          Json[]
-  coAuthors          CoAuthors[]
-  Publication        Publication[]
-  PublicationFlags   PublicationFlags[]
-  PublicationRatings PublicationRatings[]
+    id                 String               @id @default(cuid())
+    orcid              String               @unique
+    firstName          String
+    lastName           String?
+    email              String?
+    role               Role                 @default(USER)
+    locked             Boolean              @default(false)
+    apiKey             String               @unique @default(uuid())
+    createdAt          DateTime             @default(now())
+    updatedAt          DateTime             @updatedAt
+    employment         Json[]
+    works              Json[]
+    education          Json[]
+    coAuthors          CoAuthors[]
+    Publication        Publication[]
+    PublicationFlags   PublicationFlags[]
+    PublicationRatings PublicationRatings[]
+    flagComments       FlagComments[]
 }
 
 model Publication {
-  id                       String                @id @default(cuid())
-  url_slug                 String                @unique @default(cuid())
-  type                     PublicationType
-  title                    String?
-  licence                  LicenceType?
-  conflictOfInterestStatus Boolean?              @default(false)
-  conflictOfInterestText   String?
-  description              String?
-  keywords                 String[]
-  content                  String?
-  doi                      String?
-  publishedDate            DateTime?
-  currentStatus            PublicationStatusEnum @default(DRAFT)
-  createdBy                String
-  createdAt                DateTime              @default(now())
-  updatedAt                DateTime              @updatedAt
-  user                     User                  @relation(fields: [createdBy], references: [id], onDelete: Cascade)
-  coAuthors                CoAuthors[]
-  linkedTo                 Links[]               @relation("from")
-  linkedFrom               Links[]               @relation("to")
-  publicationFlags         PublicationFlags[]
-  publicationRatings       PublicationRatings[]
-  publicationStatus        PublicationStatus[]
+    id                       String                @id @default(cuid())
+    url_slug                 String                @unique @default(cuid())
+    type                     PublicationType
+    title                    String?
+    licence                  LicenceType?
+    conflictOfInterestStatus Boolean?              @default(false)
+    conflictOfInterestText   String?
+    description              String?
+    keywords                 String[]
+    content                  String?
+    doi                      String?
+    publishedDate            DateTime?
+    currentStatus            PublicationStatusEnum @default(DRAFT)
+    createdBy                String
+    createdAt                DateTime              @default(now())
+    updatedAt                DateTime              @updatedAt
+    user                     User                  @relation(fields: [createdBy], references: [id], onDelete: Cascade)
+    coAuthors                CoAuthors[]
+    linkedTo                 Links[]               @relation("from")
+    linkedFrom               Links[]               @relation("to")
+    publicationFlags         PublicationFlags[]
+    publicationRatings       PublicationRatings[]
+    publicationStatus        PublicationStatus[]
 }
 
 model Links {
-  id                 String      @id @default(cuid())
-  publicationFrom    String
-  publicationTo      String
-  active             Boolean?    @default(true)
-  createdAt          DateTime    @default(now())
-  updatedAt          DateTime    @updatedAt
-  publicationFromRef Publication @relation("from", fields: [publicationFrom], references: [id], onDelete: Cascade)
-  publicationToRef   Publication @relation("to", fields: [publicationTo], references: [id], onDelete: Cascade)
+    id                 String      @id @default(cuid())
+    publicationFrom    String
+    publicationTo      String
+    active             Boolean?    @default(true)
+    createdAt          DateTime    @default(now())
+    updatedAt          DateTime    @updatedAt
+    publicationFromRef Publication @relation("from", fields: [publicationFrom], references: [id], onDelete: Cascade)
+    publicationToRef   Publication @relation("to", fields: [publicationTo], references: [id], onDelete: Cascade)
 
-  @@unique([publicationFrom, publicationTo])
+    @@unique([publicationFrom, publicationTo])
 }
 
 model PublicationStatus {
-  id            String                @id @default(cuid())
-  publicationId String
-  status        PublicationStatusEnum
-  createdAt     DateTime              @default(now())
-  publication   Publication           @relation(fields: [publicationId], references: [id], onDelete: Cascade)
+    id            String                @id @default(cuid())
+    publicationId String
+    status        PublicationStatusEnum
+    createdAt     DateTime              @default(now())
+    publication   Publication           @relation(fields: [publicationId], references: [id], onDelete: Cascade)
 }
 
 model CoAuthors {
-  id                String      @id @default(cuid())
-  publicationId     String
-  email             String
-  code              String      @default(cuid())
-  confirmedCoAuthor Boolean     @default(false)
-  linkedUser        String?
-  user              User?       @relation(fields: [linkedUser], references: [id])
-  publication       Publication @relation(fields: [publicationId], references: [id], onDelete: Cascade)
+    id                String      @id @default(cuid())
+    publicationId     String
+    email             String
+    code              String      @default(cuid())
+    confirmedCoAuthor Boolean     @default(false)
+    linkedUser        String?
+    user              User?       @relation(fields: [linkedUser], references: [id])
+    publication       Publication @relation(fields: [publicationId], references: [id], onDelete: Cascade)
 
-  @@unique([publicationId, email])
+    @@unique([publicationId, email])
 }
 
 model PublicationFlags {
-  id            String                      @id @default(cuid())
-  publicationId String
-  category      PublicationFlagCategoryEnum
-  comments      String
-  createdBy     String
-  createdAt     DateTime                    @default(now())
-  user          User                        @relation(fields: [createdBy], references: [id], onDelete: Cascade)
-  publication   Publication                 @relation(fields: [publicationId], references: [id], onDelete: Cascade)
+    id            String                      @id @default(cuid())
+    publicationId String
+    category      PublicationFlagCategoryEnum
+    resolved      Boolean                     @default(false)
+    createdBy     String
+    createdAt     DateTime                    @default(now())
+    user          User                        @relation(fields: [createdBy], references: [id], onDelete: Cascade)
+    publication   Publication                 @relation(fields: [publicationId], references: [id], onDelete: Cascade)
+    flagComments  FlagComments[]
+}
 
-  @@unique([publicationId, category, createdBy])
+model FlagComments {
+    id        String           @id @default(cuid())
+    flagId    String
+    comment   String
+    createdBy String
+    createdAt DateTime         @default(now())
+    user      User             @relation(fields: [createdBy], references: [id], onDelete: Cascade)
+    flag      PublicationFlags @relation(fields: [flagId], references: [id], onDelete: Cascade)
 }
 
 model PublicationRatings {
-  id            String      @id @default(cuid())
-  publicationId String
-  userId        String
-  rating        Int
-  category      String
-  publication   Publication @relation(fields: [publicationId], references: [id], onDelete: Cascade)
-  user          User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+    id            String      @id @default(cuid())
+    publicationId String
+    userId        String
+    rating        Int
+    category      String
+    publication   Publication @relation(fields: [publicationId], references: [id], onDelete: Cascade)
+    user          User        @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@unique([publicationId, userId, category])
+    @@unique([publicationId, userId, category])
 }
 
 enum Role {
-  SUPER_USER
-  FUNDER
-  USER
+    SUPER_USER
+    FUNDER
+    USER
 }
 
 enum PublicationStatusEnum {
-  DRAFT
-  LIVE
-  HIDDEN
+    DRAFT
+    LIVE
+    HIDDEN
 }
 
 enum PublicationType {
-  PROBLEM
-  PROTOCOL
-  ANALYSIS
-  REAL_WORLD_APPLICATION
-  HYPOTHESIS
-  DATA
-  INTERPRETATION
-  PEER_REVIEW
+    PROBLEM
+    PROTOCOL
+    ANALYSIS
+    REAL_WORLD_APPLICATION
+    HYPOTHESIS
+    DATA
+    INTERPRETATION
+    PEER_REVIEW
 }
 
 enum PublicationFlagCategoryEnum {
-  PLAGIARISM
-  ETHICAL_ISSUES
-  MISREPRESENTATION
-  UNDECLARED_IMAGE_MANIPULATION
-  COPYRIGHT
-  INAPPROPRIATE
+    PLAGIARISM
+    ETHICAL_ISSUES
+    MISREPRESENTATION
+    UNDECLARED_IMAGE_MANIPULATION
+    COPYRIGHT
+    INAPPROPRIATE
 }
 
 enum LicenceType {
-  CC_BY
-  CC_BY_SA
-  CC_BY_ND
-  CC_BY_NC
-  CC_BY_NC_SA
-  CC_BY_NC_ND
+    CC_BY
+    CC_BY_SA
+    CC_BY_ND
+    CC_BY_NC
+    CC_BY_NC_SA
+    CC_BY_NC_ND
 }

--- a/api/prisma/seeds/publications.ts
+++ b/api/prisma/seeds/publications.ts
@@ -53,34 +53,53 @@ const publicationSeeds = [
                 code: 'test'
             }
         },
+        publicationFlags: {
+            create: {
+                id: 'publication-problem-live-flag',
+                createdBy: 'test-user-2',
+                category: 'PLAGIARISM',
+                flagComments: {
+                    create: {
+                        createdBy: 'test-user-2',
+                        comment: 'This is a comment'
+                    }
+                }
+            }
+        },
         publicationRatings: {
             create: [
                 {
+                    id: 'publication-problem-live-test-user-2-PROBLEM_WELL_DEFINED',
                     userId: 'test-user-2',
                     rating: 5,
                     category: 'PROBLEM_WELL_DEFINED'
                 },
                 {
+                    id: 'publication-problem-live-test-user-2-PROBLEM_ORIGINAL',
                     userId: 'test-user-2',
                     rating: 10,
                     category: 'PROBLEM_ORIGINAL'
                 },
                 {
+                    id: 'publication-problem-live-test-user-2-PROBLEM_IMPORTANT',
                     userId: 'test-user-2',
                     rating: 8,
                     category: 'PROBLEM_IMPORTANT'
                 },
                 {
+                    id: 'publication-problem-live-test-user-3-PROBLEM_WELL_DEFINED',
                     userId: 'test-user-3',
                     rating: 7,
                     category: 'PROBLEM_WELL_DEFINED'
                 },
                 {
+                    id: 'publication-problem-live-test-user-3-PROBLEM_ORIGINAL',
                     userId: 'test-user-3',
                     rating: 8,
                     category: 'PROBLEM_ORIGINAL'
                 },
                 {
+                    id: 'publication-problem-live-test-user-3-PROBLEM_IMPORTANT',
                     userId: 'test-user-3',
                     rating: 6,
                     category: 'PROBLEM_IMPORTANT'
@@ -149,6 +168,20 @@ const publicationSeeds = [
         user: {
             connect: {
                 id: 'test-user-1'
+            }
+        },
+        publicationFlags: {
+            create: {
+                id: 'publication-hypothesis-live-flag',
+                createdBy: 'test-user-2',
+                category: 'PLAGIARISM',
+                resolved: true,
+                flagComments: {
+                    create: {
+                        createdBy: 'test-user-2',
+                        comment: 'This is a comment'
+                    }
+                }
             }
         },
         publicationStatus: {

--- a/api/prisma/seeds/users.ts
+++ b/api/prisma/seeds/users.ts
@@ -22,6 +22,15 @@ const userSeeds = [
         lastName: 'User 3',
         locked: false,
         apiKey: '1234'
+    },
+    {
+        id: 'test-user-4',
+        orcid: '123456789',
+        firstName: 'Test',
+        lastName: 'User 4',
+        locked: false,
+        apiKey: '4321',
+        role: 'SUPER_USER'
     }
 ];
 

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -205,3 +205,19 @@ functions:
                   path: ${self:custom.versions.v1}/publications/{id}/ratings
                   method: post
                   cors: true
+    createFlagComment:
+        handler: src/components/publication/routes.createFlagComment
+        warmup: true
+        events:
+            - http:
+                  path: ${self:custom.versions.v1}/flag/{id}/comment
+                  method: post
+                  cors: true
+    resolveFlag:
+        handler: src/components/publication/routes.resolveFlag
+        warmup: true
+        events:
+            - http:
+                  path: ${self:custom.versions.v1}/flag/{id}/resolve
+                  method: post
+                  cors: true

--- a/api/src/components/publication/__tests__/createFlag.test.ts
+++ b/api/src/components/publication/__tests__/createFlag.test.ts
@@ -13,11 +13,11 @@ describe('Create flags on publications', () => {
                 apiKey: '987654321'
             })
             .send({
-                comments: 'Comments',
+                comment: 'Comments',
                 category: 'ETHICAL_ISSUES'
             });
 
-        expect(createFlag.status).toEqual(201);
+        expect(createFlag.status).toEqual(200);
     });
 
     test('User cannot create a valid flag on LIVE publication they created', async () => {
@@ -27,7 +27,7 @@ describe('Create flags on publications', () => {
                 apiKey: '123456789'
             })
             .send({
-                comments: 'Comments',
+                comment: 'Comments',
                 category: 'ETHICAL_ISSUES'
             });
 
@@ -41,25 +41,25 @@ describe('Create flags on publications', () => {
                 apiKey: '987654321'
             })
             .send({
-                comments: 'Comments',
+                comment: 'Comments',
                 category: 'INVALID_CATEGORY'
             });
 
         expect(createFlag.status).toEqual(422);
     });
 
-    test('User cannot create a duplicate flag', async () => {
+    test('User cannot create a duplicate flag for an unresolved flag', async () => {
         const createFlag = await testUtils.agent
             .post('/publications/publication-interpretation-live/flag')
             .query({
                 apiKey: '987654321'
             })
             .send({
-                comments: 'Comments',
+                comment: 'Comments',
                 category: 'ETHICAL_ISSUES'
             });
 
-        expect(createFlag.status).toEqual(201);
+        expect(createFlag.status).toEqual(200);
 
         const createFlagAttempt2 = await testUtils.agent
             .post('/publications/publication-interpretation-live/flag')
@@ -67,11 +67,11 @@ describe('Create flags on publications', () => {
                 apiKey: '987654321'
             })
             .send({
-                comments: 'Comments',
+                comment: 'Comments',
                 category: 'ETHICAL_ISSUES'
             });
 
-        expect(createFlagAttempt2.status).toEqual(500);
+        expect(createFlagAttempt2.status).toEqual(404);
     });
 
     test('Cannot create a valid flag for a publication that is in DRAFT', async () => {
@@ -81,7 +81,7 @@ describe('Create flags on publications', () => {
                 apiKey: '987654321'
             })
             .send({
-                comments: 'Comments',
+                comment: 'Comments',
                 category: 'ETHICAL_ISSUES'
             });
 
@@ -95,11 +95,11 @@ describe('Create flags on publications', () => {
                 apiKey: '987654321'
             })
             .send({
-                comments: 'Comments',
+                comment: 'Comments',
                 category: 'ETHICAL_ISSUES'
             });
 
-        expect(createFlag.status).toEqual(201);
+        expect(createFlag.status).toEqual(200);
 
         const createFlagAttempt2 = await testUtils.agent
             .post('/publications/publication-interpretation-live/flag')
@@ -107,10 +107,10 @@ describe('Create flags on publications', () => {
                 apiKey: '987654321'
             })
             .send({
-                comments: 'Comments',
+                comment: 'Comments',
                 category: 'COPYRIGHT'
             });
 
-        expect(createFlagAttempt2.status).toEqual(201);
+        expect(createFlagAttempt2.status).toEqual(200);
     });
 });

--- a/api/src/components/publication/__tests__/createFlagComment.test.ts
+++ b/api/src/components/publication/__tests__/createFlagComment.test.ts
@@ -1,0 +1,85 @@
+import * as testUtils from 'lib/testUtils';
+
+describe('Create flags comments on a flag', () => {
+    beforeEach(async () => {
+        await testUtils.clearDB();
+        await testUtils.initialSeed();
+    });
+
+    test('User who created the flag can leave comments', async () => {
+        const createFlagComment = await testUtils.agent
+            .post('/flag/publication-problem-live-flag/comment')
+            .query({
+                apiKey: '987654321'
+            })
+            .send({
+                comment: 'Comments'
+            });
+
+        expect(createFlagComment.status).toEqual(200);
+    });
+
+    test('Owner of the publication can leave comments', async () => {
+        const createFlagComment = await testUtils.agent
+            .post('/flag/publication-problem-live-flag/comment')
+            .query({
+                apiKey: '123456789'
+            })
+            .send({
+                comment: 'Comments'
+            });
+        expect(createFlagComment.status).toEqual(200);
+    });
+
+    test('You cannot leave a comment on an resolved flag', async () => {
+        const createFlagComment = await testUtils.agent
+            .post('/flag/publication-hypothesis-live/comment')
+            .query({
+                apiKey: '123456789'
+            })
+            .send({
+                comment: 'Comments'
+            });
+
+        expect(createFlagComment.status).toEqual(404);
+    });
+
+    test('You cannot leave a comment on an un-flagged publication', async () => {
+        const createFlagComment = await testUtils.agent
+            .post('/flag/publication-analysis-live/comment')
+            .query({
+                apiKey: '123456789'
+            })
+            .send({
+                comment: 'Comments'
+            });
+
+        expect(createFlagComment.status).toEqual(404);
+    });
+
+    test('You can only leave a comment if you are either the author of the publication or the flagger', async () => {
+        const createFlagComment = await testUtils.agent
+            .post('/flag/publication-problem-live-flag/comment')
+            .query({
+                apiKey: '1234'
+            })
+            .send({
+                comment: 'Comments'
+            });
+
+        expect(createFlagComment.status).toEqual(403);
+    });
+
+    test('The body of the request is invalid', async () => {
+        const createFlagComment = await testUtils.agent
+            .post('/flag/publication-problem-live-flag/comment')
+            .query({
+                apiKey: '123456789'
+            })
+            .send({
+                comments: 'Comments'
+            });
+        // console.log(createFlagComment.body);
+        expect(createFlagComment.status).toEqual(422);
+    });
+});

--- a/api/src/components/publication/__tests__/resolveFlag.test.ts
+++ b/api/src/components/publication/__tests__/resolveFlag.test.ts
@@ -1,0 +1,56 @@
+import * as testUtils from 'lib/testUtils';
+
+describe('Resolve a flag', () => {
+    beforeEach(async () => {
+        await testUtils.clearDB();
+        await testUtils.initialSeed();
+    });
+
+    test('The flagger can resolve the flag', async () => {
+        const resolveFlag = await testUtils.agent.post('/flag/publication-problem-live-flag/resolve').query({
+            apiKey: '987654321'
+        });
+
+        expect(resolveFlag.status).toEqual(200);
+    });
+
+    test('Only the flagger or super user can resolve the flag', async () => {
+        const resolveFlag = await testUtils.agent.post('/flag/publication-problem-live-flag/resolve').query({
+            apiKey: '123456789'
+        });
+
+        expect(resolveFlag.status).toEqual(403);
+    });
+
+    test('A super user can resolve the flag', async () => {
+        const resolveFlag = await testUtils.agent.post('/flag/publication-problem-live-flag/resolve').query({
+            apiKey: '4321'
+        });
+
+        expect(resolveFlag.status).toEqual(200);
+    });
+
+    test('An unrelated user cannot resolve a flag', async () => {
+        const resolveFlag = await testUtils.agent.post('/flag/publication-problem-live-flag/resolve').query({
+            apiKey: '1234'
+        });
+
+        expect(resolveFlag.status).toEqual(403);
+    });
+
+    test('You cannot resolve a flag that has already been resolved', async () => {
+        const resolveFlag = await testUtils.agent.post('/flag/publication-hypothesis-live-flag/resolve').query({
+            apiKey: '987654321'
+        });
+
+        expect(resolveFlag.status).toEqual(403);
+    });
+
+    test('You can only resolve a flag that exists', async () => {
+        const resolveFlag = await testUtils.agent.post('/flag/publication-does-not-exist-flag/resolve').query({
+            apiKey: '987654321'
+        });
+
+        expect(resolveFlag.status).toEqual(404);
+    });
+});

--- a/api/src/components/publication/routes.ts
+++ b/api/src/components/publication/routes.ts
@@ -43,3 +43,14 @@ export const createFlag = middy(publicationController.createFlag)
     .use(middleware.httpJsonBodyParser())
     .use(middleware.authentication())
     .use(middleware.validator(publicationSchema.createFlag, 'body'));
+
+export const createFlagComment = middy(publicationController.createFlagComment)
+    .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))
+    .use(middleware.httpJsonBodyParser())
+    .use(middleware.authentication())
+    .use(middleware.validator(publicationSchema.createFlagComment, 'body'));
+
+export const resolveFlag = middy(publicationController.resolveFlag)
+    .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))
+    .use(middleware.httpJsonBodyParser())
+    .use(middleware.authentication());

--- a/api/src/components/publication/schema/createFlag.ts
+++ b/api/src/components/publication/schema/createFlag.ts
@@ -14,11 +14,11 @@ const updatedPublicationSchema: I.Schema = {
                 'INAPPROPRIATE'
             ]
         },
-        comments: {
+        comment: {
             type: 'string'
         }
     },
-    required: ['comments', 'category'],
+    required: ['comment', 'category'],
     additionalProperties: false
 };
 

--- a/api/src/components/publication/schema/createFlagComment.ts
+++ b/api/src/components/publication/schema/createFlagComment.ts
@@ -1,0 +1,14 @@
+import * as I from 'interface';
+
+const createFlagCommentSchema: I.Schema = {
+    type: 'object',
+    properties: {
+        comment: {
+            type: 'string'
+        }
+    },
+    required: ['comment'],
+    additionalProperties: false
+};
+
+export default createFlagCommentSchema;

--- a/api/src/components/publication/schema/index.ts
+++ b/api/src/components/publication/schema/index.ts
@@ -3,3 +3,4 @@ export { default as updateStatus } from './updateStatus';
 export { default as getAll } from './getAll';
 export { default as update } from './update';
 export { default as createFlag } from './createFlag';
+export { default as createFlagComment } from './createFlagComment';

--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -1,6 +1,7 @@
 import * as client from 'lib/client';
 
 import * as I from 'interface';
+import { ResponseError } from '@opensearch-project/opensearch/lib/errors';
 
 export const getAllByIds = async (ids: Array<string>) => {
     const publications = await client.prisma.publication.findMany({
@@ -61,12 +62,15 @@ export const get = async (id: string) => {
                 }
             },
             publicationFlags: {
+                where: {
+                    resolved: false
+                },
                 select: {
                     category: true,
-                    comments: true,
                     createdBy: true,
                     id: true,
-                    createdAt: true
+                    createdAt: true,
+                    flagComments: true
                 }
             },
             user: {
@@ -318,15 +322,20 @@ export const createFlag = async (
     publication: string,
     user: string,
     category: I.PublicationFlagCategoryEnum,
-    comments: string
+    comment: string
 ) => {
     const flag = await client.prisma.publicationFlags.create({
         data: {
-            comments,
             category,
             user: {
                 connect: {
                     id: user
+                }
+            },
+            flagComments: {
+                create: {
+                    comment,
+                    createdBy: user
                 }
             },
             publication: {
@@ -340,12 +349,54 @@ export const createFlag = async (
     return flag;
 };
 
+export const getFlag = async (id: string) => {
+    const flag = await client.prisma.publicationFlags.findFirst({
+        where: {
+            id
+        },
+        include: {
+            publication: {
+                include: {
+                    user: true
+                }
+            }
+        }
+    });
+
+    return flag;
+};
+
+export const createFlagComment = async (id: string, comment: string, user: string) => {
+    const flagComment = await client.prisma.flagComments.create({
+        data: {
+            flagId: id,
+            comment,
+            createdBy: user
+        }
+    });
+
+    return flagComment;
+};
+
 export const validateConflictOfInterest = (publication: I.Publication) => {
     if (publication.conflictOfInterestStatus) {
         if (!publication.conflictOfInterestText?.length) return false;
     }
 
     return true;
+};
+
+export const doesDuplicateFlagExist = async (publication, category, user) => {
+    const flag = await client.prisma.publicationFlags.findFirst({
+        where: {
+            publicationId: publication,
+            createdBy: user,
+            category,
+            resolved: false
+        }
+    });
+
+    return flag;
 };
 
 export const isPublicationReadyToPublish = (publication: I.Publication, status: string) => {
@@ -363,4 +414,17 @@ export const isPublicationReadyToPublish = (publication: I.Publication, status: 
     if (hasAtLeastOneLinkTo && hasAllFields && conflictOfInterest && !hasPublishDate && isAttemptToLive) isReady = true;
 
     return isReady;
+};
+
+export const resolveFlag = async (id: string) => {
+    const resolveFlag = await client.prisma.publicationFlags.update({
+        where: {
+            id
+        },
+        data: {
+            resolved: true
+        }
+    });
+
+    return resolveFlag;
 };

--- a/api/src/components/user/__tests__/getUser.test.ts
+++ b/api/src/components/user/__tests__/getUser.test.ts
@@ -14,7 +14,7 @@ describe('Get individual user', () => {
     });
 
     test('User not found', async () => {
-        const user = await testUtils.agent.get('/users/test-user-3');
+        const user = await testUtils.agent.get('/users/test-user-100');
 
         expect(user.status).toEqual(404);
     });

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -165,7 +165,7 @@ export interface CreateFlagPathParams {
 
 export interface CreateFlagRequestBody {
     category: PublicationFlagCategoryEnum;
-    comments: string;
+    comment: string;
 }
 
 export interface AuthorizeRequestBody {
@@ -341,4 +341,16 @@ export type Ratings =
 export interface CreateRatingRequestBody {
     type: Ratings;
     value: number;
+}
+
+export interface CreateFlagCommentBody {
+    comment: string;
+}
+
+export interface CreateFlagCommentPathParams {
+    id: string;
+}
+
+export interface ResolveFlagPathParams {
+    id: string;
 }

--- a/api/src/lib/testUtils.ts
+++ b/api/src/lib/testUtils.ts
@@ -8,7 +8,12 @@ jest.setTimeout(60000);
 export const agent = supertest.agent(`http://0.0.0.0:4003/${process.env.STAGE}/v1`);
 
 export const initialSeed = async (): Promise<void> => {
-    await client.prisma.user.createMany({ data: seeds.users });
+    for (let user of seeds.users) {
+        await client.prisma.user.create({
+            // @ts-ignore
+            data: user
+        });
+    }
 
     // not ideal, but best thing I can do right now. For some reason createMany will not work with provided seed data...
     for (let publication of seeds.publications) {


### PR DESCRIPTION
The purpose of this PR was to create an API endpoints for a flagging dispute process so that users can comment on and resolve flags. We also resolved a bug on the `createFlag` endpoint.

Once a flag is created, this opens up the ability to add “comments” to that chain, where both the “flagger” and publication owner can leave comments. Once the “flagger” is satisfied that this red flag has been resolved, they can mark the conversation as resolved. This will effectively hide the flag and resolve it on the database. 

Only the ‘flagger’ or author of the flagged publication have the ability to comment, and only the flagger or a super user has the ability to resolve the flag.  

We have created two different end points, **one to add comments to a flagged publication:**
Path: `POST /flag/{id}/comment`
body: 
```
{
    comment: "This publication is copyright."
}
```

which will receive a successful response back that looks like this: 
```
{
    "id": "cl1xoe84r0013qe4c71efgxnn",
    "flagId": "publication-problem-live-flag",
    "comment": "This publication is copyright",
    "createdBy": "test-user-1",
    "createdAt": "2022-04-13T14:36:26.667Z"
}
```

and another to **resolve a flag**: 
Path: `POST /flag/{id}/resolve`

which receives a successful response back that looks like this: 
```
{
    "id": "publication-problem-live-flag",
    "publicationId": "publication-problem-live",
    "category": "PLAGIARISM",
    "resolved": true,
    "createdBy": "test-user-2",
    "createdAt": "2022-04-13T14:25:31.268Z"
}
```

# Acceptance Criteria:
- A user can only have 1 unresolved red flag per publication per category.
- Only the “flagger” or super users can resolve the flag.
- Once a flag is resovled, it should not be returned in the publication.
- Only the “flagger” or publicaiton owner, can comment during the “dispute” process.
- Messages/content are free text only, not WYSIWYG

# Tests:
## Create Flag Comment Tests: 
```
 PASS  src/components/publication/__tests__/createFlagComment.test.ts (5.722 s)
  Create flags comments on a flag
    ✓ User who created the flag can leave comments (887 ms)
    ✓ Owner of the publication can leave comments (606 ms)
    ✓ You cannot leave a comment on an resolved flag (577 ms)
    ✓ You cannot leave a comment on an un-flagged publication (575 ms)
    ✓ You can only leave a comment if you are either the author of the publication or the flagger (596 ms)
    ✓ The body of the request is invalid (577 ms)
```

## Resolve Flag Tests: 

```
 PASS  src/components/publication/__tests__/resolveFlag.test.ts (5.232 s)
  Resolve a flag
    ✓ The flagger can resolve the flag (713 ms)
    ✓ Only the flagger or super user can resolve the flag (548 ms)
    ✓ A super user can resolve the flag (609 ms)
    ✓ An unrelated user cannot resolve a flag (537 ms)
    ✓ You cannot resolve a flag that has already been resolved (545 ms)
    ✓ You can only resolve a flag that exists (547 ms)
```