### PR TITLE
Create a 'funders statement' free text field - API & UI

### DIFF
--- a/api/prisma/migrations/20220524111833_init/migration.sql
+++ b/api/prisma/migrations/20220524111833_init/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Publication" ADD COLUMN     "fundersStatement" TEXT;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -81,6 +81,7 @@ model Publication {
     publicationStatus        PublicationStatus[]
     PublicationBookmarks     PublicationBookmarks[]
     funders                  Funders[]
+    fundersStatement         String?
 }
 
 model Funders {

--- a/api/src/components/publication/schema/create.ts
+++ b/api/src/components/publication/schema/create.ts
@@ -55,6 +55,9 @@ const createPublicationSchema: I.Schema = {
         },
         selfDeclaration: {
             type: 'boolean'
+        },
+        fundersStatement: {
+            type: 'string'
         }
     },
     required: ['type', 'title'],

--- a/api/src/components/publication/schema/update.ts
+++ b/api/src/components/publication/schema/update.ts
@@ -45,6 +45,9 @@ const updatePublicationSchema: I.Schema = {
         },
         selfDeclaration: {
             type: 'boolean'
+        },
+        fundersStatement: {
+            type: 'string'
         }
     },
     additionalProperties: false

--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -286,6 +286,7 @@ export const create = async (e: I.CreatePublicationRequestBody, user: I.User) =>
             ethicalStatement: e.ethicalStatement,
             ethicalStatementFreeText: e.ethicalStatementFreeText,
             selfDeclaration: e.selfDeclaration,
