### PR TITLE
Adding/deleting images via the API (OCT-196)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 node_modules
 jspm_packages
 
+.localstack
+
 # Serverless directories
 .serverless
 

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1323,6 +1323,11 @@
                 "defer-to-connect": "^1.0.1"
             }
         },
+        "@tokenizer/token": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+            "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
+        },
         "@tootallnate/once": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -2221,10 +2226,9 @@
             }
         },
         "aws-sdk": {
-            "version": "2.1101.0",
-            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1101.0.tgz",
-            "integrity": "sha512-7lyVb7GXGl8yyu954Qxf6vU6MrcgFlmKyTLBVXJyo3Phn1OB+qOExA55WtSC6gQiQ7e5TeWOn1RUHLg30ywTBA==",
-            "dev": true,
+            "version": "2.1114.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1114.0.tgz",
+            "integrity": "sha512-LB3q0aHK37GccvNZ4HKtA+0YF94GWYDbJMz3XYoNSEVFOFnLj2DfpkoWlBSnBEJlG9m8GRNssDWs65gQ3MVzDQ==",
             "requires": {
                 "buffer": "4.9.2",
                 "events": "1.1.1",
@@ -2240,8 +2244,7 @@
                 "querystring": {
                     "version": "0.2.0",
                     "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-                    "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-                    "dev": true
+                    "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
                 }
             }
         },
@@ -2333,8 +2336,7 @@
         "base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-            "dev": true
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
         },
         "bestzip": {
             "version": "2.2.0",
@@ -2481,7 +2483,6 @@
             "version": "4.9.2",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
             "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-            "dev": true,
             "requires": {
                 "base64-js": "^1.0.2",
                 "ieee754": "^1.1.4",
@@ -3685,8 +3686,7 @@
         "events": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
-            "dev": true
+            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
         },
         "execa": {
             "version": "5.1.1",
@@ -3828,6 +3828,16 @@
             "dev": true,
             "requires": {
                 "flat-cache": "^3.0.4"
+            }
+        },
+        "file-type": {
+            "version": "16.5.3",
+            "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.3.tgz",
+            "integrity": "sha512-uVsl7iFhHSOY4bEONLlTK47iAHtNsFHWP5YE4xJfZ4rnX7S1Q3wce09XgqSC7E/xh8Ncv/be1lNoyprlUH/x6A==",
+            "requires": {
+                "readable-web-to-node-stream": "^3.0.0",
+                "strtok3": "^6.2.4",
+                "token-types": "^4.1.1"
             }
         },
         "fill-range": {
@@ -4259,8 +4269,7 @@
         "ieee754": {
             "version": "1.1.13",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-            "dev": true
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
         },
         "ignore": {
             "version": "5.2.0",
@@ -4624,8 +4633,7 @@
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-            "dev": true
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "isexe": {
             "version": "2.0.0",
@@ -5197,8 +5205,7 @@
         "jmespath": {
             "version": "0.16.0",
             "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
-            "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
-            "dev": true
+            "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
         },
         "js-levenshtein": {
             "version": "1.1.6",
@@ -6455,6 +6462,11 @@
             "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
             "dev": true
         },
+        "peek-readable": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+            "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="
+        },
         "picocolors": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -6783,11 +6795,18 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
             "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-            "dev": true,
             "requires": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
                 "util-deprecate": "^1.0.1"
+            }
+        },
+        "readable-web-to-node-stream": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+            "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+            "requires": {
+                "readable-stream": "^3.6.0"
             }
         },
         "readdir-glob": {
@@ -6966,8 +6985,7 @@
         "sax": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-            "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
-            "dev": true
+            "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
         },
         "saxes": {
             "version": "5.0.1",
@@ -7449,7 +7467,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
             "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-            "dev": true,
             "requires": {
                 "safe-buffer": "~5.2.0"
             }
@@ -7480,6 +7497,15 @@
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true
+        },
+        "strtok3": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+            "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+            "requires": {
+                "@tokenizer/token": "^0.3.0",
+                "peek-readable": "^4.1.0"
+            }
         },
         "superagent": {
             "version": "7.1.1",
@@ -7698,6 +7724,22 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
             "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
+        },
+        "token-types": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.0.tgz",
+            "integrity": "sha512-P0rrp4wUpefLncNamWIef62J0v0kQR/GfDVji9WKY7GDCWy5YbVSrKUTam07iWPZQGy0zWNOfstYTykMmPNR7w==",
+            "requires": {
+                "@tokenizer/token": "^0.3.0",
+                "ieee754": "^1.2.1"
+            },
+            "dependencies": {
+                "ieee754": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+                    "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+                }
+            }
         },
         "touch": {
             "version": "3.1.0",
@@ -7972,7 +8014,6 @@
             "version": "0.10.3",
             "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
             "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-            "dev": true,
             "requires": {
                 "punycode": "1.3.2",
                 "querystring": "0.2.0"
@@ -7981,14 +8022,12 @@
                 "punycode": {
                     "version": "1.3.2",
                     "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-                    "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-                    "dev": true
+                    "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
                 },
                 "querystring": {
                     "version": "0.2.0",
                     "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-                    "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-                    "dev": true
+                    "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
                 }
             }
         },
