### PR TITLE
Create peer review from publication page (query params) OCT-197

### DIFF
--- a/ui/src/pages/create.tsx
+++ b/ui/src/pages/create.tsx
@@ -63,18 +63,20 @@ const Create: Types.NextPage<PageProps> = (props): React.ReactElement => {
                 props.token
             );
 
-            const redirect = {
-                pathname: `${Config.urls.viewPublication.path}/${response.data.id}/edit`,
-                query: {}
-            };
-
             if (props.publicationForID) {
-                redirect.query = {
-                    for: props.publicationForID
-                };
+                await api.post(
+                    '/links',
+                    {
+                        to: props.publicationForID,
+                        from: response.data.id
+                    },
+                    props.token
+                );
             }
 
-            router.push(redirect);
+            router.push({
+                pathname: `${Config.urls.viewPublication.path}/${response.data.id}/edit`
+            });
         } catch (err) {
             const { message } = err as Interfaces.JSONResponseError;
             setError(message);
@@ -143,13 +145,20 @@ const Create: Types.NextPage<PageProps> = (props): React.ReactElement => {
                             name="publicationType"
                             value={publicationType}
                             onChange={(e) => setPublicationType(e.target.value as Types.PublicationType)}
+                            disabled={!!props.publicationType}
                             className="my-4 block w-fit rounded border bg-white-50 text-grey-800 outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400"
                         >
-                            {Config.values.publicationTypes.map((type) => (
-                                <option key={type} value={type}>
-                                    {Helpers.formatPublicationType(type)}
+                            {props.publicationType ? (
+                                <option key={props.publicationType} value={props.publicationType}>
+                                    {Helpers.formatPublicationType(props.publicationType)}
                                 </option>
-                            ))}
+                            ) : (
+                                Config.values.publicationTypes.map((type) => (
+                                    <option key={type} value={type}>
+                                        {Helpers.formatPublicationType(type)}
+                                    </option>
+                                ))
+                            )}
                         </select>
                         <SupportText>
                             {Config.values.octopusInformation.publications[publicationType].content}


### PR DESCRIPTION
The purpose of this PR was to allow the publication creation page to accept two query params. 
1. A publication type, if available, the dropdown of publication type is pre selected & disabled disallowing change.
2. A publication for ID. If provided, on creation of the publication, an attempt of creating a link will be done.

[For Jira Ticket 197](https://jiscdev.atlassian.net/jira/software/projects/OCT/boards/836?selectedIssue=OCT-197)

---

### Acceptance Criteria:

A user can select to write a review of a publication. This will take them to the publication creation page with information pre selected. The link to that publication for review will automatically be created.

---

### Screenshots:


https://user-images.githubusercontent.com/81176162/167603247-53905e5b-2b2b-4c3d-943a-87a8bc5d9832.mov