+            fundersStatement: e.fundersStatement,
             user: {
                 connect: {
                     id: user.id

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -75,6 +75,7 @@ export interface CreatePublicationRequestBody {
     keywords?: string[];
     content?: string;
     language?: Languages;
+    fundersStatement: string;
     ethicalStatement?: boolean;
     ethicalStatementFreeText?: string;
     selfDeclaration?: boolean;

--- a/ui/src/components/Button/index.tsx
+++ b/ui/src/components/Button/index.tsx
@@ -18,7 +18,6 @@ type Props = {
 const Button: React.FC<Props> = (props): React.ReactElement | null => {
     const parentStyles = React.useMemo(() => {
         return `
-            pb-2
             group
             inline-flex
             items-center

--- a/ui/src/components/Button/index.tsx
+++ b/ui/src/components/Button/index.tsx
@@ -54,7 +54,13 @@ const Button: React.FC<Props> = (props): React.ReactElement | null => {
 
     if (props.link && props.href) {
         return (
-            <Components.Link href={props.href} title={props.title} ariaLabel={props.title} className={parentStyles}>
+            <Components.Link
+                href={props.href}
+                title={props.title}
+                ariaLabel={props.title}
+                className={parentStyles}
+                openNew
+            >
                 <>
                     {props.iconPosition === 'LEFT' && props.icon}
                     <span className={childStyles}>{props.title}</span>

--- a/ui/src/components/Publication/Creation/Funders.tsx
+++ b/ui/src/components/Publication/Creation/Funders.tsx
@@ -47,7 +47,9 @@ const TableRow: React.FC<TableProps> = (props): React.ReactElement => {
                     {props.item.name}
                 </td>
                 <td className="space-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
-                    <a href={props.item.link}>{props.item.link}</a>
+                    <Components.Link href={props.item.link} openNew>
+                        {props.item.link}
+                    </Components.Link>
                 </td>
                 <td className="space-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
                     {props.item.city}, {props.item.country}
@@ -237,11 +239,11 @@ const Funders: React.FC = (): React.ReactElement => {
                             type="radio"
                             defaultChecked={method === 'ror'}
                             onChange={(e) => setMethod('ror')}
-                            className="border-gray-300 h-4 w-4 text-teal-600 focus:ring-teal-600"
+                            className="border-gray-300 mb-1 h-4 w-4 text-teal-600 focus:ring-teal-600"
                         />
                         <label
                             htmlFor="ror"
-                            className="text-gray-700 ml-3 block text-sm font-medium dark:text-white-100"
+                            className="text-gray-700 mb-1 ml-3 block text-sm font-medium dark:text-white-100"
                         >
                             Enter funder ROR ID
                         </label>

--- a/ui/src/components/Publication/Creation/Funders.tsx
+++ b/ui/src/components/Publication/Creation/Funders.tsx
@@ -401,7 +401,7 @@ const Funders: React.FC = (): React.ReactElement => {
                                     className={`mb-2 mt-3 w-5/6 rounded border border-grey-100 bg-white-50 bg-white-50 p-2 text-grey-700 shadow focus:ring-2 focus:ring-yellow-400
                             `}
                                     placeholder="Enter any details"
-                                    value={funderStatement}
+                                    value={funderStatement ?? ''}
                                     onChange={(e) => updateFunderStatement(e.target.value)}
                                 />
                             </div>

--- a/ui/src/components/Publication/Creation/Funders.tsx
+++ b/ui/src/components/Publication/Creation/Funders.tsx
@@ -218,6 +218,15 @@ const Funders: React.FC = (): React.ReactElement => {
                     . This ensures that consistent, accurate organisational data is displayed and enables more efficient
                     discovery and tracking of research outputs across institutions and funding bodies.
                 </span>
+                <Components.Button
+                    title="Search for your organisation's ROR"
+                    link
+                    href="https://ror.org/"
+                    iconPosition="RIGHT"
+                    icon={
+                        <OutlineIcons.SearchIcon className="h-6 w-6 text-teal-500 transition-colors duration-500 dark:text-white-50" />
+                    }
+                />
             </div>
             <div className="flex items-center ">
                 <fieldset className="w-full">

--- a/ui/src/components/Publication/Creation/Funders.tsx
+++ b/ui/src/components/Publication/Creation/Funders.tsx
@@ -9,6 +9,7 @@ import * as Config from '@config';
 import * as Types from '@types';
 import * as api from '@api';
 import * as Interfaces from '@interfaces';
+import * as Helpers from '@helpers';
 
 type Props = {
     loading: boolean;
@@ -193,14 +194,6 @@ const Funders: React.FC = (): React.ReactElement => {
         }
     };
 
-    const checkLinkIsValid = (text: string) => {
-        const lowerCaseText = text.toLowerCase();
-        const urlR = new RegExp(
-            /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/g
-        );
-        setIsLinkValid(urlR.test(lowerCaseText));
-    };
-
     return (
         <div className="space-y-12 2xl:space-y-16">
             <div>
@@ -322,7 +315,7 @@ const Funders: React.FC = (): React.ReactElement => {
                             type="url"
                             value={link}
                             onChange={(e) => {
-                                checkLinkIsValid(e.target.value);
+                                setIsLinkValid(Helpers.checkLinkIsValid(e.target.value));
                                 setLink(e.target.value);
                             }}
                         />

--- a/ui/src/components/Publication/Creation/Funders.tsx
+++ b/ui/src/components/Publication/Creation/Funders.tsx
@@ -120,6 +120,9 @@ const Funders: React.FC = (): React.ReactElement => {
     const funders = Stores.usePublicationCreationStore((state) => state.funders);
     const updateFunders = Stores.usePublicationCreationStore((state) => state.updateFunders);
 
+    const funderStatement = Stores.usePublicationCreationStore((state) => state.funderStatement);
+    const updateFunderStatement = Stores.usePublicationCreationStore((state) => state.updateFunderStatement);
+
     const publicationId = Stores.usePublicationCreationStore((state) => state.id);
     const user = Stores.useAuthStore((state) => state.user);
 
@@ -129,6 +132,7 @@ const Funders: React.FC = (): React.ReactElement => {
     const [city, setCity] = React.useState('');
     const [country, setCountry] = React.useState('');
     const [link, setLink] = React.useState('');
+    const [isLinkValid, setIsLinkValid] = React.useState(false);
     const [submitLoading, setSubmitLoading] = React.useState(false);
 
     const [rorLoading, setRorLoading] = React.useState(false);
@@ -187,6 +191,14 @@ const Funders: React.FC = (): React.ReactElement => {
         }
     };
 
+    const checkLinkIsValid = (text: string) => {
+        const lowerCaseText = text.toLowerCase();
+        const urlR = new RegExp(
+            /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/g
+        );
+        setIsLinkValid(urlR.test(lowerCaseText));
+    };
+
     return (
         <div className="space-y-12 2xl:space-y-16">
             <div>
@@ -207,9 +219,9 @@ const Funders: React.FC = (): React.ReactElement => {
                     discovery and tracking of research outputs across institutions and funding bodies.
                 </span>
             </div>
-            <div className="flex items-center space-x-4">
+            <div className="flex items-center ">
                 <fieldset className="w-full">
-                    <div className="mb-2 flex items-center">
+                    <div className="flex items-center">
                         <input
                             id="ror"
                             name="funder-method"
@@ -289,22 +301,33 @@ const Funders: React.FC = (): React.ReactElement => {
                             onChange={(e) => setCountry(e.target.value)}
                         />
                     </div>
-                    <div className="mb-4">
+                    <div>
                         <input
                             placeholder="Link"
                             disabled={method === 'ror'}
                             className={`w-1/2 rounded border border-grey-100  p-2 text-grey-800 shadow focus:ring-2 focus:ring-yellow-400 ${
                                 method === 'ror' ? 'bg-grey-50 dark:bg-grey-400' : 'bg-white-50'
                             }`}
+                            type="url"
                             value={link}
-                            onChange={(e) => setLink(e.target.value)}
+                            onChange={(e) => {
+                                checkLinkIsValid(e.target.value);
+                                setLink(e.target.value);
+                            }}
                         />
+                        {!isLinkValid && link ? (
+                            <Components.Alert
+                                severity="ERROR"
+                                title="Please enter a valid URL."
+                                className="mt-3 w-1/2"
+                            />
+                        ) : null}
                     </div>
                 </fieldset>
             </div>
             <Components.Button
                 title="Add funder"
-                disabled={name == '' || link == '' || city == '' || link == ''}
+                disabled={name == '' || link == '' || city == '' || link == '' || isLinkValid == false}
                 onClick={onSubmitHandler}
                 iconPosition="RIGHT"
                 icon={
@@ -319,8 +342,8 @@ const Funders: React.FC = (): React.ReactElement => {
                 <div className="-my-2 -mx-4 overflow-x-auto sm:-mx-6 lg:-mx-8">
                     <div className="inline-block min-w-full py-2 align-middle md:px-6 lg:px-8">
                         {funders.length ? (
-                            <div className="overflow-hidden shadow ring-1 ring-black ring-opacity-5 dark:ring-transparent md:rounded-lg">
-                                <table className="min-w-full divide-y divide-grey-100 dark:divide-teal-300">
+                            <div className="mb-6 overflow-hidden shadow ring-1 ring-black ring-opacity-5 dark:ring-transparent md:rounded-lg">
+                                <table className="min-w-full divide-y divide-grey-100  dark:divide-teal-300">
                                     <thead className="bg-grey-50 transition-colors duration-500 dark:bg-grey-700">
                                         <tr>
                                             <th className="whitespace-pre py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-grey-900 transition-colors duration-500 dark:text-grey-50 sm:pl-6 ">
@@ -351,9 +374,27 @@ const Funders: React.FC = (): React.ReactElement => {
                             <Components.Alert
                                 severity="INFO"
                                 title="This publication does not have any funders."
-                                className="w-fit"
+                                className="w-1/2"
                             />
                         )}
+                        {funders.length ? (
+                            <div className="mb-2 flex flex-col">
+                                <label
+                                    htmlFor="ror"
+                                    className="text-gray-700 mt-6 block text-sm font-medium dark:text-white-100"
+                                >
+                                    If needed, provide further information on this publication’s funding arrangements
+                                </label>
+                                <textarea
+                                    name="free-text"
+                                    className={`mb-2 mt-3 w-5/6 rounded border border-grey-100 bg-white-50 bg-white-50 p-2 text-grey-700 shadow focus:ring-2 focus:ring-yellow-400
+                            `}
+                                    placeholder="Enter any details"
+                                    value={funderStatement}
+                                    onChange={(e) => updateFunderStatement(e.target.value)}
+                                />
+                            </div>
+                        ) : null}
                     </div>
                 </div>
             </Framer.motion.div>

--- a/ui/src/components/Publication/Creation/StepTwo.tsx
+++ b/ui/src/components/Publication/Creation/StepTwo.tsx
@@ -94,7 +94,7 @@ const StepTwo: React.FC = (): React.ReactElement => {
     return (
         <div className="space-y-6 lg:space-y-10 2xl:w-10/12">
             <div>
-                <Components.PublicationCreationStepTitle text="What publications do you want to linked to?" />
+                <Components.PublicationCreationStepTitle text="What publications do you want to link to?" />
                 <p className="mb-6 block text-sm text-grey-800 transition-colors duration-500 dark:text-white-50">
                     All publications in Octopus are linked to each other to form research chains, branching down from
                     research Problems to Real world implementations.

--- a/ui/src/layouts/BuildPublication.tsx
+++ b/ui/src/layouts/BuildPublication.tsx
@@ -78,7 +78,6 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
         if (store.type === 'PROTOCOL' || store.type === 'HYPOTHESIS') {
             body.selfDeclaration = store.selfDeclaration;
         }
-        console.log(body);
 
         await api.patch(`${Config.endpoints.publications}/${props.publication.id}`, body, props.token);
 

--- a/ui/src/layouts/BuildPublication.tsx
+++ b/ui/src/layouts/BuildPublication.tsx
@@ -66,7 +66,8 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
             licence: store.licence,
             language: store.language,
             conflictOfInterestStatus: store.conflictOfInterestStatus,
-            conflictOfInterestText: store.conflictOfInterestText
+            conflictOfInterestText: store.conflictOfInterestText,
+            fundersStatement: store.funderStatement
         };
 
         if (store.type === 'DATA') {
@@ -77,6 +78,7 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
         if (store.type === 'PROTOCOL' || store.type === 'HYPOTHESIS') {
             body.selfDeclaration = store.selfDeclaration;
         }
+        console.log(body);
 
         await api.patch(`${Config.endpoints.publications}/${props.publication.id}`, body, props.token);
 

--- a/ui/src/lib/helpers.tsx
+++ b/ui/src/lib/helpers.tsx
@@ -284,3 +284,11 @@ export const formatKeywords = (keywordsAsString: string): string[] => {
     }
     return formattedKeywords;
 };
+
+export const checkLinkIsValid = (text: string) => {
+    const lowerCaseText = text.toLowerCase();
+    const urlR = new RegExp(
+        /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/
+    );
+    return urlR.test(lowerCaseText);
+};

--- a/ui/src/lib/interfaces.ts
+++ b/ui/src/lib/interfaces.ts
@@ -341,7 +341,7 @@ export interface PublicationUpdateRequestBody extends JSON {
     description: string;
     keywords: string[];
     licence: Types.LicenceType;
-    fundersStatement: string | null;
+    fundersStatement?: string | null;
     language: Types.Languages;
     conflictOfInterestStatus: boolean;
     conflictOfInterestText: string;

--- a/ui/src/lib/interfaces.ts
+++ b/ui/src/lib/interfaces.ts
@@ -76,6 +76,7 @@ export interface Publication extends CorePublication {
     ratings: Rating;
     coAuthors: CoAuthor[];
     funders: Funder[];
+    fundersStatement: string | null;
     publicationFlags: Flag[];
 }
 
@@ -340,6 +341,7 @@ export interface PublicationUpdateRequestBody extends JSON {
     description: string;
     keywords: string[];
     licence: Types.LicenceType;
+    fundersStatement: string | null;
     language: Types.Languages;
     conflictOfInterestStatus: boolean;
     conflictOfInterestText: string;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -74,7 +74,7 @@ export type PublicationCreationStoreType = {
     reset: () => void;
     coAuthors: Interfaces.CoAuthor[];
     updateCoAuthors: (coAuthors: Interfaces.CoAuthor[]) => void;
-    funderStatement: string | null;
+    funderStatement: string | number | readonly string[] | undefined;
     updateFunderStatement: (funderStatement: string | null) => void;
     funders: Interfaces.Funder[];
     updateFunders: (funders: Interfaces.Funder[]) => void;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -74,7 +74,7 @@ export type PublicationCreationStoreType = {
     reset: () => void;
     coAuthors: Interfaces.CoAuthor[];
     updateCoAuthors: (coAuthors: Interfaces.CoAuthor[]) => void;
-    funderStatement: string | number | readonly string[] | undefined;
+    funderStatement: string | null;
     updateFunderStatement: (funderStatement: string | null) => void;
     funders: Interfaces.Funder[];
     updateFunders: (funders: Interfaces.Funder[]) => void;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -74,6 +74,8 @@ export type PublicationCreationStoreType = {
     reset: () => void;
     coAuthors: Interfaces.CoAuthor[];
     updateCoAuthors: (coAuthors: Interfaces.CoAuthor[]) => void;
+    funderStatement: string | null;
+    updateFunderStatement: (funderStatement: string | null) => void;
     funders: Interfaces.Funder[];
     updateFunders: (funders: Interfaces.Funder[]) => void;
     selfDeclaration: boolean;

--- a/ui/src/pages/publications/[id]/edit.tsx
+++ b/ui/src/pages/publications/[id]/edit.tsx
@@ -250,6 +250,7 @@ const Edit: Types.NextPage<Props> = (props): React.ReactElement => {
         store.updateLinkTo(props.draftedPublication.linkedTo);
         store.updateCoAuthors(props.draftedPublication.coAuthors);
         store.updateFunders(props.draftedPublication.funders);
+        store.updateFunderStatement(props.draftedPublication.fundersStatement);
     }, []);
 
     React.useEffect(() => {

--- a/ui/src/pages/publications/[id]/index.tsx
+++ b/ui/src/pages/publications/[id]/index.tsx
@@ -553,11 +553,16 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                     )}
                     {/* Publication funders section */}
                     <Components.PublicationContentSection id="funders" title="Funders" hasBreak>
-                        {publication.funders.length ? (
+                        {!publication.funders.length ? (
+                            <p className="block leading-relaxed text-grey-800 transition-colors duration-500 dark:text-grey-100">
+                                No sources of funding have been specified for this{' '}
+                                {Helpers.formatPublicationType(publication.type)}.
+                            </p>
+                        ) : (
                             <>
                                 <p className="block leading-relaxed text-grey-800 transition-colors duration-500 dark:text-grey-100">
-                                    This {Helpers.formatPublicationType(publication.type)} has the following funder
-                                    {publication.funders.length > 1 && 's'}:
+                                    This {Helpers.formatPublicationType(publication.type)} has the following sources of
+                                    funding:
                                 </p>
                                 <ul>
                                     {publication.funders.map((funder) => {
@@ -571,11 +576,10 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                                         );
                                     })}
                                 </ul>
+                                <p className="block leading-relaxed text-grey-800 transition-colors duration-500 dark:text-grey-100">
+                                    {publication.fundersStatement}
+                                </p>
                             </>
-                        ) : (
-                            <p className="block leading-relaxed text-grey-800 transition-colors duration-500 dark:text-grey-100">
-                                This {Helpers.formatPublicationType(publication.type)} has no funders.
-                            </p>
                         )}
                     </Components.PublicationContentSection>
 

--- a/ui/src/pages/publications/[id]/index.tsx
+++ b/ui/src/pages/publications/[id]/index.tsx
@@ -576,7 +576,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                                         );
                                     })}
                                 </ul>
-                                <p className="block leading-relaxed text-grey-800 transition-colors duration-500 dark:text-grey-100">
+                                <p className="block pt-2 leading-relaxed text-grey-800 transition-colors duration-500 dark:text-grey-100">
                                     {publication.fundersStatement}
                                 </p>
                             </>

--- a/ui/src/stores/publicationCreation.ts
+++ b/ui/src/stores/publicationCreation.ts
@@ -18,6 +18,7 @@ let store: any = (set: (params: any) => void) => ({
                 type: Config.values.octopusInformation.publications.PROBLEM.id,
                 content: '',
                 description: '',
+                funderStatement: '',
                 funders: [],
                 keywords: [],
                 licence: Config.values.octopusInformation.licences.CC_BY.value,
@@ -83,6 +84,8 @@ let store: any = (set: (params: any) => void) => ({
     updateCoAuthors: (coAuthors: Interfaces.CoAuthor[]) => set(() => ({ coAuthors })),
 
     // Funders
+    funderStatement: '',
+    updateFunderStatement: (funderStatement: string) => set(() => ({ funderStatement })),
     funders: [],
     updateFunders: (funders: Interfaces.Funder[]) => set(() => ({ funders })),
 


### PR DESCRIPTION
The purpose of this PR is to create a feature that enables users to add optional details regarding the funders of their publication. 

This PR contains amendments to the API, changes to the `Publication` schema to store the funder's statement, the addition of the free text fields on the UI and the displaying of the statement (if specified) on the Publication page. It also contains amendments to the 'funders' page within the build publication process as per Lola's request, including: regulation on the 'link' field to check that the user has given a valid URL, copy tweaks, a button that links to [https://ror.org/](url) and styling tweaks.

## Acceptance Criteria:
- The free text field should only display if the user has added funders to the publication - this is the same for the UI on the publication page
- The free text field is optional 

## Screenshots:
### Add a funder's statement in the build publication process: 
https://user-images.githubusercontent.com/100135505/170275225-3d521437-f1c4-4949-9fd5-8f37e443d876.mov

### The Publication page with a funder's statement and funder details: 
![Screenshot 2022-05-25 at 15 10 05](https://user-images.githubusercontent.com/100135505/170282587-3e470a99-a42d-44a5-8a58-f181ae82ca3e.png)


