### PR TITLE
OCT-220 Remove section links from box on publication page

### DIFF
--- a/ui/src/pages/publications/[id]/index.tsx
+++ b/ui/src/pages/publications/[id]/index.tsx
@@ -139,12 +139,10 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
     if (showRedFlags) list.push({ title: 'Red flags', href: 'red-flags' });
 
     const sectionList = [
-        { title: 'Publication chain', href: 'publication-chain' },
         { title: 'Main text', href: 'main-text' },
         ...list,
         { title: 'Funders', href: 'funders' },
-        { title: 'Conflict of interest', href: 'coi' },
-        { title: 'Affiliated organisations', href: 'affiliations' }
+        { title: 'Conflict of interest', href: 'coi' }
     ];
 
     const currentCoAuthor = React.useMemo(


### PR DESCRIPTION
The purpose of this PR is to remove `publication chain` and `affiliated organisations` from the publication page.

---

### Acceptance Criteria:

As per [OCT-220](https://jiscdev.atlassian.net/browse/OCT-220)

---

### Screenshots:

![image (3)](https://user-images.githubusercontent.com/78794569/176661699-bfe1c3c2-993b-4f33-af6b-c9d7b3bffc8c.png)

