### PR TITLE
Update mediaBucket values

### DIFF
--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -32,6 +32,13 @@ provider:
             Project: Octopus
             Owner: 0 - 3 Years Innovation Team
             Name: Octopus API
+    iamRoleStatements:
+      - Effect: 'Allow'
+        Action:
+            - 'lambda:InvokeFunction'
+            - 'ses:SendEmail'
+            - 'ses:SendRawEmail'
+        Resource: '*'
 custom:
     customDomain:
         domainName: '${self:provider.stage}.api.octopus.ac'

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -9,14 +9,6 @@
 # Crash log files
 crash.log
 
-# Exclude all .tfvars files, which are likely to contain sensitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
-# to change depending on the environment.
-#
-*.tfvars
-!example.tfvars
-
 # Ignore override files as they are usually used to override resources locally and so
 # are not checked in
 override.tf

--- a/infra/create-app/int.tfvars
+++ b/infra/create-app/int.tfvars
@@ -1,0 +1,8 @@
+domain_name = "int.octopus.ac"
+
+allocated_storage       = 50
+instance                = "db.t3.micro"
+db_version              = "12.5"
+backup_retention_period = 1
+
+elasticsearch_instance_size = "t3.small.elasticsearch"

--- a/infra/modules/s3/main.tf
+++ b/infra/modules/s3/main.tf
@@ -8,3 +8,21 @@ resource "aws_s3_bucket_public_access_block" "image_bucket" {
   block_public_acls   = true
   block_public_policy = true
 }
+
+data "aws_iam_policy_document" "allow_public_access" {
+  statement {
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "s3:GetObject"
+    ]
+
+    resources = [
+      aws_s3_bucket.example.arn,
+      "${aws_s3_bucket.image_bucket.id}/*",
+    ]
+  }
+}

--- a/infra/modules/s3/main.tf
+++ b/infra/modules/s3/main.tf
@@ -21,7 +21,7 @@ data "aws_iam_policy_document" "allow_public_access" {
     ]
 
     resources = [
-      aws_s3_bucket.example.arn,
+      aws_s3_bucket.image_bucket.arn,
       "${aws_s3_bucket.image_bucket.id}/*",
     ]
   }

--- a/infra/modules/s3/main.tf
+++ b/infra/modules/s3/main.tf
@@ -21,8 +21,12 @@ data "aws_iam_policy_document" "allow_public_access" {
     ]
 
     resources = [
-      aws_s3_bucket.image_bucket.arn,
-      "${aws_s3_bucket.image_bucket.id}/*",
+      "${aws_s3_bucket.image_bucket.arn}/*"
     ]
   }
+}
+
+resource "aws_s3_bucket_policy" "allow_public_access" {
+  bucket = aws_s3_bucket.image_bucket.id
+  policy = data.aws_iam_policy_document.allow_public_access.json
 }

--- a/ui/src/config/urls.ts
+++ b/ui/src/config/urls.ts
@@ -11,12 +11,12 @@ switch (process.env.NEXT_PUBLIC_ENV) {
         break;
     case 'prod':
         host = 'https://octopus.ac';
-        mediaBucket = `https://${bucketName}.eu-west-1.amazonaws.com/`;
+        mediaBucket = `https://${bucketName}.s3.eu-west-1.amazonaws.com`;
         orcidAppiID = '';
         break;
     default:
         host = `https://${process.env.NEXT_PUBLIC_ENV}.octopus.ac`;
-        mediaBucket = `https://${bucketName}.eu-west-1.amazonaws.com/`;
+        mediaBucket = `https://${bucketName}.s3.eu-west-1.amazonaws.com`;
         orcidAppiID = 'APP-I16GNK4VA08WTE9Y';
 }
 


### PR DESCRIPTION

**Infra changes**

- Added tfvar files to the repository (we never use these to store sensitive values, and committing these would go against best practice anyway).
- Added `int.tfvars` file
- Set iam policy for s3 public access

**API changes**

Added `iamRoleStatement` (at request of @nathan-at-jisc) for lambda and email functions.

**UI changes**

Fixed the s3 bucket url for user uploaded content (eg. publication editor)

Currently object src are along the lines of...
https://science-octopus-publishing-images-int.eu-west-1.amazonaws.com//cl2yizbzd000009mr0dr62uhv

Where they need to be:
https://science-octopus-publishing-images-int.s3.eu-west-1.amazonaws.com/cl2yizbzd000009mr0dr62uhv 

This fix removes the surplus slash, and adds `s3` to the bucket url.

---

### Acceptance Criteria:

n/a

---

### Tests:

No additional

---

### Screenshots:

n/a