### PR TITLE
OCT-225 Holding page - Use modified about page as homepage

### DIFF
--- a/ui/src/components/Footer/index.tsx
+++ b/ui/src/components/Footer/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Image from 'next/image';
-import * as NextRouter from 'next/router';
 
 import * as Components from '@components';
 import * as Config from '@config';
@@ -11,8 +10,6 @@ type Props = {
 };
 
 const Footer: React.FC<Props> = (props: Props): React.ReactElement => {
-    const router = NextRouter.useRouter();
-
     return (
         <>
             {props.waves && (
@@ -23,34 +20,34 @@ const Footer: React.FC<Props> = (props: Props): React.ReactElement => {
                 />
             )}
 
-            {router.asPath !== '/about' && (
-                <footer className="relative bg-teal-700 py-28 transition-all duration-500 dark:bg-grey-800 print:hidden">
-                    <div className="container mx-auto grid grid-cols-1 gap-8 px-8 md:grid-cols-4">
-                        {/** Title and social icons */}
-                        <h2 className="col-span-1 block font-montserrat text-4xl font-bold text-white-50 lg:mb-12">
-                            Octopus
-                        </h2>
-                        <div className="col-span-1 flex space-x-4 pt-4 md:col-span-3 lg:col-span-3">
-                            <Components.Link
-                                href="https://github.com/JiscSD/octopus"
-                                openNew={true}
-                                ariaLabel="Github Repository"
-                                className="h-fit"
-                            >
-                                <Assets.Github height={25} width={25} className="fill-white-50" />
-                            </Components.Link>
-                            <Components.Link
-                                href="https://twitter.com/science_octopus"
-                                openNew={true}
-                                ariaLabel="Twitter"
-                                className="h-fit"
-                            >
-                                <Assets.Twitter width={25} height={25} className="fill-white-50" />
-                            </Components.Link>
-                        </div>
-                        {/** Links */}
-                        <div className="col-span-1 mb-14 md:col-span-2 lg:col-span-1">
-                            <Components.Link
+            <footer className="relative bg-teal-700 py-28 transition-all duration-500 dark:bg-grey-800 print:hidden">
+                <div className="container mx-auto grid grid-cols-1 gap-8 px-8 md:grid-cols-4">
+                    {/** Title and social icons */}
+                    <h2 className="col-span-1 block font-montserrat text-4xl font-bold text-white-50 lg:mb-12">
+                        Octopus
+                    </h2>
+                    <div className="col-span-1 flex space-x-4 pt-4 md:col-span-3 lg:col-span-3">
+                        <Components.Link
+                            href="https://github.com/JiscSD/octopus"
+                            openNew={true}
+                            ariaLabel="Github Repository"
+                            className="h-fit"
+                        >
+                            <Assets.Github height={25} width={25} className="fill-white-50" />
+                        </Components.Link>
+                        <Components.Link
+                            href="https://twitter.com/science_octopus"
+                            openNew={true}
+                            ariaLabel="Twitter"
+                            className="h-fit"
+                        >
+                            <Assets.Twitter width={25} height={25} className="fill-white-50" />
+                        </Components.Link>
+                    </div>
+                    {/** Links */}
+                    <div className="col-span-1 mb-14 md:col-span-2 lg:col-span-1">
+                        {/* TODO: Re add these links once ORCID login has been fixed */}
+                        {/* <Components.Link
                                 href={Config.urls.browsePublications.path}
                                 className="mb-1 block max-w-fit p-1"
                             >
@@ -78,76 +75,67 @@ const Footer: React.FC<Props> = (props: Props): React.ReactElement => {
                                 <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">
                                     Get involved
                                 </h3>
-                            </Components.Link>
-                        </div>
-                        {/** Links */}
-                        <div className="col-span-1 mb-4 md:col-span-2 lg:col-span-3">
-                            <Components.Link href={Config.urls.terms.path} className="mb-1 block max-w-fit p-1">
-                                <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">
-                                    Terms
-                                </h3>
-                            </Components.Link>
-                            <Components.Link href={Config.urls.privacy.path} className="mb-1 block max-w-fit p-1">
-                                <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">
-                                    Privacy
-                                </h3>
-                            </Components.Link>
-                            <Components.Link
-                                href={Config.urls.accessibility.path}
-                                className="mb-1 block max-w-fit p-1 "
-                            >
-                                <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">
-                                    Accessibility
-                                </h3>
-                            </Components.Link>
-                        </div>
-
-                        {/** Socket */}
-                        <div className="col-span-1 md:col-span-2 lg:col-span-1">
-                            <h4 className="text-md mb-8 block font-montserrat text-sm font-bold text-white-50 dark:text-teal-200">
-                                In partnership with
-                            </h4>
-                            <Components.Link href="https://www.ukrn.org/" openNew={true} className="flex w-fit">
-                                <Image src="/images/ukrn.png" alt="Jisc Logo" width={60} height={60} />
-                            </Components.Link>
-                        </div>
-                        <div className="col-span-1 md:col-span-2 lg:col-span-1">
-                            <h4 className="text-md mb-8 block font-montserrat text-sm font-bold text-white-50 dark:text-teal-200">
-                                With support from
-                            </h4>
-                            <div className="flex">
-                                <Components.Link href="https://www.ukri.org/" openNew={true} className="flex w-fit">
-                                    <Image src="/images/logo-ukri.png" alt="UKRI" width={200} height={64} />
-                                </Components.Link>
-                            </div>
-                        </div>
-                        <div className="col-span-1 md:col-span-2 lg:col-span-1">
-                            <h4 className="text-md mb-8 block font-montserrat text-sm font-bold text-white-50 dark:text-teal-200">
-                                A collaboration with
-                            </h4>
-                            <div className="flex">
-                                <Components.Link href="https://jisc.ac.uk" openNew={true} className="flex">
-                                    <Image src="/images/jisc-logo.svg" alt="Jisc Logo" width={60} height={60} />
-                                </Components.Link>
-                            </div>
-                        </div>
-                        <div className="col-span-1 md:col-span-2 lg:col-span-1">
-                            <h4 className="text-md mb-8 block font-montserrat text-sm font-bold text-teal-400 dark:text-teal-200">
-                                &nbsp;
-                            </h4>
-                            <div className="flex"></div>
-                        </div>
-                        {/* contact us section */}
-                        <div className="col-span-1 mb-4 mt-14 md:col-span-2 lg:col-span-3">
+                            </Components.Link> */}
+                    </div>
+                    {/** Links */}
+                    <div className="col-span-1 mb-4 md:col-span-2 lg:col-span-3">
+                        <Components.Link href={Config.urls.terms.path} className="mb-1 block max-w-fit p-1">
+                            <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">Terms</h3>
+                        </Components.Link>
+                        <Components.Link href={Config.urls.privacy.path} className="mb-1 block max-w-fit p-1">
+                            <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">Privacy</h3>
+                        </Components.Link>
+                        <Components.Link href={Config.urls.accessibility.path} className="mb-1 block max-w-fit p-1 ">
                             <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">
-                                Contact us:{' '}
-                                <Components.Link href="mailto:help@jisc.ac.uk">help@jisc.ac.uk</Components.Link>
+                                Accessibility
                             </h3>
+                        </Components.Link>
+                    </div>
+
+                    {/** Socket */}
+                    <div className="col-span-1 md:col-span-2 lg:col-span-1">
+                        <h4 className="text-md mb-8 block font-montserrat text-sm font-bold text-white-50 dark:text-teal-200">
+                            In partnership with
+                        </h4>
+                        <Components.Link href="https://www.ukrn.org/" openNew={true} className="flex w-fit">
+                            <Image src="/images/ukrn.png" alt="Jisc Logo" width={60} height={60} />
+                        </Components.Link>
+                    </div>
+                    <div className="col-span-1 md:col-span-2 lg:col-span-1">
+                        <h4 className="text-md mb-8 block font-montserrat text-sm font-bold text-white-50 dark:text-teal-200">
+                            With support from
+                        </h4>
+                        <div className="flex">
+                            <Components.Link href="https://www.ukri.org/" openNew={true} className="flex w-fit">
+                                <Image src="/images/logo-ukri.png" alt="UKRI" width={200} height={64} />
+                            </Components.Link>
                         </div>
                     </div>
-                    <Components.ScrollToTop />
-                </footer>
-            )}
+                    <div className="col-span-1 md:col-span-2 lg:col-span-1">
+                        <h4 className="text-md mb-8 block font-montserrat text-sm font-bold text-white-50 dark:text-teal-200">
+                            A collaboration with
+                        </h4>
+                        <div className="flex">
+                            <Components.Link href="https://jisc.ac.uk" openNew={true} className="flex">
+                                <Image src="/images/jisc-logo.svg" alt="Jisc Logo" width={60} height={60} />
+                            </Components.Link>
+                        </div>
+                    </div>
+                    <div className="col-span-1 md:col-span-2 lg:col-span-1">
+                        <h4 className="text-md mb-8 block font-montserrat text-sm font-bold text-teal-400 dark:text-teal-200">
+                            &nbsp;
+                        </h4>
+                        <div className="flex"></div>
+                    </div>
+                    {/* contact us section */}
+                    <div className="col-span-1 mb-4 mt-14 md:col-span-2 lg:col-span-3">
+                        <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">
+                            Contact us: <Components.Link href="mailto:help@jisc.ac.uk">help@jisc.ac.uk</Components.Link>
+                        </h3>
+                    </div>
+                </div>
+                <Components.ScrollToTop />
+            </footer>
         </>
     );
 };

