### PR TITLE
Allow users to add an 'Affiliated Organisations' and/or 'Funders' statement if no organisation has been added - UI

### DIFF
--- a/ui/src/components/RORForm/index.tsx
+++ b/ui/src/components/RORForm/index.tsx
@@ -384,31 +384,28 @@ const RORForm: React.FC<FormProps> = (props): React.ReactElement => {
                                 className="w-1/2"
                             />
                         )}
-                        {specifiedArray.length ? (
-                            <div className="mb-2 flex flex-col">
-                                <label
-                                    htmlFor="ror"
-                                    className="text-gray-700 mt-6 block text-sm font-medium dark:text-white-100"
-                                >
-                                    If needed, provide further information on this publication’s{' '}
-                                    {props.type == 'funders' ? 'funding arrangements' : 'affiliations'}.
-                                </label>
-                                <textarea
-                                    name="free-text"
-                                    className={`mb-2 mt-3 w-5/6 rounded border border-grey-100 bg-white-50 bg-white-50 p-2 text-grey-700 shadow focus:ring-2 focus:ring-yellow-400
+
+                        <div className="mb-2 flex flex-col">
+                            <label
+                                htmlFor="ror"
+                                className="text-gray-700 mt-6 block text-sm font-medium dark:text-white-100"
+                            >
+                                If needed, provide further information on this publication’s{' '}
+                                {props.type == 'funders' ? 'funding arrangements' : 'affiliations'}.
+                            </label>
+                            <textarea
+                                name="free-text"
+                                className={`mb-2 mt-3 w-5/6 rounded border border-grey-100 bg-white-50 bg-white-50 p-2 text-grey-700 shadow focus:ring-2 focus:ring-yellow-400
                             `}
-                                    placeholder="Enter any details"
-                                    value={
-                                        props.type == 'funders' ? funderStatement ?? '' : affiliationsStatement ?? ''
-                                    }
-                                    onChange={(e) =>
-                                        props.type == 'funders'
-                                            ? updateFunderStatement(e.target.value)
-                                            : updateAffiliationsStatement(e.target.value)
-                                    }
-                                />
-                            </div>
-                        ) : null}
+                                placeholder="Enter any details"
+                                value={props.type == 'funders' ? funderStatement ?? '' : affiliationsStatement ?? ''}
+                                onChange={(e) =>
+                                    props.type == 'funders'
+                                        ? updateFunderStatement(e.target.value)
+                                        : updateAffiliationsStatement(e.target.value)
+                                }
+                            />
+                        </div>
                     </div>
                 </div>
             </Framer.motion.div>

--- a/ui/src/pages/create.tsx
+++ b/ui/src/pages/create.tsx
@@ -74,7 +74,6 @@ const Create: Types.NextPage<PageProps> = (props): React.ReactElement => {
                     props.token
                 );
             }
-            console.log(response);
 
             router.push({
                 pathname: `${Config.urls.viewPublication.path}/${response.data.id}/edit`

--- a/ui/src/pages/create.tsx
+++ b/ui/src/pages/create.tsx
@@ -53,6 +53,7 @@ const Create: Types.NextPage<PageProps> = (props): React.ReactElement => {
 
     const createPublication = async () => {
         setError(null);
+
         try {
             const response = await api.post<{ id: string }>(
                 Config.endpoints.publications,
@@ -73,6 +74,7 @@ const Create: Types.NextPage<PageProps> = (props): React.ReactElement => {
                     props.token
                 );
             }
+            console.log(response);
 
             router.push({
                 pathname: `${Config.urls.viewPublication.path}/${response.data.id}/edit`

--- a/ui/src/pages/publications/[id]/index.tsx
+++ b/ui/src/pages/publications/[id]/index.tsx
@@ -543,35 +543,41 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                     )}
                     {/* Publication funders section */}
                     <Components.PublicationContentSection id="funders" title="Funders" hasBreak>
-                        {!publicationData.funders?.length ? (
+                        {!publicationData.funders?.length && !publicationData.fundersStatement ? (
                             <p className="block leading-relaxed text-grey-800 transition-colors duration-500 dark:text-grey-100">
                                 No sources of funding have been specified for this{' '}
                                 {Helpers.formatPublicationType(publicationData.type)}.
                             </p>
                         ) : (
                             <>
-                                <p className="block leading-relaxed text-grey-800 transition-colors duration-500 dark:text-grey-100">
-                                    This {Helpers.formatPublicationType(publicationData.type)} has the following sources
-                                    of funding:
-                                </p>
-                                <ul className="block leading-relaxed text-grey-800 transition-colors duration-500 dark:text-grey-100">
-                                    {publicationData.funders?.map((funder) => {
-                                        return (
-                                            <li key={funder.id} className="ml-7 mt-1 list-disc">
-                                                <a
-                                                    href={funder.link}
-                                                    className="text-teal-600 transition-colors duration-500 hover:underline dark:text-teal-400"
-                                                >
-                                                    {funder.name}
-                                                </a>{' '}
-                                                - {funder.city}, {funder.country}
-                                            </li>
-                                        );
-                                    })}
-                                </ul>
-                                <p className="block pt-2 leading-relaxed text-grey-800 transition-colors duration-500 dark:text-grey-100">
-                                    {publicationData.fundersStatement}
-                                </p>
+                                {publicationData.funders?.length ? (
+                                    <>
+                                        <p className="block leading-relaxed text-grey-800 transition-colors duration-500 dark:text-grey-100">
+                                            This {Helpers.formatPublicationType(publicationData.type)} has the following
+                                            sources of funding:
+                                        </p>
+                                        <ul className="block leading-relaxed text-grey-800 transition-colors duration-500 dark:text-grey-100">
+                                            {publicationData.funders?.map((funder) => {
+                                                return (
+                                                    <li key={funder.id} className="ml-7 mt-1 list-disc">
+                                                        <a
+                                                            href={funder.link}
+                                                            className="text-teal-600 transition-colors duration-500 hover:underline dark:text-teal-400"
+                                                        >
+                                                            {funder.name}
+                                                        </a>{' '}
+                                                        - {funder.city}, {funder.country}
+                                                    </li>
+                                                );
+                                            })}
+                                        </ul>
+                                    </>
+                                ) : null}
+                                {publicationData.fundersStatement ? (
+                                    <p className="block pt-2 leading-relaxed text-grey-800 transition-colors duration-500 dark:text-grey-100">
+                                        {publicationData.fundersStatement}
+                                    </p>
+                                ) : null}
                             </>
                         )}
                     </Components.PublicationContentSection>


### PR DESCRIPTION
The purpose of this PR was to remove the 'Affiliated Organisations' and 'Funders' limit which only shows free text field when organisation has been added (within the publication creation process). Initially you could only add a statement if you had added at least one organisation, but now you can at a statement regardless. This PR contains amendments to the ROR form and amendments to the publication index page with the UI.

---

### Screenshots:
![Screenshot 2022-07-06 at 15 01 48](https://user-images.githubusercontent.com/100135505/177568443-8697b210-8187-4d22-84d3-9082393179eb.png)
![Screenshot 2022-07-06 at 15 01 36](https://user-images.githubusercontent.com/100135505/177568455-7bf3b41f-e937-4fcd-9e10-14d1554fe9d9.png)

