### PR TITLE
OCT-issue-151

### DIFF
--- a/ui/src/pages/search.tsx
+++ b/ui/src/pages/search.tsx
@@ -354,46 +354,52 @@ const Search: Types.NextPage<Props> = (props): React.ReactElement => {
                                             </div>
                                         ))}
                                     </div>
-                                    <form
-                                        name="date-form"
-                                        id="date-form"
-                                        className="col-span-12 lg:col-span-3 xl:col-span-4"
-                                        onSubmit={handlerDateFormSubmit}
-                                    >
-                                        <legend className="pb-4 font-montserrat text-xl font-semibold text-grey-800 transition-colors duration-500 dark:text-white-50">
-                                            Date Range
-                                        </legend>
-                                        <label htmlFor="date-from" className="relative block w-full">
-                                            <span className="mb-1 block text-xxs font-bold uppercase tracking-widest text-grey-600 transition-colors duration-500 dark:text-grey-300">
-                                                Date From:
-                                            </span>
-                                            <input
-                                                name="date-from"
-                                                id="date-from"
-                                                type="date"
-                                                placeholder="Date from..."
-                                                className="w-full rounded-md border border-grey-200 px-4 py-2 outline-none focus:ring-2 focus:ring-yellow-500 disabled:opacity-70"
-                                                disabled={isValidating}
-                                                value={dateFrom}
-                                                onChange={(e) => setDateFrom(e.target.value)}
-                                            />
-                                        </label>
-                                        <label htmlFor="date-to" className="relative block w-full">
-                                            <span className="mb-1 block pt-2 text-xxs font-bold uppercase tracking-widest text-grey-600 transition-colors duration-500 dark:text-grey-300">
-                                                Date to:
-                                            </span>
-                                            <input
-                                                name="date-to"
-                                                id="date-to"
-                                                type="date"
-                                                placeholder="Date to..."
-                                                className="w-full rounded-md border border-grey-200 px-4 py-2 outline-none focus:ring-2 focus:ring-yellow-500 disabled:opacity-70"
-                                                disabled={isValidating}
-                                                value={dateTo}
-                                                onChange={(e) => setDateTo(e.target.value)}
-                                            />
-                                        </label>
-                                    </form>
+
+                                    {searchType === 'publications' ? (
+                                        <Framer.motion.form
+                                            name="date-form"
+                                            id="date-form"
+                                            className="col-span-12 lg:col-span-3 xl:col-span-4"
+                                            onSubmit={handlerDateFormSubmit}
+                                            initial={{ opacity: 0 }}
+                                            animate={{ opacity: 1 }}
+                                            exit={{ opacity: 0 }}
+                                        >
+                                            <legend className="pb-4 font-montserrat text-xl font-semibold text-grey-800 transition-colors duration-500 dark:text-white-50">
+                                                Date Range
+                                            </legend>
+                                            <label htmlFor="date-from" className="relative block w-full">
+                                                <span className="mb-1 block text-xxs font-bold uppercase tracking-widest text-grey-600 transition-colors duration-500 dark:text-grey-300">
+                                                    Date From:
+                                                </span>
+                                                <input
+                                                    name="date-from"
+                                                    id="date-from"
+                                                    type="date"
+                                                    placeholder="Date from..."
+                                                    className="w-full rounded-md border border-grey-200 px-4 py-2 outline-none focus:ring-2 focus:ring-yellow-500 disabled:opacity-70"
+                                                    disabled={isValidating}
+                                                    value={dateFrom}
+                                                    onChange={(e) => setDateFrom(e.target.value)}
+                                                />
+                                            </label>
+                                            <label htmlFor="date-to" className="relative block w-full">
+                                                <span className="mb-1 block pt-2 text-xxs font-bold uppercase tracking-widest text-grey-600 transition-colors duration-500 dark:text-grey-300">
+                                                    Date to:
+                                                </span>
+                                                <input
+                                                    name="date-to"
+                                                    id="date-to"
+                                                    type="date"
+                                                    placeholder="Date to..."
+                                                    className="w-full rounded-md border border-grey-200 px-4 py-2 outline-none focus:ring-2 focus:ring-yellow-500 disabled:opacity-70"
+                                                    disabled={isValidating}
+                                                    value={dateTo}
+                                                    onChange={(e) => setDateTo(e.target.value)}
+                                                />
+                                            </label>
+                                        </Framer.motion.form>
+                                    ) : null}
                                 </div>
 
                                 <div className="pt-6">
@@ -433,7 +439,10 @@ const Search: Types.NextPage<Props> = (props): React.ReactElement => {
                                     <Components.Alert
                                         severity="INFO"
                                         title="No results found"
-                                        details={['Placeholder support text here', 'Placeholder support text here']}
+                                        details={[
+                                            'Try a different search criteria.',
+                                            'If you think something is wrong, please contact the helpdesk.'
+                                        ]}
                                     />
                                 )}
 


### PR DESCRIPTION
Hides the date pickers on the `/search` page when the chosen search type is 'users'. This fixes a bug where a runtime error would occur as a date filter is only valid for publications.

I also spotted the empty results alert contained placeholder text so have populated that with some more useful text.

Issue: #151 

---

### Acceptance Criteria:

Go to the search page and change the search type to users, the date pickers should disappear. Changing back to publications should make them reappear again.
