### PR TITLE
OCT-247 - Ethical Statement blocking publication

### DIFF
--- a/api/prisma/migrations/20220706145818_update_ethical_statement/migration.sql
+++ b/api/prisma/migrations/20220706145818_update_ethical_statement/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Publication" ALTER COLUMN "ethicalStatement" SET DATA TYPE TEXT;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -59,7 +59,7 @@ model Publication {
     licence                            LicenceType            @default(CC_BY)
     conflictOfInterestStatus           Boolean?               @default(false)
     conflictOfInterestText             String?
-    ethicalStatement                   Boolean?
+    ethicalStatement                   String?
     ethicalStatementFreeText           String?
     dataPermissionsStatement           String?
     dataPermissionsStatementProvidedBy String?

--- a/api/prisma/seeds/publications.ts
+++ b/api/prisma/seeds/publications.ts
@@ -630,6 +630,7 @@ const publicationSeeds = [
         licence: 'CC_BY',
         content: 'Publication HYPOTHESIS-LIVE',
         currentStatus: 'LIVE',
+        doi: '10.82259/cty5-2g23',
         user: {
             connect: {
                 id: 'test-user-1'

--- a/api/src/components/publication/schema/create.ts
+++ b/api/src/components/publication/schema/create.ts
@@ -47,7 +47,7 @@ const createPublicationSchema: I.Schema = {
             enum: H.OctopusInformation.languages
         },
         ethicalStatement: {
-            type: 'boolean'
+            type: 'string'
         },
         ethicalStatementFreeText: {
             type: 'string'

--- a/api/src/components/publication/schema/update.ts
+++ b/api/src/components/publication/schema/update.ts
@@ -37,7 +37,7 @@ const updatePublicationSchema: I.Schema = {
             enum: H.OctopusInformation.languages
         },
         ethicalStatement: {
-            type: 'boolean'
+            type: 'string'
         },
         ethicalStatementFreeText: {
             type: 'string'

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -76,7 +76,7 @@ export interface CreatePublicationRequestBody {
     content?: string;
     language?: Languages;
     fundersStatement: string;
-    ethicalStatement?: boolean;
+    ethicalStatement?: string;
     ethicalStatementFreeText?: string;
     dataPermissionsStatement?: string;
     dataPermissionsStatementProvidedBy?: string;
@@ -118,7 +118,7 @@ export interface UpdatePublicationRequestBody {
     keywords?: string[];
     id?: string;
     language?: Languages;
-    ethicalStatement?: boolean;
+    ethicalStatement?: string;
     ethicalStatementFreeText?: string;
     dataPermissionsStatement?: string;
     dataPermissionsStatementProvidedBy?: string;

--- a/ui/src/components/Publication/Creation/DataStatements.tsx
+++ b/ui/src/components/Publication/Creation/DataStatements.tsx
@@ -6,19 +6,19 @@ import * as Components from '@components';
 import * as Stores from '@stores';
 
 const ethicalStatementOptions: string[] = [
-    'The results and data in this publication involved human or animal subjects.',
-    'The results and data in this publication does not involve human or animal subjects.'
+    'The results in this publication involved human or animal subjects.',
+    'The results in this publication do <strong>not</strong> involve human or animal subjects.'
 ];
 const dataPermissionsOptions: string[] = [
-    'The results and data in this publication involved access to owned or copyrighted materials',
-    'The results and data in this publication does <strong>not</strong> involve access to materials owned or copyrighted materials (except those in the private ownership of the authors)'
+    'The results in this publication involved access to owned or copyrighted materials.',
+    'The results in this publication do <strong>not</strong> involve access to materials owned or copyrighted materials (except those in the private ownership of the authors).'
 ];
 const dataAccessOptions: string[] = [
-    'This publication includes all the relevant results or data collected by the authors',
-    'This publication contains a sample of relevant results or data, with the full data publicly stored on another platform',
-    'This publication contains partial data because full data contains transcripts of interviews, which were impossible to anonymise or where the participants did not consent to sharing',
-    'This publication contains partial data because the raw data contains confidential information, protected by a non-disclosure agreement or copyright (e.g. of digital images, maps, texts, audio-visual material)',
-    'This publication contains representative digital data of physical samples or records (e.g. of museum objects, geological samples, tissue samples, images). Relevant accession/reference numbers and associated information of where the originals are stored are provided'
+    'This publication includes all the relevant results or data collected by the authors.',
+    'This publication contains a sample of relevant results or data, with the full data publicly stored on another platform.',
+    'This publication contains partial data because full data contains transcripts of interviews, which were impossible to anonymise or where the participants did not consent to sharing.',
+    'This publication contains partial data because the raw data contains confidential information, protected by a non-disclosure agreement or copyright (e.g. of digital images, maps, texts, audio-visual material).',
+    'This publication contains representative digital data of physical samples or records (e.g. of museum objects, geological samples, tissue samples, images). Relevant accession/reference numbers and associated information of where the originals are stored are provided.'
 ];
 
 const DataStatements: React.FC = (): React.ReactElement => {
@@ -157,8 +157,8 @@ const DataStatements: React.FC = (): React.ReactElement => {
             <div>
                 <Components.PublicationCreationStepTitle text="Data access statement" />
                 <span className="block text-sm leading-snug text-grey-700 transition-colors duration-500 dark:text-white-100">
-                    If relevant, please provide a data access statement which describes where the results and data
-                    associated with your publication can be found, and how they can be accessed.{' '}
+                    If relevant, please provide a data access statement which describes where the results associated
+                    with your publication can be found, and how they can be accessed.{' '}
                 </span>
                 <span className="mb-2 block text-sm leading-snug text-grey-700 transition-colors duration-500 dark:text-white-100">
                     Select from the pre-defined statements below, or create your own. You can provide a link to any

--- a/ui/src/components/Publication/Creation/DataStatements.tsx
+++ b/ui/src/components/Publication/Creation/DataStatements.tsx
@@ -66,8 +66,8 @@ const DataStatements: React.FC = (): React.ReactElement => {
                                 checked={option === ethicalStatement}
                                 onChange={() => {
                                     updateEthicalStatement(option);
-                                    if (option === ethicalStatementOptions[0]) {
-                                        updateEthicalStatementFreeText('');
+                                    if (option === ethicalStatementOptions[1]) {
+                                        updateEthicalStatementFreeText(null);
                                     }
                                 }}
                                 className="hover:cursor-pointer"

--- a/ui/src/components/Publication/Creation/DataStatements.tsx
+++ b/ui/src/components/Publication/Creation/DataStatements.tsx
@@ -29,7 +29,6 @@ const DataStatements: React.FC = (): React.ReactElement => {
     const updateEthicalStatementFreeText = Stores.usePublicationCreationStore(
         (state) => state.updateEthicalStatementFreeText
     );
-    console.log(ethicalStatementFreeText);
 
     // Data permissions statement
     const dataPermissionsStatement = Stores.usePublicationCreationStore((state) => state.dataPermissionsStatement);

--- a/ui/src/components/Publication/Creation/DataStatements.tsx
+++ b/ui/src/components/Publication/Creation/DataStatements.tsx
@@ -5,6 +5,14 @@ import * as OutlineIcons from '@heroicons/react/outline';
 import * as Components from '@components';
 import * as Stores from '@stores';
 
+const ethicalStatementOptions: string[] = [
+    'The results and data in this publication involved human or animal subjects.',
+    'The results and data in this publication does not involve human or animal subjects.'
+];
+const dataPermissionsOptions: string[] = [
+    'The results and data in this publication involved access to owned or copyrighted materials',
+    'The results and data in this publication does <strong>not</strong> involve access to materials owned or copyrighted materials (except those in the private ownership of the authors)'
+];
 const dataAccessOptions: string[] = [
     'This publication includes all the relevant results or data collected by the authors',
     'This publication contains a sample of relevant results or data, with the full data publicly stored on another platform',
@@ -12,24 +20,20 @@ const dataAccessOptions: string[] = [
     'This publication contains partial data because the raw data contains confidential information, protected by a non-disclosure agreement or copyright (e.g. of digital images, maps, texts, audio-visual material)',
     'This publication contains representative digital data of physical samples or records (e.g. of museum objects, geological samples, tissue samples, images). Relevant accession/reference numbers and associated information of where the originals are stored are provided'
 ];
-const dataPermissionsOptions: string[] = [
-    'The results and data in this publication involved access to owned or copyrighted materials',
-    'The results and data in this publication does <strong>not</strong> involve access to materials owned or copyrighted materials (except those in the private ownership of the authors)'
-];
 
 const DataStatements: React.FC = (): React.ReactElement => {
-    // Ethic statement
+    // Ethical statement
     const ethicalStatement = Stores.usePublicationCreationStore((state) => state.ethicalStatement);
     const updateEthicalStatement = Stores.usePublicationCreationStore((state) => state.updateEthicalStatement);
     const ethicalStatementFreeText = Stores.usePublicationCreationStore((state) => state.ethicalStatementFreeText);
     const updateEthicalStatementFreeText = Stores.usePublicationCreationStore(
         (state) => state.updateEthicalStatementFreeText
     );
-
-    // Data access statement
-    const dataAccessStatement = Stores.usePublicationCreationStore((state) => state.dataAccessStatement);
-    const updateDataAccessStatement = Stores.usePublicationCreationStore((state) => state.updateDataAccessStatement);
-    const [dataAccessStatementOther, setDataAccessStatementOther] = React.useState('');
+    const ethicalStatementProvidedBy = Stores.usePublicationCreationStore((state) => state.ethicalStatementProvidedBy);
+    const updateEthicalStatementProvidedBy = Stores.usePublicationCreationStore(
+        (state) => state.updateEthicalStatementProvidedBy
+    );
+    console.log(ethicalStatementProvidedBy);
 
     // Data permissions statement
     const dataPermissionsStatement = Stores.usePublicationCreationStore((state) => state.dataPermissionsStatement);
@@ -43,59 +47,79 @@ const DataStatements: React.FC = (): React.ReactElement => {
         (state) => state.updateDataPermissionsStatementProvidedBy
     );
 
+    // Data access statement
+    const dataAccessStatement = Stores.usePublicationCreationStore((state) => state.dataAccessStatement);
+    const updateDataAccessStatement = Stores.usePublicationCreationStore((state) => state.updateDataAccessStatement);
+    const [dataAccessStatementOther, setDataAccessStatementOther] = React.useState('');
+
     return (
         <div className="space-y-12 2xl:space-y-16">
             {/* Ethical statement */}
             <div>
                 <Components.PublicationCreationStepTitle text="Ethical statement" required />
                 <fieldset className="my-8 space-y-3">
-                    <label htmlFor="true" className="flex items-center space-x-2 hover:cursor-pointer">
-                        <input
-                            type="radio"
-                            name="true"
-                            id="true"
-                            checked={ethicalStatement === true}
-                            onChange={() => updateEthicalStatement(true)}
-                            className="hover:cursor-pointer"
-                            aria-label="The results and data in this publication involved human or animal subjects."
-                        />
-                        <span className="ml-2 text-sm text-grey-800 transition-colors duration-500 dark:text-white-50">
-                            The results and data in this publication involved human or animal subjects.{' '}
-                        </span>
-                    </label>
-                    <label htmlFor="false" className="flex items-center space-x-2 hover:cursor-pointer">
-                        <input
-                            type="radio"
-                            name="false"
-                            id="false"
-                            checked={ethicalStatement === false}
-                            onChange={() => updateEthicalStatement(false)}
-                            className="hover:cursor-pointer"
-                            aria-label="The results and data in this publication does not involve human or animal subjects."
-                        />
-                        <span className="ml-2 text-sm text-grey-800 transition-colors duration-500 dark:text-white-50">
-                            The results and data in this publication does <strong>not</strong> involve human or animal
-                            subjects.{' '}
-                        </span>
-                    </label>
+                    {ethicalStatementOptions.map((option) => (
+                        <label
+                            key={option}
+                            htmlFor={option}
+                            className="flex items-center space-x-2 hover:cursor-pointer"
+                        >
+                            <input
+                                type="radio"
+                                name={option}
+                                id={option}
+                                checked={option === ethicalStatement}
+                                onChange={() => {
+                                    updateEthicalStatement(option);
+                                    if (option === ethicalStatementOptions[0]) {
+                                        updateEthicalStatementFreeText('');
+                                    }
+                                }}
+                                className="hover:cursor-pointer"
+                                aria-label="The results and data in this publication involved human or animal subjects."
+                            />
+                            <span className="ml-2 text-sm text-grey-800 transition-colors duration-500 dark:text-white-50">
+                                {parse(option)}
+                            </span>
+                        </label>
+                        // <label htmlFor="false" className="flex items-center space-x-2 hover:cursor-pointer">
+                        //     <input
+                        //         type="radio"
+                        //         name="false"
+                        //         id="false"
+                        //         checked={ethicalStatement === false}
+                        //         onChange={() => updateEthicalStatement(false)}
+                        //         className="hover:cursor-pointer"
+                        //         aria-label="The results and data in this publication does not involve human or animal subjects."
+                        //     />
+                        //     <span className="ml-2 text-sm text-grey-800 transition-colors duration-500 dark:text-white-50">
+                        //         The results and data in this publication does <strong>not</strong> involve human or animal
+                        //         subjects.{' '}
+                        //     </span>
+                        // </label>
+                    ))}
                 </fieldset>
 
                 <div className="mt-8">
-                    <span className="mb-2 block text-sm leading-snug text-grey-700 transition-colors duration-500 dark:text-white-100">
-                        If relevant: Ethical approval for the data collection and sharing was given by:
-                    </span>
-                    <span className="mb-2 block text-xs leading-snug text-grey-700 transition-colors duration-500 dark:text-white-100">
-                        You may wish to link to a copy of the approval letter from your ethical committee.
-                    </span>
-                    <textarea
-                        name="freeText"
-                        id="freeText"
-                        rows={3}
-                        className="w-full rounded-md border border-grey-100 bg-white-50 text-grey-800 outline-0 focus:ring-2 focus:ring-yellow-400 disabled:opacity-50 lg:w-2/3"
-                        required
-                        value={ethicalStatementFreeText ?? ''}
-                        onChange={(e) => updateEthicalStatementFreeText(e.target.value)}
-                    />
+                    {ethicalStatement === ethicalStatementOptions[0] && (
+                        <>
+                            <span className="mb-2 block text-sm leading-snug text-grey-700 transition-colors duration-500 dark:text-white-100">
+                                If relevant: Ethical approval for the data collection and sharing was given by:
+                            </span>
+                            <span className="mb-2 block text-xs leading-snug text-grey-700 transition-colors duration-500 dark:text-white-100">
+                                You may wish to link to a copy of the approval letter from your ethical committee.
+                            </span>
+                            <textarea
+                                name="freeText"
+                                id="freeText"
+                                rows={3}
+                                className="w-full rounded-md border border-grey-100 bg-white-50 text-grey-800 outline-0 focus:ring-2 focus:ring-yellow-400 disabled:opacity-50 lg:w-2/3"
+                                required
+                                value={ethicalStatementProvidedBy ?? ''}
+                                onChange={(e) => updateEthicalStatementFreeText(e.target.value)}
+                            />
+                        </>
+                    )}
                 </div>
             </div>
 

--- a/ui/src/components/Publication/Creation/DataStatements.tsx
+++ b/ui/src/components/Publication/Creation/DataStatements.tsx
@@ -29,11 +29,7 @@ const DataStatements: React.FC = (): React.ReactElement => {
     const updateEthicalStatementFreeText = Stores.usePublicationCreationStore(
         (state) => state.updateEthicalStatementFreeText
     );
-    const ethicalStatementProvidedBy = Stores.usePublicationCreationStore((state) => state.ethicalStatementProvidedBy);
-    const updateEthicalStatementProvidedBy = Stores.usePublicationCreationStore(
-        (state) => state.updateEthicalStatementProvidedBy
-    );
-    console.log(ethicalStatementProvidedBy);
+    console.log(ethicalStatementFreeText);
 
     // Data permissions statement
     const dataPermissionsStatement = Stores.usePublicationCreationStore((state) => state.dataPermissionsStatement);
@@ -82,21 +78,6 @@ const DataStatements: React.FC = (): React.ReactElement => {
                                 {parse(option)}
                             </span>
                         </label>
-                        // <label htmlFor="false" className="flex items-center space-x-2 hover:cursor-pointer">
-                        //     <input
-                        //         type="radio"
-                        //         name="false"
-                        //         id="false"
-                        //         checked={ethicalStatement === false}
-                        //         onChange={() => updateEthicalStatement(false)}
-                        //         className="hover:cursor-pointer"
-                        //         aria-label="The results and data in this publication does not involve human or animal subjects."
-                        //     />
-                        //     <span className="ml-2 text-sm text-grey-800 transition-colors duration-500 dark:text-white-50">
-                        //         The results and data in this publication does <strong>not</strong> involve human or animal
-                        //         subjects.{' '}
-                        //     </span>
-                        // </label>
                     ))}
                 </fieldset>
 
@@ -115,7 +96,7 @@ const DataStatements: React.FC = (): React.ReactElement => {
                                 rows={3}
                                 className="w-full rounded-md border border-grey-100 bg-white-50 text-grey-800 outline-0 focus:ring-2 focus:ring-yellow-400 disabled:opacity-50 lg:w-2/3"
                                 required
-                                value={ethicalStatementProvidedBy ?? ''}
+                                value={ethicalStatementFreeText ?? ''}
                                 onChange={(e) => updateEthicalStatementFreeText(e.target.value)}
                             />
                         </>

--- a/ui/src/components/Publication/Creation/Review.tsx
+++ b/ui/src/components/Publication/Creation/Review.tsx
@@ -95,7 +95,7 @@ const Review: React.FC = (): React.ReactElement => {
                             <span className="block font-montserrat text-xl text-grey-800 transition-colors duration-500 dark:text-white-50">
                                 Ethical statement
                             </span>
-                            {ethicalStatement ? <CompletedIcon /> : <IncompleteIcon />}
+                            {ethicalStatement?.length ? <CompletedIcon /> : <IncompleteIcon />}
                         </div>
 
                         <div className="relative">

--- a/ui/src/components/Publication/SearchResult/index.tsx
+++ b/ui/src/components/Publication/SearchResult/index.tsx
@@ -51,7 +51,7 @@ const SearchResult: React.FC<Props> = (props): React.ReactElement => (
             `}
         >
             <div className="z-10 col-span-11 w-full">
-                <span className="leading-0 mb-2 block font-montserrat text-xs font-semibold tracking-wide text-teal-400">
+                <span className="leading-0 mb-2 block font-montserrat text-xs font-semibold tracking-wide text-teal-400 dark:text-teal-200">
                     {Helpers.formatPublicationType(props.publication.type)}
                 </span>
                 <h2 className="col-span-7 mb-2 leading-6 text-grey-800 transition-colors duration-500 dark:text-white-50">

--- a/ui/src/lib/interfaces.ts
+++ b/ui/src/lib/interfaces.ts
@@ -64,7 +64,7 @@ export interface CorePublication {
     licence: Types.LicenceType;
     content: string;
     language: Types.Languages;
-    ethicalStatement: string;
+    ethicalStatement: string | null;
     ethicalStatementFreeText: string | null;
 }
 
@@ -388,7 +388,7 @@ export interface PublicationUpdateRequestBody extends JSON {
     language: Types.Languages;
     conflictOfInterestStatus: boolean;
     conflictOfInterestText: string;
-    ethicalStatement?: string;
+    ethicalStatement?: string | null;
     ethicalStatementFreeText?: string | null;
     dataAccessStatement?: string | null;
     dataPermissionsStatement?: string | null;

--- a/ui/src/lib/interfaces.ts
+++ b/ui/src/lib/interfaces.ts
@@ -64,7 +64,7 @@ export interface CorePublication {
     licence: Types.LicenceType;
     content: string;
     language: Types.Languages;
-    ethicalStatement: string | null;
+    ethicalStatement: string;
     ethicalStatementFreeText: string | null;
 }
 

--- a/ui/src/lib/interfaces.ts
+++ b/ui/src/lib/interfaces.ts
@@ -64,7 +64,7 @@ export interface CorePublication {
     licence: Types.LicenceType;
     content: string;
     language: Types.Languages;
-    ethicalStatement: boolean | null;
+    ethicalStatement: string;
     ethicalStatementFreeText: string | null;
 }
 
@@ -388,7 +388,7 @@ export interface PublicationUpdateRequestBody extends JSON {
     language: Types.Languages;
     conflictOfInterestStatus: boolean;
     conflictOfInterestText: string;
-    ethicalStatement?: boolean | null;
+    ethicalStatement?: string;
     ethicalStatementFreeText?: string | null;
     dataAccessStatement?: string | null;
     dataPermissionsStatement?: string | null;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -69,10 +69,8 @@ export type PublicationCreationStoreType = {
     updateLinkTo: (linkTo: Interfaces.LinkTo[]) => void;
     ethicalStatement: string | null;
     ethicalStatementFreeText: string | null;
-    updateEthicalStatementFreeText: (ethicalStatementFreeText: string) => void;
+    updateEthicalStatementFreeText: (ethicalStatementFreeText: string | null) => void;
     updateEthicalStatement: (ethicalStatement: string) => void;
-    ethicalStatementProvidedBy: string | null;
-    updateEthicalStatementProvidedBy: (dataPermissionsStatementProvidedBy: string | null) => void;
     dataAccessStatement: string | null;
     updateDataAccessStatement: (dataAccessStatement: string | null) => void;
     dataPermissionsStatement: string | null;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -67,10 +67,12 @@ export type PublicationCreationStoreType = {
     updateConflictOfInterestText: (conflictOfInterestText: string) => void;
     linkTo: Interfaces.LinkTo[];
     updateLinkTo: (linkTo: Interfaces.LinkTo[]) => void;
-    ethicalStatement: boolean | null;
+    ethicalStatement: string | null;
     ethicalStatementFreeText: string | null;
-    updateEthicalStatement: (ethicalStatement: boolean) => void;
     updateEthicalStatementFreeText: (ethicalStatementFreeText: string) => void;
+    updateEthicalStatement: (ethicalStatement: string) => void;
+    ethicalStatementProvidedBy: string | null;
+    updateEthicalStatementProvidedBy: (dataPermissionsStatementProvidedBy: string | null) => void;
     dataAccessStatement: string | null;
     updateDataAccessStatement: (dataAccessStatement: string | null) => void;
     dataPermissionsStatement: string | null;

--- a/ui/src/pages/publications/[id]/index.tsx
+++ b/ui/src/pages/publications/[id]/index.tsx
@@ -444,9 +444,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                         <Components.PublicationContentSection id="ethical-statement" title="Ethical statement" hasBreak>
                             <>
                                 <p className="block text-grey-800 transition-colors duration-500 dark:text-white-50">
-                                    {publicationData.ethicalStatement
-                                        ? 'The results and data in this publication involved human or animal subjects.'
-                                        : 'The results and data in this publication does not involve human or animal subjects.'}
+                                    {parse(publicationData.ethicalStatement)}
                                 </p>
                                 {!!publicationData.ethicalStatementFreeText && (
                                     <p className="mt-4 block text-sm text-grey-700 transition-colors duration-500 dark:text-white-100">

--- a/ui/src/pages/search.tsx
+++ b/ui/src/pages/search.tsx
@@ -297,6 +297,7 @@ const Search: Types.NextPage<Props> = (props): React.ReactElement => {
                                 <button
                                     type="submit"
                                     form="query-form"
+                                    aria-label="Search"
                                     className="absolute right-px rounded-md p-2 outline-none focus:ring-2 focus:ring-yellow-500 disabled:opacity-70"
                                     disabled={isValidating}
                                 >


### PR DESCRIPTION
The purpose of this PR was to fix a bug in the ethical statement section of the publication flow.
JIRA Ticket: https://jiscdev.atlassian.net/browse/OCT-247

Ethical statement doesn't count as completed if second option is selected
This is only for ‘Results’ types.

Incorrect functionality at the moment:

- When choosing the second option, the ‘ethical statement’ section is shown as not complete.
- The optional free text field is shown with both options, it should only be shown when the first option is selected.

I have also:
- Implemented accessibility fixes so that lighthouse ci passes
- Added in a missing doi to the test seed data so that api tests can be run locally

---

### Acceptance Criteria:

A user wants to publish a 'Results' publication and the results involved human or animal subjects, then: they tick 'The results in this publication involved human or animal subjects.' and a free text field appears so they can optionally add relevant info, the publication can be saved/published and the publication page shows this text and any information from the free text field. 

A user wants to publish a 'Results' publication and the results didn't involve human or animal subjects, then: they tick 'The results in this publication do not involve human or animal subjects.', the publication can be saved/published and the publication page shows this text.

A user does not pick an option from the 'Ethical statement' section of the publication flow. This section is shown with a warning on the 'review' page, and the publication cannot be published.
