### PR TITLE
OCT-236 Token issue following email verification

### DIFF
--- a/ui/src/pages/verify.tsx
+++ b/ui/src/pages/verify.tsx
@@ -100,7 +100,7 @@ const Verify: Types.NextPage<Props> = (props): React.ReactElement => {
             // If success, decode the JWT, set the updated user, and redirect to state
             if (getToken.status == 200) {
                 const decodedJWT = Helpers.setAndReturnJWT(getToken.data.token) as Types.UserType;
-                if (decodedJWT && user) setUser({ ...decodedJWT, token: user?.token });
+                if (decodedJWT && user) setUser({ ...decodedJWT, token: getToken.data.token });
                 setSuccess(true);
                 setTimeout(() => Router.push(decodeURIComponent(props.state)), 1000);
             } else {


### PR DESCRIPTION
This PR addresses issue #169 / [OCT-236](https://jiscdev.atlassian.net/jira/software/projects/OCT/boards/836?selectedIssue=OCT-236).

### Steps to reproduce

This bug surrounds emails being sent to newly verified users. To reproduce:

1. Log in as new user
2. Verify email
3. Raise red flag on a publication

The flag will be raised, and the author of the publication will receive a _“Your publication has been red flagged”_ email, but the newly verified user does not receive the _“Red flag created”_ email.

On logging out, and back in, creating a red flag, emails work as expected.

### Fix applied

This turned out to be an incorrect use of `user?.token` within setUser. This resulted in a `null` value being set instead of the new, verified email address which was available in `getToken.data.token`

---

### Acceptance Criteria:

Should resolve issue as raised.

---

### Tests:

Manual testing carried out:

https://user-images.githubusercontent.com/86601264/177351361-45288579-fb7f-4f30-9ce9-63b4db7a308f.mov

---