--- a/ui/src/components/Footer/index.tsx
+++ b/ui/src/components/Footer/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Image from 'next/image';
+import * as NextRouter from 'next/router';
 
 import * as Components from '@components';
 import * as Config from '@config';
@@ -9,115 +10,146 @@ type Props = {
     waves: boolean;
 };
 
-const Footer: React.FC<Props> = (props: Props): React.ReactElement => (
-    <>
-        {props.waves && (
-            <Assets.Wave
-                top="fill-teal-200 dark:fill-grey-600"
-                middle="fill-teal-400 dark:fill-grey-700"
-                bottom="fill-teal-700 dark:fill-grey-800"
-            />
-        )}
-        <footer className="relative bg-teal-700 py-28 transition-all duration-500 dark:bg-grey-800 print:hidden">
-            <div className="container mx-auto grid grid-cols-1 gap-8 px-8 md:grid-cols-4">
-                {/** Title and social icons */}
-                <h2 className="col-span-1 block font-montserrat text-4xl font-bold text-white-50 lg:mb-12">Octopus</h2>
-                <div className="col-span-1 flex space-x-4 pt-4 md:col-span-3 lg:col-span-3">
-                    <Components.Link
-                        href="https://github.com/JiscSD/octopus"
-                        openNew={true}
-                        ariaLabel="Github Repository"
-                        className="h-fit"
-                    >
-                        <Assets.Github height={25} width={25} className="fill-white-50" />
-                    </Components.Link>
-                    <Components.Link
-                        href="https://twitter.com/science_octopus"
-                        openNew={true}
-                        ariaLabel="Twitter"
-                        className="h-fit"
-                    >
-                        <Assets.Twitter width={25} height={25} className="fill-white-50" />
-                    </Components.Link>
-                </div>
-                {/** Links */}
-                <div className="col-span-1 mb-14 md:col-span-2 lg:col-span-1">
-                    <Components.Link href={Config.urls.browsePublications.path} className="mb-1 block max-w-fit p-1">
-                        <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">Browse</h3>
-                    </Components.Link>
-                    <Components.Link href={Config.urls.createPublication.path} className="mb-1 block max-w-fit p-1">
-                        <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">Publish</h3>
-                    </Components.Link>
-                    <Components.Link href={Config.urls.about.path} className="mb-1 block max-w-fit p-1">
-                        <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">About</h3>
-                    </Components.Link>
-                    <Components.Link href={Config.urls.faq.path} className="mb-1 block max-w-fit p-1">
-                        <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">FAQs</h3>
-                    </Components.Link>
-                    <Components.Link href={Config.urls.getInvolved.path} className="mb-1 block max-w-fit p-1">
-                        <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">Get involved</h3>
-                    </Components.Link>
-                </div>
-                {/** Links */}
-                <div className="col-span-1 mb-4 md:col-span-2 lg:col-span-3">
-                    <Components.Link href={Config.urls.terms.path} className="mb-1 block max-w-fit p-1">
-                        <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">Terms</h3>
-                    </Components.Link>
-                    <Components.Link href={Config.urls.privacy.path} className="mb-1 block max-w-fit p-1">
-                        <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">Privacy</h3>
-                    </Components.Link>
-                    <Components.Link href={Config.urls.accessibility.path} className="mb-1 block max-w-fit p-1 ">
-                        <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">
-                            Accessibility
-                        </h3>
-                    </Components.Link>
-                </div>
+const Footer: React.FC<Props> = (props: Props): React.ReactElement => {
+    const router = NextRouter.useRouter();
 
-                {/** Socket */}
-                <div className="col-span-1 md:col-span-2 lg:col-span-1">
-                    <h4 className="text-md mb-8 block font-montserrat text-sm font-bold text-white-50 dark:text-teal-200">
-                        In partnership with
-                    </h4>
-                    <Components.Link href="https://www.ukrn.org/" openNew={true} className="flex w-fit">
-                        <Image src="/images/ukrn.png" alt="Jisc Logo" width={60} height={60} />
-                    </Components.Link>
-                </div>
-                <div className="col-span-1 md:col-span-2 lg:col-span-1">
-                    <h4 className="text-md mb-8 block font-montserrat text-sm font-bold text-white-50 dark:text-teal-200">
-                        With support from
-                    </h4>
-                    <div className="flex">
-                        <Components.Link href="https://www.ukri.org/" openNew={true} className="flex w-fit">
-                            <Image src="/images/logo-ukri.png" alt="UKRI" width={200} height={64} />
-                        </Components.Link>
+    return (
+        <>
+            {props.waves && (
+                <Assets.Wave
+                    top="fill-teal-200 dark:fill-grey-600"
+                    middle="fill-teal-400 dark:fill-grey-700"
+                    bottom="fill-teal-700 dark:fill-grey-800"
+                />
+            )}
+
+            {router.asPath !== '/about' && (
+                <footer className="relative bg-teal-700 py-28 transition-all duration-500 dark:bg-grey-800 print:hidden">
+                    <div className="container mx-auto grid grid-cols-1 gap-8 px-8 md:grid-cols-4">
+                        {/** Title and social icons */}
+                        <h2 className="col-span-1 block font-montserrat text-4xl font-bold text-white-50 lg:mb-12">
+                            Octopus
+                        </h2>
+                        <div className="col-span-1 flex space-x-4 pt-4 md:col-span-3 lg:col-span-3">
+                            <Components.Link
+                                href="https://github.com/JiscSD/octopus"
+                                openNew={true}
+                                ariaLabel="Github Repository"
+                                className="h-fit"
+                            >
+                                <Assets.Github height={25} width={25} className="fill-white-50" />
+                            </Components.Link>
+                            <Components.Link
+                                href="https://twitter.com/science_octopus"
+                                openNew={true}
+                                ariaLabel="Twitter"
+                                className="h-fit"
+                            >
+                                <Assets.Twitter width={25} height={25} className="fill-white-50" />
+                            </Components.Link>
+                        </div>
+                        {/** Links */}
+                        <div className="col-span-1 mb-14 md:col-span-2 lg:col-span-1">
+                            <Components.Link
+                                href={Config.urls.browsePublications.path}
+                                className="mb-1 block max-w-fit p-1"
+                            >
+                                <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">
+                                    Browse
+                                </h3>
+                            </Components.Link>
+                            <Components.Link
+                                href={Config.urls.createPublication.path}
+                                className="mb-1 block max-w-fit p-1"
+                            >
+                                <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">
+                                    Publish
+                                </h3>
+                            </Components.Link>
+                            <Components.Link href={Config.urls.about.path} className="mb-1 block max-w-fit p-1">
+                                <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">
+                                    About
+                                </h3>
+                            </Components.Link>
+                            <Components.Link href={Config.urls.faq.path} className="mb-1 block max-w-fit p-1">
+                                <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">FAQs</h3>
+                            </Components.Link>
+                            <Components.Link href={Config.urls.getInvolved.path} className="mb-1 block max-w-fit p-1">
+                                <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">
+                                    Get involved
+                                </h3>
+                            </Components.Link>
+                        </div>
+                        {/** Links */}
+                        <div className="col-span-1 mb-4 md:col-span-2 lg:col-span-3">
+                            <Components.Link href={Config.urls.terms.path} className="mb-1 block max-w-fit p-1">
+                                <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">
+                                    Terms
+                                </h3>
+                            </Components.Link>
+                            <Components.Link href={Config.urls.privacy.path} className="mb-1 block max-w-fit p-1">
+                                <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">
+                                    Privacy
+                                </h3>
+                            </Components.Link>
+                            <Components.Link
+                                href={Config.urls.accessibility.path}
+                                className="mb-1 block max-w-fit p-1 "
+                            >
+                                <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">
+                                    Accessibility
+                                </h3>
+                            </Components.Link>
+                        </div>
+
+                        {/** Socket */}
+                        <div className="col-span-1 md:col-span-2 lg:col-span-1">
+                            <h4 className="text-md mb-8 block font-montserrat text-sm font-bold text-white-50 dark:text-teal-200">
+                                In partnership with
+                            </h4>
+                            <Components.Link href="https://www.ukrn.org/" openNew={true} className="flex w-fit">
+                                <Image src="/images/ukrn.png" alt="Jisc Logo" width={60} height={60} />
+                            </Components.Link>
+                        </div>
+                        <div className="col-span-1 md:col-span-2 lg:col-span-1">
+                            <h4 className="text-md mb-8 block font-montserrat text-sm font-bold text-white-50 dark:text-teal-200">
+                                With support from
+                            </h4>
+                            <div className="flex">
+                                <Components.Link href="https://www.ukri.org/" openNew={true} className="flex w-fit">
+                                    <Image src="/images/logo-ukri.png" alt="UKRI" width={200} height={64} />
+                                </Components.Link>
+                            </div>
+                        </div>
+                        <div className="col-span-1 md:col-span-2 lg:col-span-1">
+                            <h4 className="text-md mb-8 block font-montserrat text-sm font-bold text-white-50 dark:text-teal-200">
+                                A collaboration with
+                            </h4>
+                            <div className="flex">
+                                <Components.Link href="https://jisc.ac.uk" openNew={true} className="flex">
+                                    <Image src="/images/jisc-logo.svg" alt="Jisc Logo" width={60} height={60} />
+                                </Components.Link>
+                            </div>
+                        </div>
+                        <div className="col-span-1 md:col-span-2 lg:col-span-1">
+                            <h4 className="text-md mb-8 block font-montserrat text-sm font-bold text-teal-400 dark:text-teal-200">
+                                &nbsp;
+                            </h4>
+                            <div className="flex"></div>
+                        </div>
+                        {/* contact us section */}
+                        <div className="col-span-1 mb-4 mt-14 md:col-span-2 lg:col-span-3">
+                            <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">
+                                Contact us:{' '}
+                                <Components.Link href="mailto:help@jisc.ac.uk">help@jisc.ac.uk</Components.Link>
+                            </h3>
+                        </div>
                     </div>
-                </div>
-                <div className="col-span-1 md:col-span-2 lg:col-span-1">
-                    <h4 className="text-md mb-8 block font-montserrat text-sm font-bold text-white-50 dark:text-teal-200">
-                        A collaboration with
-                    </h4>
-                    <div className="flex">
-                        <Components.Link href="https://jisc.ac.uk" openNew={true} className="flex">
-                            <Image src="/images/jisc-logo.svg" alt="Jisc Logo" width={60} height={60} />
-                        </Components.Link>
-                    </div>
-                </div>
-                <div className="col-span-1 md:col-span-2 lg:col-span-1">
-                    <h4 className="text-md mb-8 block font-montserrat text-sm font-bold text-teal-400 dark:text-teal-200">
-                        &nbsp;
-                    </h4>
-                    <div className="flex"></div>
-                </div>
-                {/* contact us section */}
-                <div className="col-span-1 mb-4 mt-14 md:col-span-2 lg:col-span-3">
-                    <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">
-                        Contact us: <Components.Link href="mailto:help@jisc.ac.uk">help@jisc.ac.uk</Components.Link>
-                    </h3>
-                </div>
-            </div>
-            <Components.ScrollToTop />
-        </footer>
-    </>
-);
+                    <Components.ScrollToTop />
+                </footer>
+            )}
+        </>
+    );
+};
 
 export default Footer;

