### PR TITLE
Add dates range to search filters on the Get Publications API endpoint

### DIFF
--- a/api/src/components/publication/schema/getAll.ts
+++ b/api/src/components/publication/schema/getAll.ts
@@ -22,6 +22,12 @@ const getAllSchema: I.Schema = {
         },
         exclude: {
             type: 'string'
+        },
+        dateFrom: {
+            type: 'string'
+        },
+        dateTo: {
+            type: 'string'
         }
     },
     additionalProperties: false

--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -212,15 +212,25 @@ export const getOpenSearchRecords = async (filters: I.PublicationFilters) => {
 
     if (filters.search) {
         // @ts-ignore
-        query.body.query.bool.must = {
-            multi_match: {
-                query: filters.search,
-                fuzziness: 'auto',
-                type: 'most_fields',
-                operator: 'or',
-                fields: ['title^3', 'cleanContent', 'keywords^2', 'description^2'] // include author full names, DOI field, content below author & title
+        query.body.query.bool.must = [
+            {
+                multi_match: {
+                    query: filters.search,
+                    fuzziness: 'auto',
+                    type: 'most_fields',
+                    operator: 'or',
+                    fields: ['title^3', 'cleanContent', 'keywords^2', 'description^2'] // include author full names, DOI field, content below author & title
+                }
+            },
+            {
+                range: {
+                    publishedDate: {
+                        gte: filters.dateFrom,
+                        lte: filters.dateTo
+                    }
+                }
             }
-        };
+        ];
     }
 
     if (filters.exclude) {

--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -225,17 +225,15 @@ export const getOpenSearchRecords = async (filters: I.PublicationFilters) => {
         });
     }
 
-    if (filters.dateFrom || filters.dateTo) {
-        console.log(filters.dateFrom);
-        must.push({
-            range: {
-                publishedDate: {
-                    gte: filters.dateFrom,
-                    lte: filters.dateTo
-                }
+    must.push({
+        range: {
+            publishedDate: {
+                gte: filters.dateFrom,
+                lte: filters.dateTo
             }
-        });
-    }
+        }
+    });
+
     // @ts-ignore
     query.body.query.bool.must = must;
 

--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -210,28 +210,34 @@ export const getOpenSearchRecords = async (filters: I.PublicationFilters) => {
         }
     };
 
+    const must: any[] = [];
+
     if (filters.search) {
         // @ts-ignore
-        query.body.query.bool.must = [
-            {
-                multi_match: {
-                    query: filters.search,
-                    fuzziness: 'auto',
-                    type: 'most_fields',
-                    operator: 'or',
-                    fields: ['title^3', 'cleanContent', 'keywords^2', 'description^2'] // include author full names, DOI field, content below author & title
-                }
-            },
-            {
-                range: {
-                    publishedDate: {
-                        gte: filters.dateFrom,
-                        lte: filters.dateTo
-                    }
+        must.push({
+            multi_match: {
+                query: filters.search,
+                fuzziness: 'auto',
+                type: 'most_fields',
+                operator: 'or',
+                fields: ['title^3', 'cleanContent', 'keywords^2', 'description^2'] // include author full names, DOI field, content below author & title
+            }
+        });
+    }
+
+    if (filters.dateFrom || filters.dateTo) {
+        console.log(filters.dateFrom);
+        must.push({
+            range: {
+                publishedDate: {
+                    gte: filters.dateFrom,
+                    lte: filters.dateTo
                 }
             }
-        ];
+        });
     }
+    // @ts-ignore
+    query.body.query.bool.must = must;
 
     if (filters.exclude) {
         // @ts-ignore

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -125,7 +125,9 @@ export interface PublicationFilters {
     limit?: string;
     offset?: string;
     type: string;
-    exclude: string;
+    exclude?: string;
+    dateFrom?: string;
+    dateTo?: string;
 }
 
 /**

--- a/ui/package.json
+++ b/ui/package.json
@@ -44,6 +44,7 @@
         "js-file-download": "^0.4.12",
         "jsonwebtoken": "^8.5.1",
         "luxon": "^2.3.0",
+        "moment": "^2.29.3",
         "next": "^12.0.10",
         "nextjs-progressbar": "0.0.13",
         "react": "17.0.2",


### PR DESCRIPTION
The purpose of this PR was to add an optional dates range to the search filters for the get all publications endpoint. 

This PR contains amendments to the `getAllPublications` endpoint, search filters and changes to the UI to display the date input fields which is functional. 

Will need further styling with a date picker or similar.

### Acceptance Criteria:


### Screenshots:
![Screenshot 2022-05-04 at 16 52 41](https://user-images.githubusercontent.com/100135505/166720954-5497513b-ba3f-4884-9068-cf014d8f60f9.png)
