### PR TITLE
OCT-209 Updated copy for verify email page

### DIFF
--- a/ui/src/pages/verify.tsx
+++ b/ui/src/pages/verify.tsx
@@ -145,6 +145,20 @@ const Verify: Types.NextPage<Props> = (props): React.ReactElement => {
                     <Components.PageTitle
                         text={props.newUser ? 'Complete your registration' : 'Update your email address'}
                     />
+                    <p className="mb-6 block font-montserrat text-lg font-medium text-grey-700 transition-colors duration-500 dark:text-grey-50">
+                        A verified email is required for essential service notifications. We’ll use it as described in
+                        our privacy notice (at{' '}
+                        <Components.Link
+                            href={Config.urls.privacy.canonical}
+                            className="rounded border-transparent underline decoration-teal-500 underline-offset-2 outline-0 focus:overflow-hidden focus:ring-2 focus:ring-yellow-400"
+                            openNew={true}
+                        >
+                            {Config.urls.privacy.canonical}
+                        </Components.Link>
+                        ) only to provide the Octopus service. We’ll store your email address until we are told that you
+                        no longer wish to hold an account. You can update your email address at any time from your user
+                        account page.
+                    </p>
                     <form className="flex-column gap-4 space-y-4">
                         {!!error && <Components.Alert severity="ERROR" title={error} />}
                         <label htmlFor="fullName" className="flex flex-col gap-1">


### PR DESCRIPTION
The purpose of this PR was to add explanatory copy to the verify email page.

---

### Acceptance Criteria:

Copy should read:

> A verified email is required for essential service notifications. We’ll use it as described in our privacy notice (at https://int.octopus.ac/privacy) only to provide the Octopus service. We’ll store your email address until we are told that you no longer wish to hold an account. You can update your email address at any time from your user account page.

---

### Tests:

No additional.

---

### Screenshots:

![localhost_3001_privacy](https://user-images.githubusercontent.com/86601264/169504109-1a5d9cad-7d3e-47a6-9fa0-b6b4c3ba03bc.png)

![localhost_3001_privacy (1)](https://user-images.githubusercontent.com/86601264/169504100-fe73fa63-d890-48dd-88da-71414fa18c03.png)

![localhost_3001_privacy (2)](https://user-images.githubusercontent.com/86601264/169504203-2f21ba45-e0b7-4959-a8ad-1721dece4a49.png)

![localhost_3001_privacy (3)](https://user-images.githubusercontent.com/86601264/169504219-a89b1670-265e-4038-b370-db31a2df5471.png)