--- a/ui/src/components/Header/index.tsx
+++ b/ui/src/components/Header/index.tsx
@@ -20,73 +20,54 @@ const Header: React.FC<Props> = (props): React.ReactElement => {
     return (
         <>
             <Components.Banner text="This is a beta release still under active development. Please don't use it for recording your real work... yet!" />
-            {router.asPath !== '/about' ? (
-                <>
-                    {user && !user?.email && router.pathname !== Config.urls.verify.path && (
-                        <div className="bg-yellow-200 text-sm text-grey-800 dark:bg-yellow-500">
-                            <div className="container mx-auto flex items-center gap-2 px-8 py-3">
-                                <OutlineIcons.ExclamationCircleIcon className="h-5 w-5 text-grey-800" />
-                                <Components.Link
-                                    href={`${Config.urls.verify.path}?newUser=true`}
-                                    className="w-fit underline decoration-2 underline-offset-4"
-                                >
-                                    Please confirm your email address to publish content
-                                </Components.Link>
-                            </div>
-                        </div>
-                    )}
-
-                    <header
-                        className={`text-grey-800 transition-colors duration-500  print:hidden  ${
-                            props.fixed && 'lg:fixed lg:top-0 lg:left-0 lg:z-20 lg:w-full'
-                        }`}
-                    >
-                        <div className="container mx-auto px-8">
-                            <div
-                                className={`flex items-center justify-between py-6 transition-colors duration-500 ${
-                                    props.hasBorder ? 'border-b border-grey-200 dark:border-grey-400' : ''
-                                }`}
+            <>
+                {user && !user?.email && router.pathname !== Config.urls.verify.path && (
+                    <div className="bg-yellow-200 text-sm text-grey-800 dark:bg-yellow-500">
+                        <div className="container mx-auto flex items-center gap-2 px-8 py-3">
+                            <OutlineIcons.ExclamationCircleIcon className="h-5 w-5 text-grey-800" />
+                            <Components.Link
+                                href={`${Config.urls.verify.path}?newUser=true`}
+                                className="w-fit underline decoration-2 underline-offset-4"
                             >
-                                <Components.Link
-                                    href={Config.urls.home.path}
-                                    className="flex max-h-[42px] items-center border-transparent"
-                                >
-                                    {isDarkMode ? (
-                                        <Assets.LogoDark height={150} width={150} />
-                                    ) : (
-                                        <Assets.LogoLight height={150} width={150} />
-                                    )}
-                                </Components.Link>
-                                <div className="flex items-center space-x-3 lg:space-x-4">
-                                    <Components.Search />
-                                    <Components.Nav />
-                                    {!user && <Components.ORCIDLogInButton currentPath={router.asPath} />}
-                                    <Components.EnableDarkMode />
-                                </div>
+                                Please confirm your email address to publish content
+                            </Components.Link>
+                        </div>
+                    </div>
+                )}
+
+                <header
+                    className={`text-grey-800 transition-colors duration-500  print:hidden  ${
+                        props.fixed && 'lg:fixed lg:top-0 lg:left-0 lg:z-20 lg:w-full'
+                    }`}
+                >
+                    <div className="container mx-auto px-8">
+                        <div
+                            className={`flex items-center justify-between py-6 transition-colors duration-500 ${
+                                props.hasBorder ? 'border-b border-grey-200 dark:border-grey-400' : ''
+                            }`}
+                        >
+                            <Components.Link
+                                href={Config.urls.home.path}
+                                className="flex max-h-[42px] items-center border-transparent"
+                            >
+                                {isDarkMode ? (
+                                    <Assets.LogoDark height={150} width={150} />
+                                ) : (
+                                    <Assets.LogoLight height={150} width={150} />
+                                )}
+                            </Components.Link>
+                            <div className="flex items-center space-x-3 lg:space-x-4">
+                                {/* Commenting out for temp holding page */}
+                                {/* <Components.Search /> */}
+                                {/* <Components.Nav /> */}
+                                {!user && <Components.ORCIDLogInButton currentPath={router.asPath} />}
+                                <Components.EnableDarkMode />
                             </div>
                         </div>
-                    </header>
-                </>
-            ) : (
-                <div className="container mx-auto px-8">
-                    <div
-                        className={`flex items-center justify-between py-6 transition-colors duration-500 ${
-                            props.hasBorder ? 'border-b border-grey-200 dark:border-grey-400' : ''
-                        }`}
-                    >
-                        <Components.Link
-                            href={Config.urls.home.path}
-                            className="flex max-h-[42px] items-center border-transparent"
-                        >
-                            {isDarkMode ? (
-                                <Assets.LogoDark height={150} width={150} />
-                            ) : (
-                                <Assets.LogoLight height={150} width={150} />
-                            )}
-                        </Components.Link>
                     </div>
-                </div>
-            )}
+                </header>
+            </>
+            )
         </>
     );
 };