@@ -8004,14 +8043,12 @@
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-            "dev": true
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "uuid": {
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-            "dev": true
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         },
         "v8-compile-cache": {
             "version": "2.3.0",
@@ -8270,7 +8307,6 @@
             "version": "0.4.19",
             "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
             "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-            "dev": true,
             "requires": {
                 "sax": ">=0.6.0",
                 "xmlbuilder": "~9.0.1"
@@ -8279,8 +8315,7 @@
         "xmlbuilder": {
             "version": "9.0.7",
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-            "dev": true
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
         },
         "xmlchars": {
             "version": "2.2.0",

--- a/api/package.json
+++ b/api/package.json
@@ -22,8 +22,8 @@
     },
     "scripts": {
         "start:local": "nodemon --ignore ./__tests__ --exec \"sls offline --httpPort 4003 --host 0.0.0.0 --stage local --aws-profile octopus \"",
-        "seed:local": "npx prisma migrate reset --force",
-        "test:local": "stage=local jest --runInBand --testTimeout=60000",
+        "seed:local": "STAGE=local npx prisma migrate reset --force",
+        "test:local": "STAGE=local jest --runInBand --testTimeout=60000",
         "format": "npx prettier --write src/"
     },
     "dependencies": {
@@ -41,8 +41,10 @@
         "@types/nodemailer": "^6.4.4",
         "ajv": "^8.8.2",
         "ajv-formats": "^2.1.1",
+        "aws-sdk": "^2.1114.0",
         "axios": "^0.26.0",
         "cheerio": "^1.0.0-rc.10",
+        "file-type": "^16.5.3",
         "html-to-text": "^8.1.0",
         "jsonwebtoken": "^8.5.1",
         "luxon": "^2.3.0",

--- a/api/prisma/migrations/20220419100253_images/migration.sql
+++ b/api/prisma/migrations/20220419100253_images/migration.sql
@@ -1,0 +1,16 @@
+-- CreateEnum
+CREATE TYPE "ImageExtension" AS ENUM ('png', 'jpg', 'jpeg');
+
+-- CreateTable
+CREATE TABLE "Images" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "user" TEXT NOT NULL,
+    "extension" "ImageExtension" NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Images_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Images" ADD CONSTRAINT "Images_user_fkey" FOREIGN KEY ("user") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -28,6 +28,22 @@ model User {
     PublicationFlags   PublicationFlags[]
     PublicationRatings PublicationRatings[]
     flagComments       FlagComments[]
+    Images             Images[]
+}
+
+model Images {
+    id         String         @id @default(cuid())
+    name       String
+    user       String
+    extension  ImageExtension
+    uploadedBy User           @relation(fields: [user], references: [id], onDelete: Cascade)
+    createdAt  DateTime       @default(now())
+}
+
+enum ImageExtension {
+    png
+    jpg
+    jpeg
 }
 
 model Publication {

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -221,3 +221,19 @@ functions:
                   path: ${self:custom.versions.v1}/flag/{id}/resolve
                   method: post
                   cors: true
+    createImage:
+        handler: src/components/image/routes.create
+        warmup: true
+        events:
+            - http:
+                  path: ${self:custom.versions.v1}/image
+                  method: post
+                  cors: true
+    deleteImage:
+        handler: src/components/image/routes.destroy
+        warmup: true
+        events:
+            - http:
+                  path: ${self:custom.versions.v1}/image/{id}
+                  method: delete
+                  cors: true

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -226,7 +226,7 @@ functions:
         warmup: true
         events:
             - http:
-                  path: ${self:custom.versions.v1}/image
+                  path: ${self:custom.versions.v1}/images
                   method: post
                   cors: true
     deleteImage:
@@ -234,6 +234,14 @@ functions:
         warmup: true
         events:
             - http:
-                  path: ${self:custom.versions.v1}/image/{id}
+                  path: ${self:custom.versions.v1}/images/{id}
                   method: delete
+                  cors: true
+    getAllImages:
+        handler: src/components/image/routes.getAll
+        warmup: true
+        events:
+            - http:
+                  path: ${self:custom.versions.v1}/images
+                  method: get
                   cors: true

--- a/api/src/components/coauthor/controller.ts
+++ b/api/src/components/coauthor/controller.ts
@@ -1,6 +1,6 @@
 import * as response from 'lib/response';
 import * as publicationService from 'publication/service';
-import * as coAuthorService from './service';
+import * as coAuthorService from 'coauthor/service';
 import * as I from 'interface';
 
 export const create = async (

--- a/api/src/components/coauthor/routes.ts
+++ b/api/src/components/coauthor/routes.ts
@@ -2,8 +2,8 @@ import middy from '@middy/core';
 
 import * as middleware from 'middleware';
 
-import * as coAuthorController from './controller';
-import * as coAuthorSchema from './schema';
+import * as coAuthorController from 'coauthor/controller';
+import * as coAuthorSchema from 'coauthor/schema';
 
 export const create = middy(coAuthorController.create)
     .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))

--- a/api/src/components/image/controller.ts
+++ b/api/src/components/image/controller.ts
@@ -43,3 +43,13 @@ export const destroy = async (
         return response.json(500, { message: 'Unknown server error.' });
     }
 };
+
+export const getAll = async (event: I.AuthenticatedAPIRequest) => {
+    try {
+        const images = await imageService.getAll(event.user.id);
+
+        return response.json(200, images);
+    } catch (err) {
+        return response.json(500, { message: 'Unknown server error.' });
+    }
+};

--- a/api/src/components/image/controller.ts
+++ b/api/src/components/image/controller.ts
@@ -1,0 +1,45 @@
+import * as response from 'lib/response';
+import * as I from 'interface';
+
+import * as imageService from 'image/service';
+
+export const create = async (event: I.AuthenticatedAPIRequest<I.ImageSentBody>): Promise<I.JSONResponse> => {
+    try {
+        const imageType = event.body.image.split(';')[0].split('/')[1];
+
+        if (imageType !== 'png' && imageType !== 'jpeg' && imageType !== 'jpg') {
+            return response.json(422, { message: 'Invalid' });
+        }
+
+        const imageReference = await imageService.createDBReference(event.body.name, imageType, event.user.id);
+
+        await imageService.uploadToS3(imageReference.id, event.body.image, imageType);
+
+        return response.json(201, imageReference);
+    } catch (err) {
+        console.log(err);
+        return response.json(500, { message: 'Unknown server error.' });
+    }
+};
+
+export const destroy = async (
+    event: I.AuthenticatedAPIRequest<undefined, undefined, I.DestroyImagePathParams>
+): Promise<I.JSONResponse> => {
+    try {
+        const image = await imageService.get(event.pathParameters.id);
+
+        if (!image) {
+            return response.json(404, { message: 'This image does not exist' });
+        }
+
+        if (image.user !== event.user.id) {
+            return response.json(403, { message: 'You do not have permission to delete this image' });
+        }
+
+        const deletedImage = await imageService.destroy(event.pathParameters.id);
+
+        return response.json(201, deletedImage);
+    } catch (err) {
+        return response.json(500, { message: 'Unknown server error.' });
+    }
+};

--- a/api/src/components/image/routes.ts
+++ b/api/src/components/image/routes.ts
@@ -12,3 +12,8 @@ export const destroy = middy(imageController.destroy)
     .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))
     .use(middleware.httpJsonBodyParser())
     .use(middleware.authentication());
