### PR TITLE
Add link to author guide on create publication page and change position of the 'Co-author' step within the publication build process

### DIFF
--- a/ui/src/components/Publication/Creation/CoAuthor.tsx
+++ b/ui/src/components/Publication/Creation/CoAuthor.tsx
@@ -51,6 +51,17 @@ const CoAuthor: React.FC = (): React.ReactElement => {
         <div className="space-y-12 2xl:space-y-16">
             <div>
                 <Components.PublicationCreationStepTitle text="Co-authors" />
+                <span className="mb-2 block text-sm leading-snug text-grey-700 transition-colors duration-500 dark:text-white-50">
+                    Add the email addresses of any co-authors involved in this publication. Note that they will
+                    immediately receive an email asking them to confirm their involvement and preview the publication.{' '}
+                    <span className="font-bold">
+                        Only add their emails when you are ready for the draft to be viewed.
+                    </span>
+                </span>
+                <span className="mb-2 block text-sm leading-snug text-grey-700 transition-colors duration-500 dark:text-white-50">
+                    Please note that in line with the smaller publication types on Octopus, we encourage you to list
+                    only those authors that were directly involved in this stage of the research process.
+                </span>
             </div>
             <div className="flex items-center space-x-4">
                 <input

--- a/ui/src/pages/create.tsx
+++ b/ui/src/pages/create.tsx
@@ -98,6 +98,7 @@ const Create: Types.NextPage<PageProps> = (props): React.ReactElement => {
 
                     <div className="mb-10">
                         <Components.PageSubTitle text="Record a piece of research" className="!mb-4" />
+
                         <SupportText>
                             Octopus is designed for officially recording your research contributions to the primary
                             research record. It is different from writing an article for a journal (which you can do
@@ -125,6 +126,14 @@ const Create: Types.NextPage<PageProps> = (props): React.ReactElement => {
                             guidelines in health research. You will also be given the opportunity to link to additional
                             resources deposited on specialist platforms (such as data or code repositories).
                         </SupportText>
+                        <Components.Link
+                            href={Config.urls.authorGuide.path}
+                            className="my-6 flex w-44 items-center justify-between rounded-lg bg-teal-400 px-8 py-4 text-center outline-0 transition-colors duration-300 hover:bg-teal-300 focus:ring-2 focus:ring-yellow-400 dark:bg-grey-700 dark:text-white-50 dark:hover:bg-grey-600"
+                        >
+                            <span className="text-center font-montserrat text-sm leading-none tracking-wide">
+                                Author Guide
+                            </span>
+                        </Components.Link>
                     </div>
 
                     <div className="mb-10">

--- a/ui/src/pages/publications/[id]/edit.tsx
+++ b/ui/src/pages/publications/[id]/edit.tsx
@@ -139,9 +139,9 @@ const Edit: Types.NextPage<Props> = (props): React.ReactElement => {
                     steps.LINKED_PUBLICATIONS,
                     steps.MAIN_TEXT,
                     steps.CONFLICT_OF_INTEREST,
-                    steps.CO_AUTHORS,
                     steps.FUNDERS,
                     steps.DATA_STATEMENT,
+                    steps.CO_AUTHORS,
                     steps.REVIEW
                 ];
                 break;
@@ -151,9 +151,9 @@ const Edit: Types.NextPage<Props> = (props): React.ReactElement => {
                     steps.LINKED_PUBLICATIONS,
                     steps.MAIN_TEXT,
                     steps.CONFLICT_OF_INTEREST,
-                    steps.CO_AUTHORS,
                     steps.FUNDERS,
                     steps.RESEARCH_PROCESS,
+                    steps.CO_AUTHORS,
                     steps.REVIEW
                 ];
                 break;
@@ -163,9 +163,9 @@ const Edit: Types.NextPage<Props> = (props): React.ReactElement => {
                     steps.LINKED_PUBLICATIONS,
                     steps.MAIN_TEXT,
                     steps.CONFLICT_OF_INTEREST,
-                    steps.CO_AUTHORS,
                     steps.FUNDERS,
                     steps.RESEARCH_PROCESS,
+                    steps.CO_AUTHORS,
                     steps.REVIEW
                 ];
                 break;
@@ -175,8 +175,8 @@ const Edit: Types.NextPage<Props> = (props): React.ReactElement => {
                     steps.LINKED_PUBLICATIONS,
                     steps.MAIN_TEXT,
                     steps.CONFLICT_OF_INTEREST,
-                    steps.CO_AUTHORS,
                     steps.FUNDERS,
+                    steps.CO_AUTHORS,
                     steps.REVIEW
                 ];
         }


### PR DESCRIPTION
The purpose of this PR was to add a link to the author guide on the 'create a publication' page, to change the position of the co-author step within the publication build process and to add some copy to the co-author page. Because both tickets are quite small, I've done both tickets ([OCT-237](https://jiscdev.atlassian.net/jira/software/projects/OCT/boards/836?selectedIssue=OCT-237) and [OCT-241](https://jiscdev.atlassian.net/jira/software/projects/OCT/boards/836?selectedIssue=OCT-241)) in this PR. 

Acceptance Criteria: 
- Move coauthor to final stage of the publication form. 
- Add the following copy to the co-author page in the publication form:
```
Add the email addresses of any co-authors involved in this publication. Note that they will immediately receive an email asking them to confirm their involvement and preview the publication. Only add their emails when you are ready for the draft to be viewed.

Please note that in line with the smaller publication types on Octopus, we encourage you to list only those authors that were directly involved in this stage of the research process.
```
- add a link to the 'Authors Guide' in the create a publication page

---

### Screenshots:
![Screenshot 2022-07-08 at 15 55 51](https://user-images.githubusercontent.com/100135505/178019594-6f7aa049-31e8-4a91-bcb1-b122529a0131.png)