--- a/ui/src/components/Header/index.tsx
+++ b/ui/src/components/Header/index.tsx
@@ -6,7 +6,6 @@ import * as Components from '@components';
 import * as Assets from '@assets';
 import * as Config from '@config';
 import * as Stores from '@stores';
-import * as Types from '@types';
 
 type Props = {
     fixed?: boolean;
@@ -21,26 +20,54 @@ const Header: React.FC<Props> = (props): React.ReactElement => {
     return (
         <>
             <Components.Banner text="This is a beta release still under active development. Please don't use it for recording your real work... yet!" />
-            {/* Confirm email banner */}
-            {user && !user?.email && router.pathname !== Config.urls.verify.path && (
-                <div className="bg-yellow-200 text-sm text-grey-800 dark:bg-yellow-500">
-                    <div className="container mx-auto flex items-center gap-2 px-8 py-3">
-                        <OutlineIcons.ExclamationCircleIcon className="h-5 w-5 text-grey-800" />
-                        <Components.Link
-                            href={`${Config.urls.verify.path}?newUser=true`}
-                            className="w-fit underline decoration-2 underline-offset-4"
-                        >
-                            Please confirm your email address to publish content
-                        </Components.Link>
-                    </div>
-                </div>
-            )}
+            {router.asPath !== '/about' ? (
+                <>
+                    {user && !user?.email && router.pathname !== Config.urls.verify.path && (
+                        <div className="bg-yellow-200 text-sm text-grey-800 dark:bg-yellow-500">
+                            <div className="container mx-auto flex items-center gap-2 px-8 py-3">
+                                <OutlineIcons.ExclamationCircleIcon className="h-5 w-5 text-grey-800" />
+                                <Components.Link
+                                    href={`${Config.urls.verify.path}?newUser=true`}
+                                    className="w-fit underline decoration-2 underline-offset-4"
+                                >
+                                    Please confirm your email address to publish content
+                                </Components.Link>
+                            </div>
+                        </div>
+                    )}
 
-            <header
-                className={`text-grey-800 transition-colors duration-500  print:hidden  ${
-                    props.fixed && 'lg:fixed lg:top-0 lg:left-0 lg:z-20 lg:w-full'
-                }`}
-            >
+                    <header
+                        className={`text-grey-800 transition-colors duration-500  print:hidden  ${
+                            props.fixed && 'lg:fixed lg:top-0 lg:left-0 lg:z-20 lg:w-full'
+                        }`}
+                    >
+                        <div className="container mx-auto px-8">
+                            <div
+                                className={`flex items-center justify-between py-6 transition-colors duration-500 ${
+                                    props.hasBorder ? 'border-b border-grey-200 dark:border-grey-400' : ''
+                                }`}
+                            >
+                                <Components.Link
+                                    href={Config.urls.home.path}
+                                    className="flex max-h-[42px] items-center border-transparent"
+                                >
+                                    {isDarkMode ? (
+                                        <Assets.LogoDark height={150} width={150} />
+                                    ) : (
+                                        <Assets.LogoLight height={150} width={150} />
+                                    )}
+                                </Components.Link>
+                                <div className="flex items-center space-x-3 lg:space-x-4">
+                                    <Components.Search />
+                                    <Components.Nav />
+                                    {!user && <Components.ORCIDLogInButton currentPath={router.asPath} />}
+                                    <Components.EnableDarkMode />
+                                </div>
+                            </div>
+                        </div>
+                    </header>
+                </>
+            ) : (
                 <div className="container mx-auto px-8">
                     <div
                         className={`flex items-center justify-between py-6 transition-colors duration-500 ${
@@ -57,15 +84,9 @@ const Header: React.FC<Props> = (props): React.ReactElement => {
                                 <Assets.LogoLight height={150} width={150} />
                             )}
                         </Components.Link>
-                        <div className="flex items-center space-x-3 lg:space-x-4">
-                            <Components.Search />
-                            <Components.Nav />
-                            {!user && <Components.ORCIDLogInButton currentPath={router.asPath} />}
-                            <Components.EnableDarkMode />
-                        </div>
                     </div>
                 </div>
-            </header>
+            )}
         </>
     );
 };

--- a/ui/src/components/Header/index.tsx
+++ b/ui/src/components/Header/index.tsx
@@ -20,53 +20,50 @@ const Header: React.FC<Props> = (props): React.ReactElement => {
     return (
         <>
             <Components.Banner text="This is a beta release still under active development. Please don't use it for recording your real work... yet!" />
-            <>
-                {user && !user?.email && router.pathname !== Config.urls.verify.path && (
-                    <div className="bg-yellow-200 text-sm text-grey-800 dark:bg-yellow-500">
-                        <div className="container mx-auto flex items-center gap-2 px-8 py-3">
-                            <OutlineIcons.ExclamationCircleIcon className="h-5 w-5 text-grey-800" />
-                            <Components.Link
-                                href={`${Config.urls.verify.path}?newUser=true`}
-                                className="w-fit underline decoration-2 underline-offset-4"
-                            >
-                                Please confirm your email address to publish content
-                            </Components.Link>
-                        </div>
-                    </div>
-                )}
-
-                <header
-                    className={`text-grey-800 transition-colors duration-500  print:hidden  ${
-                        props.fixed && 'lg:fixed lg:top-0 lg:left-0 lg:z-20 lg:w-full'
-                    }`}
-                >
-                    <div className="container mx-auto px-8">
-                        <div
-                            className={`flex items-center justify-between py-6 transition-colors duration-500 ${
-                                props.hasBorder ? 'border-b border-grey-200 dark:border-grey-400' : ''
-                            }`}
+            {user && !user?.email && router.pathname !== Config.urls.verify.path && (
+                <div className="bg-yellow-200 text-sm text-grey-800 dark:bg-yellow-500">
+                    <div className="container mx-auto flex items-center gap-2 px-8 py-3">
+                        <OutlineIcons.ExclamationCircleIcon className="h-5 w-5 text-grey-800" />
+                        <Components.Link
+                            href={`${Config.urls.verify.path}?newUser=true`}
+                            className="w-fit underline decoration-2 underline-offset-4"
                         >
-                            <Components.Link
-                                href={Config.urls.home.path}
-                                className="flex max-h-[42px] items-center border-transparent"
-                            >
-                                {isDarkMode ? (
-                                    <Assets.LogoDark height={150} width={150} />
-                                ) : (
-                                    <Assets.LogoLight height={150} width={150} />
-                                )}
-                            </Components.Link>
-                            <div className="flex items-center space-x-3 lg:space-x-4">
-                                {/* Commenting out for temp holding page */}
-                                {/* <Components.Search /> */}
-                                {/* <Components.Nav /> */}
-                                {!user && <Components.ORCIDLogInButton currentPath={router.asPath} />}
-                                <Components.EnableDarkMode />
-                            </div>
+                            Please confirm your email address to publish content
+                        </Components.Link>
+                    </div>
+                </div>
+            )}
+            <header
+                className={`text-grey-800 transition-colors duration-500  print:hidden  ${
+                    props.fixed && 'lg:fixed lg:top-0 lg:left-0 lg:z-20 lg:w-full'
+                }`}
+            >
+                <div className="container mx-auto px-8">
+                    <div
+                        className={`flex items-center justify-between py-6 transition-colors duration-500 ${
+                            props.hasBorder ? 'border-b border-grey-200 dark:border-grey-400' : ''
+                        }`}
+                    >
+                        <Components.Link
+                            href={Config.urls.home.path}
+                            className="flex max-h-[42px] items-center border-transparent"
+                        >
+                            {isDarkMode ? (
+                                <Assets.LogoDark height={150} width={150} />
+                            ) : (
+                                <Assets.LogoLight height={150} width={150} />
+                            )}
+                        </Components.Link>
+                        <div className="flex items-center space-x-3 lg:space-x-4">
+                            {/* Commenting out for temp holding page */}
+                            {/* <Components.Search /> */}
+                            {/* <Components.Nav /> */}
+                            {!user && <Components.ORCIDLogInButton currentPath={router.asPath} />}
+                            <Components.EnableDarkMode />
                         </div>
                     </div>
-                </header>
-            </>
+                </div>
+            </header>
             )
         </>
     );

--- a/ui/src/components/Header/index.tsx
+++ b/ui/src/components/Header/index.tsx
@@ -58,13 +58,12 @@ const Header: React.FC<Props> = (props): React.ReactElement => {
                             {/* Commenting out for temp holding page */}
                             {/* <Components.Search /> */}
                             {/* <Components.Nav /> */}
-                            {!user && <Components.ORCIDLogInButton currentPath={router.asPath} />}
+                            {/* {!user && <Components.ORCIDLogInButton currentPath={router.asPath} />} */}
                             <Components.EnableDarkMode />
                         </div>
                     </div>
                 </div>
             </header>
-            )
         </>
     );
 };

--- a/ui/src/pages/_app.tsx
+++ b/ui/src/pages/_app.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Head from 'next/head';
 import * as SWR from 'swr';
 import * as Framer from 'framer-motion';
+import * as NextRouter from 'next/router';
 import NextNprogress from 'nextjs-progressbar';
 
 import * as Components from '@components';
@@ -11,8 +12,21 @@ import * as api from '@api';
 
 import '../styles/globals.css';
 
+// TODO: Remove after ORCID login is fixed
+const tempAllowedPaths = [
+    '/about',
+    '/faq',
+    '/privacy',
+    '/terms',
+    '/accessibility',
+    '/author-guide',
+    '/octopus-aims',
+    '/get-involved'
+];
+
 const App = ({ Component, pageProps }: Types.AppProps) => {
     const isMounted = React.useRef(false);
+    const router = NextRouter.useRouter();
     const [loading, setLoading] = React.useState(true);
     const darkMode = Stores.usePreferencesStore((state) => state.darkMode);
     const showCmdPalette = Stores.useGlobalsStore((state) => state.showCmdPalette);
@@ -38,13 +52,17 @@ const App = ({ Component, pageProps }: Types.AppProps) => {
     }, [showCmdPalette, toggleCmdPalette]);
 
     React.useEffect(() => {
+        // TODO: Remove after ORCID login is fixed
+        if (!tempAllowedPaths.includes(router.asPath)) {
+            router.push('/about');
+        }
         isMounted.current = true;
         setUpCmdPalListeners();
         setLoading(false);
         return () => {
             isMounted.current = false;
         };
-    }, []);
+    }, [router.asPath]);
 
     return (
         <>

--- a/ui/src/pages/about.tsx
+++ b/ui/src/pages/about.tsx
@@ -58,7 +58,8 @@ const About: NextPage = (): React.ReactElement => (
                 <>
                     <div className="mx-auto block lg:w-9/12 xl:w-10/12 2xl:w-7/12">
                         <h1 className="mb-5 mt-5 block text-center font-montserrat text-3xl font-black !leading-tight tracking-tight text-grey-700 transition-colors duration-500 dark:text-white-50 lg:text-5xl">
-                            Learn about Octopus.
+                            Free, fast and fair: The global primary research record where researchers record their work
+                            in full detail
                         </h1>
                         <h2 className="text-l mx-auto mb-5 block text-center font-montserrat font-medium leading-relaxed text-grey-700 transition-colors duration-500 dark:text-grey-100 lg:text-xl">
                             Octopus is not just another publishing platform, it is designed to be the primary research
@@ -189,7 +190,7 @@ const About: NextPage = (): React.ReactElement => (
                 whileInView={{ opacity: 1 }}
                 viewport={{ once: true }}
                 transition={{ type: 'spring', delay: 0.5 }}
-                className="mt-10 transition-all duration-500 md:mt-0"
+                className="my-10 transition-all duration-500 md:mt-0"
             >
                 <div className="mx-auto mb-2 flex flex-col items-center gap-1 font-montserrat text-base font-semibold uppercase tracking-wide text-grey-900 transition-colors duration-500 dark:text-white-50 lg:text-xl">
                     <OutlineIcons.UserCircleIcon className="mb-2 h-6 w-6 rounded-full bg-teal-500 p-1 text-white-50 shadow transition-colors duration-500" />
@@ -200,7 +201,7 @@ const About: NextPage = (): React.ReactElement => (
                     open and post-publication.
                 </div>
             </Framer.motion.div>
-            <PageSection>
+            {/* <PageSection>
                 <>
                     <Components.PageSubTitle text="Get started with Octopus" className="text-center" />
                     <div className="grid grid-cols-1 gap-8 lg:grid-cols-3 lg:gap-12">
@@ -227,7 +228,7 @@ const About: NextPage = (): React.ReactElement => (
                         />
                     </div>
                 </>
-            </PageSection>
+            </PageSection> */}
         </Layouts.Standard>
     </>
 );

--- a/ui/src/pages/about.tsx
+++ b/ui/src/pages/about.tsx
@@ -208,6 +208,7 @@ const About: NextPage = (): React.ReactElement => (
                     open and post-publication.
                 </div>
             </Framer.motion.div>
+            {/* TODO: Re add these links once ORCID login has been fixed*/}
             {/* <PageSection>
                 <>
                     <Components.PageSubTitle text="Get started with Octopus" className="text-center" />

--- a/ui/src/pages/about.tsx
+++ b/ui/src/pages/about.tsx
@@ -37,7 +37,7 @@ const PageSection: React.FC<PageSectionProps> = (props): React.ReactElement => {
             whileInView={{ opacity: 1 }}
             viewport={{ once: true }}
             transition={{ type: 'spring' }}
-            className="container mx-auto my-16 mt-10 px-8 transition-all duration-500 lg:mx-auto lg:pt-10 2xl:my-36"
+            className="container mx-auto my-16 px-8 transition-all duration-500 lg:mx-auto lg:pt-10 2xl:my-36"
         >
             {props.children}
         </Framer.motion.div>
@@ -54,10 +54,16 @@ const About: NextPage = (): React.ReactElement => (
         </Head>
 
         <Layouts.Standard fixedHeader={false}>
-            <PageSection>
+            <Framer.motion.div
+                initial={{ opacity: 0 }}
+                whileInView={{ opacity: 1 }}
+                viewport={{ once: true }}
+                transition={{ type: 'spring' }}
+                className="container mx-auto my-10 px-8 transition-all duration-500 lg:mx-auto lg:pt-10"
+            >
                 <>
                     <div className="mx-auto block lg:w-9/12 xl:w-10/12 2xl:w-7/12">
-                        <h1 className="mb-5 mt-5 block text-center font-montserrat text-3xl font-black !leading-tight tracking-tight text-grey-700 transition-colors duration-500 dark:text-white-50 lg:text-5xl">
+                        <h1 className="mb-5 block text-center font-montserrat text-3xl font-black !leading-tight tracking-tight text-grey-700 transition-colors duration-500 dark:text-white-50 lg:text-5xl">
                             Free, fast and fair: The global primary research record where researchers record their work
                             in full detail
                         </h1>
@@ -98,7 +104,8 @@ const About: NextPage = (): React.ReactElement => (
                         </Components.Link>
                     </div>
                 </>
-            </PageSection>
+            </Framer.motion.div>
+
             <PageSection>
                 <div className="grid grid-cols-1 gap-2 lg:my-10 lg:grid-cols-2 lg:gap-4 2xl:grid-cols-4">
                     <CardItem

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -56,7 +56,7 @@ const Home: Types.NextPage<Props> = (props): React.ReactElement => {
                 <section className="container mx-auto px-8 py-8 lg:py-24">
                     <div className="mx-auto block lg:w-9/12 xl:w-10/12 2xl:w-7/12">
                         <h1 className="mb-8 block text-center font-montserrat text-2xl font-black !leading-tight tracking-tight text-grey-700 transition-colors duration-500 dark:text-white-50 lg:text-5xl ">
-                            Free, fast and fair: the global primary research record where researchers record their work
+                            Free, fast and fair: The global primary research record where researchers record their work
                             in full detail
                         </h1>
                         <p className="mx-auto mb-10 block text-center font-montserrat text-base font-medium leading-relaxed text-grey-700 transition-colors duration-500 dark:text-grey-100 lg:w-8/12 lg:text-lg">

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -17,6 +17,7 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
     const errors: Errors = {
         latest: null
     };
+    console.log(context.resolvedUrl);
 
     let latest: unknown = [];
     try {
@@ -31,10 +32,6 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
         props: {
             latest,
             errors
-        },
-        redirect: {
-            destination: '/about',
-            permanent: false
         }
     };
 };
@@ -46,7 +43,6 @@ type Props = {
 
 const Home: Types.NextPage<Props> = (props): React.ReactElement => {
     const toggleCmdPalette = Stores.useGlobalsStore((state: Types.GlobalsStoreType) => state.toggleCmdPalette);
-    console.log({ branch: process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF });
     return (
         <>
             <Head>

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -32,6 +32,11 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
         props: {
             latest,
             errors
+        },
+        // TODO: Temp redirect for now until ORCID login gets fixed
+        redirect: {
+            destination: '/about',
+            permanent: false
         }
     };
 };

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -4,7 +4,6 @@ import * as OutlineIcons from '@heroicons/react/outline';
 import * as Components from '@components';
 import * as Interfaces from '@interfaces';
 import * as Layouts from '@layouts';
-import * as Helpers from '@helpers';
 import * as Config from '@config';
 import * as Stores from '@stores';
 import * as Types from '@types';
@@ -32,6 +31,10 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
         props: {
             latest,
             errors
+        },
+        redirect: {
+            destination: '/about',
+            permanent: false
         }
     };
 };

--- a/ui/src/pages/login.tsx
+++ b/ui/src/pages/login.tsx
@@ -18,7 +18,7 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
 
     if (context.query.code) code = context.query.code;
     if (context.query.state) redirect = context.query.state;
-    
+
     if (!code) {
         return {
             notFound: true


### PR DESCRIPTION
The purpose of this PR is to redirect to the about page until the ORCID login (and other things) gets fixed. This PR needs to get revisited once these things get sorted.

Only the following pages can be navigated to:

```
'/about',
'/faq',
'/privacy',
'/terms',
'/accessibility',
'/author-guide',
'/octopus-aims',
'/get-involved'
```

---

### Things to revert at a later date:

#### Footer
[Enable links](https://github.com/JiscSD/octopus/blob/main/ui/src/components/Footer/index.tsx)

#### Header
[Enable links](https://github.com/JiscSD/octopus/blob/main/ui/src/components/Header/index.tsx)

#### App
[Remove redirects](https://github.com/JiscSD/octopus/blob/main/ui/src/pages/_app.tsx)

####  Index
[Remove redirects](https://github.com/JiscSD/octopus/blob/main/ui/src/pages/index.tsx)

####  About
[Enable page section](https://github.com/JiscSD/octopus/blob/main/ui/src/pages/about.tsx)

---

### Acceptance Criteria:

[OCT-225](https://jiscdev.atlassian.net/browse/OCT-225)

Modify: https://www.octopus.ac/about  

Remove header and footer from about page - removing links to functionality - keep logo if possible

Replace bolded ‘learn……..’ text with bolded text from current home page: ‘Free, fast and fair: the global primary research record where researchers record their work in full detail’

Remove ‘get started with Octopus’ section at bottom as contains links to publish and browse

Point http://octopus.ac/  to modified about page

---

### Screenshots:

![image](https://user-images.githubusercontent.com/78794569/176871491-aad53dc8-3371-472c-83c3-6c6acd492f75.png)

![image](https://user-images.githubusercontent.com/78794569/176871661-03238a39-cafe-4e7c-b737-99d168f14b96.png)