+
+export const getAll = middy(imageController.getAll)
+    .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))
+    .use(middleware.httpJsonBodyParser())
+    .use(middleware.authentication());

--- a/api/src/components/image/routes.ts
+++ b/api/src/components/image/routes.ts
@@ -1,0 +1,14 @@
+import middy from '@middy/core';
+import * as imageController from './controller';
+
+import * as middleware from 'middleware';
+
+export const create = middy(imageController.create)
+    .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))
+    .use(middleware.httpJsonBodyParser())
+    .use(middleware.authentication());
+
+export const destroy = middy(imageController.destroy)
+    .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))
+    .use(middleware.httpJsonBodyParser())
+    .use(middleware.authentication());

--- a/api/src/components/image/service.ts
+++ b/api/src/components/image/service.ts
@@ -64,3 +64,15 @@ export const destroy = async (id: string) => {
 
     return image;
 };
+
+export const getAll = async (user: string) => {
+    const images = await client.prisma.images.findMany({
+        where: {
+            user
+        }
+    });
+
+    console.log(images);
+
+    return images;
+};

--- a/api/src/components/image/service.ts
+++ b/api/src/components/image/service.ts
@@ -1,0 +1,66 @@
+import AWS from 'aws-sdk';
+
+import * as client from 'lib/client';
+import * as I from 'interface';
+
+const config = {
+    region: 'eu-west-1',
+    endpoint: process.env.STAGE === 'local' ? 'http://localhost:4566' : 'https://s3.eu-west-1.amazonaws.com',
+    s3ForcePathStyle: true
+};
+
+if (process.env.STAGE === 'local') {
+    // @ts-ignore
+    config.credentials = {
+        accessKeyId: 'dummy',
+        secretAccessKey: 'dummy'
+    };
+}
+
+const s3 = new AWS.S3(config);
+
+export const createDBReference = async (name: string, extension: I.ImageExtension, user: string) => {
+    const imageReference = await client.prisma.images.create({
+        data: {
+            name,
+            extension,
+            user
+        }
+    });
+
+    return imageReference;
+};
+
+export const uploadToS3 = async (id: string, image: string, imageType: I.ImageExtension) => {
+    const s3Image = await s3
+        .putObject({
+            Bucket: `science-octopus-publishing-images-${process.env.STAGE}`,
+            Key: id,
+            ContentType: `image/${imageType}`,
+            ContentEncoding: 'base64',
+            Body: Buffer.from(image.replace(/^data:image\/\w+;base64,/, ''), 'base64')
+        })
+        .promise();
+
+    return s3Image;
+};
+
+export const get = async (id: string) => {
+    const image = await client.prisma.images.findFirst({
+        where: {
+            id
+        }
+    });
+
+    return image;
+};
+
+export const destroy = async (id: string) => {
+    const image = await client.prisma.images.delete({
+        where: {
+            id
+        }
+    });
+
+    return image;
+};

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -1,5 +1,12 @@
 import { Prisma, PublicationType, LicenceType, PublicationFlagCategoryEnum, Role } from '@prisma/client';
