### PR TITLE
Overlapping issue with the dropdown profile menu and the linked publication visualisation section - UI

### DIFF
--- a/ui/src/components/Nav/Desktop/index.tsx
+++ b/ui/src/components/Nav/Desktop/index.tsx
@@ -23,7 +23,7 @@ const Desktop: React.FC<Props> = (props): React.ReactElement => (
                     )}
 
                     {item.subItems?.length && (
-                        <HeadlessUI.Menu as="div" className="relative z-30 inline-block text-left">
+                        <HeadlessUI.Menu as="div" className="relative z-50 inline-block text-left">
                             <HeadlessUI.Menu.Button className="rounded border-transparent p-2 font-medium text-grey-800 outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400 dark:text-white-50">
                                 <span className="flex items-center">
                                     {item.label}


### PR DESCRIPTION
The purpose of this PR was to resolve a [minor bug fix](https://github.com/JiscSD/octopus/issues/183) within the ui. The headers which contain the publication types within the 'linked publication visualisation' overlap the dropdown profile menu when the user is accessing the page from a desktop browser. 

This PR contains changes to the z index of the dropdown menu within the nav bar.

### Screenshots:
![Screenshot 2022-07-06 at 15 27 23](https://user-images.githubusercontent.com/100135505/177574051-bd9497a6-12bf-4286-8868-3e19c50228e1.png)