### PR TITLE
Amend the design of the search bar within the 'Search' page to make it more usable for small screens

### DIFF
--- a/ui/src/pages/search.tsx
+++ b/ui/src/pages/search.tsx
@@ -277,7 +277,7 @@ const Search: Types.NextPage<Props> = (props): React.ReactElement => {
                         <form
                             name="query-form"
                             id="query-form"
-                            className="col-span-12 lg:col-span-3 xl:col-span-4"
+                            className="col-span-12 lg:col-span-7"
                             onSubmit={handlerSearchFormSubmit}
                         >
                             <label htmlFor="search-query" className="relative block w-full">


### PR DESCRIPTION
The purpose of this PR was to amend the length of the search bar to make it more adaptable for smaller screens - as per [this Github issue ](https://github.com/JiscSD/octopus/issues/179). 

I have amended the search bar so that it takes up the full width left of the row for lg + sized screens. Looking at the seed data, it seems that the titles of publications can get quite lengthy so I can assume that a user's search query could also get quite lengthy. So it makes sense to allow the search bar to take up the maximum width to allow users to type as much as they can without being cut off, whilst also not compromising on the width of the `searching` and `showing` fields. In my opinion this also looks much better from a design perspective.

### Acceptance Criteria:
- Make the break point more generous 
- Ensure the magnifying icon within the field doesn't cover the placeholder text.

### Screenshots:
![Screenshot 2022-07-06 at 15 43 25](https://user-images.githubusercontent.com/100135505/177579124-04dc2c5c-9a7e-405d-818c-0cc6a25d1763.png)