-export { PublicationType, LicenceType, PublicationStatusEnum, PublicationFlagCategoryEnum, Role } from '@prisma/client';
+export {
+    PublicationType,
+    LicenceType,
+    PublicationStatusEnum,
+    PublicationFlagCategoryEnum,
+    Role,
+    ImageExtension
+} from '@prisma/client';
 
 import {
     APIGatewayProxyEventV2,
@@ -309,6 +316,11 @@ export interface UpdateCoAuthorPathParams {
     id: string;
 }
 
+export interface ImageSentBody {
+    name: string;
+    image: string;
+}
+
 /* @description Ratings
  */
 
@@ -359,5 +371,9 @@ export interface CreateFlagCommentPathParams {
 }
 
 export interface ResolveFlagPathParams {
+    id: string;
+}
+
+export interface DestroyImagePathParams {
     id: string;
 }

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -42,8 +42,14 @@
             "authorization/*": [
                 "src/components/authorization/*"
             ],
+            "image/*": [
+                "src/components/image/*"
+            ],
             "rating/*": [
                 "src/components/rating/*"
+            ],
+            "coauthor/*": [
+                "src/components/coauthor/*"
             ],
             "lib/*": [
                 "src/lib/*"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.1"
+version: "3.2"
 
 services:
     db:
@@ -26,6 +26,19 @@ services:
         ports:
             - 1025:1025
             - 8025:8025
+
+    localstack:
+        image: localstack/localstack:latest
+        ports:
+            - '4510-4559:4510-4559'
+            - '4566:4566'
+        environment:
+            - SERVICES=s3
+            - DEBUG=1
+            - DATA_DIR=/tmp/localstack/data
+        volumes:
+            - './.localstack:/tmp/localstack'
+            - '/var/run/docker.sock:/var/run/docker.sock'
 
     opensearch-node1:
         image: opensearchproject/opensearch:1.2.4

--- a/infra/create-app/main.tf
+++ b/infra/create-app/main.tf
@@ -60,3 +60,8 @@ module "elasticsearch" {
   vpc_id             = module.network.vpc_id
   instance_size      = var.elasticsearch_instance_size
 }
+
+module "s3" {
+  source             = "../modules/s3"
+  environment        = local.environment
+}

--- a/infra/modules/s3/main.tf
+++ b/infra/modules/s3/main.tf
@@ -1,0 +1,4 @@
+resource "aws_s3_bucket" "image_bucket" {
+  bucket = "science-octopus-publishing-images-${var.environment}"
+  acl    = "public-read"
+}

--- a/infra/modules/s3/vars.tf
+++ b/infra/modules/s3/vars.tf
@@ -1,0 +1,3 @@
+variable "environment" {
+  type = string
+}

--- a/ui/src/lib/helpers.tsx
+++ b/ui/src/lib/helpers.tsx
@@ -232,3 +232,15 @@ export const blobFileDownload = async (url: string, fileName: string) => {
     // @ts-ignore
     fileDownload(res.data, fileName);
 };
+
+export const getBase64FromFile = async (file: Blob) =>
+    new Promise((resolve, reject) => {
+        const fileReader = new FileReader();
+        fileReader.readAsDataURL(file);
+        fileReader.onload = () => {
+            resolve(fileReader.result);
+        };
+        fileReader.onerror = (error) => {
+            reject(error);
+        };
+    });

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -44,11 +44,6 @@ type Props = {
 const Home: Types.NextPage<Props> = (props): React.ReactElement => {
     const toggleCmdPalette = Stores.useGlobalsStore((state: Types.GlobalsStoreType) => state.toggleCmdPalette);
 
-    const x = async (e: any) => {
-        const y = await Helpers.getBase64FromFile(e.target.files[0]);
-        console.log(y);
-    };
-
     return (
         <>
             <Head>
@@ -93,8 +88,6 @@ const Home: Types.NextPage<Props> = (props): React.ReactElement => {
                         </div>
                     </div>
                 </section>
-                <input type="file" onChange={x} />
-                cd
                 {/** Mockup flow not ready */}
                 {/* <section className="container mx-auto py-16 px-8 2xl:py-28">
                     <Components.MockupFlow />

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -44,6 +44,11 @@ type Props = {
 const Home: Types.NextPage<Props> = (props): React.ReactElement => {
     const toggleCmdPalette = Stores.useGlobalsStore((state: Types.GlobalsStoreType) => state.toggleCmdPalette);
 
+    const x = async (e: any) => {
+        const y = await Helpers.getBase64FromFile(e.target.files[0]);
+        console.log(y);
+    };
+
     return (
         <>
             <Head>
@@ -88,12 +93,12 @@ const Home: Types.NextPage<Props> = (props): React.ReactElement => {
                         </div>
                     </div>
                 </section>
-
+                <input type="file" onChange={x} />
+                cd
                 {/** Mockup flow not ready */}
                 {/* <section className="container mx-auto py-16 px-8 2xl:py-28">
                     <Components.MockupFlow />
                 </section> */}
-
                 <section className="container mx-auto px-8 py-16 2xl:py-28 ">
                     {/* <Components.PageSubTitle text="Get started with Octopus" className="text-center" /> */}
 
@@ -143,7 +148,6 @@ const Home: Types.NextPage<Props> = (props): React.ReactElement => {
                         />
                     </div>
                 </section>
-
                 {/* <section className="container mx-auto border-t border-grey-100 px-8 py-16 dark:border-grey-600 2xl:py-28">
                     <div className="grid grid-cols-3 gap-x-32">
                         <div className="space-y-4">


### PR DESCRIPTION
The purpose of this PR was to create the ability to upload and delete images via the API. A lot went into this PR:
- Updated Terraform to include an `s3` module, that will create the `s3` bucket needed to store images per environment (i.e `int`, `prod`, etc).
- Updated `docker-compose` to add `localstack`, enabling us to run a copy of `s3` locally.
- Updated seed command so that it checks if a local `s3` bucket exists, if it doesn't, it will create, `science-octopus-publishing-images-local`.
- Added `image` model to prisma. This does not store the image, only a reference to it (i.e `id`, `name`, `user` and `createdAt`).
- Added helper function to UI, to get Base64 of image.

> POST /images
```json
{
  "name": "my-first-image",
  "image": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAUFBQUFBQYGBgYICQgJCAwLCgoLDBINDg0ODRIbERQRERQRGxgdGBYYHRgrIh4eIisyKigqMjw2NjxMSExkZIYBBQUFBQUFBgYGBggJCAkIDAsKCgsMEg0ODQ4NEhsRFBERFBEbGB0YFhgdGCsiHh4iKzIqKCoyPDY2PExITGRkhv..."
}
```

> DELETE /images/{id}

> GET /images
---

### Acceptance Criteria:
- Only authenticated users can upload images.
- Only `jpg`, `jpeg` and `png` can be uploaded.
- Only the owner of the image can delete their image.
- When retrieving a list of images, only you can see your list.
- Anyone can view any image.

