### PR TITLE
OCT-240 Data permissions statement blocking publication

### DIFF
--- a/ui/src/components/Publication/Creation/DataStatements.tsx
+++ b/ui/src/components/Publication/Creation/DataStatements.tsx
@@ -4,15 +4,13 @@ import * as OutlineIcons from '@heroicons/react/outline';
 
 import * as Components from '@components';
 import * as Stores from '@stores';
+import * as Config from '@config';
 
 const ethicalStatementOptions: string[] = [
     'The results in this publication involved human or animal subjects.',
     'The results in this publication do <strong>not</strong> involve human or animal subjects.'
 ];
-const dataPermissionsOptions: string[] = [
-    'The results in this publication involved access to owned or copyrighted materials.',
-    'The results in this publication do <strong>not</strong> involve access to materials owned or copyrighted materials (except those in the private ownership of the authors).'
-];
+
 const dataAccessOptions: string[] = [
     'This publication includes all the relevant results or data collected by the authors.',
     'This publication contains a sample of relevant results or data, with the full data publicly stored on another platform.',
@@ -107,7 +105,7 @@ const DataStatements: React.FC = (): React.ReactElement => {
             <div>
                 <Components.PublicationCreationStepTitle text="Data permissions statement" required />
                 <fieldset className="my-8 space-y-3">
-                    {dataPermissionsOptions.map((option) => (
+                    {Config.values.dataPermissionsOptions.map((option) => (
                         <label
                             key={option}
                             htmlFor={option}
@@ -120,7 +118,7 @@ const DataStatements: React.FC = (): React.ReactElement => {
                                 checked={option === dataPermissionsStatement}
                                 onChange={() => {
                                     updateDataPermissionsStatement(option);
-                                    if (option === dataPermissionsOptions[1]) {
+                                    if (option === Config.values.dataPermissionsOptions[1]) {
                                         updateDataPermissionsStatementProvidedBy(null);
                                     }
                                 }}
@@ -134,7 +132,7 @@ const DataStatements: React.FC = (): React.ReactElement => {
                     ))}
                 </fieldset>
 
-                {dataPermissionsStatement === dataPermissionsOptions[0] && (
+                {dataPermissionsStatement === Config.values.dataPermissionsOptions[0] && (
                     <>
                         <span className="mb-2 block text-sm leading-snug text-grey-700 transition-colors duration-500 dark:text-white-100">
                             Permission for the data collection and sharing was given by <Components.RequiredIndicator />

--- a/ui/src/components/Publication/Creation/DataStatements.tsx
+++ b/ui/src/components/Publication/Creation/DataStatements.tsx
@@ -13,8 +13,8 @@ const dataAccessOptions: string[] = [
     'This publication contains representative digital data of physical samples or records (e.g. of museum objects, geological samples, tissue samples, images). Relevant accession/reference numbers and associated information of where the originals are stored are provided'
 ];
 const dataPermissionsOptions: string[] = [
-    'The results and data in this publication involved access to owned or copyrighted materials',
-    'The results and data in this publication does <strong>not</strong> involve access to materials owned or copyrighted materials (except those in the private ownership of the authors)'
+    'The results and data in this publication involved access to owned or copyrighted materials.',
+    'The results and data in this publication does <strong>not</strong> involve access to materials owned or copyrighted materials (except those in the private ownership of the authors).'
 ];
 
 const DataStatements: React.FC = (): React.ReactElement => {

--- a/ui/src/components/Publication/Creation/LinkedPublications.tsx
+++ b/ui/src/components/Publication/Creation/LinkedPublications.tsx
@@ -94,7 +94,10 @@ const LinkedPublications: React.FC = (): React.ReactElement => {
     return (
         <div className="space-y-6 lg:space-y-10 2xl:w-10/12">
             <div>
-                <Components.PublicationCreationStepTitle text="What publications do you want to linked to?" required />
+                <Components.PublicationCreationStepTitle
+                    text="What publications should this publication be linked from?"
+                    required
+                />
                 <p className="mb-6 block text-sm text-grey-800 transition-colors duration-500 dark:text-white-50">
                     All publications in Octopus are linked to each other to form research chains, branching down from
                     research problems to real world implementations.

--- a/ui/src/components/Publication/Creation/Review.tsx
+++ b/ui/src/components/Publication/Creation/Review.tsx
@@ -30,11 +30,6 @@ const Review: React.FC = (): React.ReactElement => {
         (state) => state.dataPermissionsStatementProvidedBy
     );
 
-    const dataPermissionsOptions: string[] = [
-        'The results and data in this publication involved access to owned or copyrighted materials.',
-        'The results and data in this publication does <strong>not</strong> involve access to materials owned or copyrighted materials (except those in the private ownership of the authors).'
-    ];
-
     return (
         <>
             <Components.PublicationCreationStepTitle text="Review &#38; publish" />
@@ -110,7 +105,7 @@ const Review: React.FC = (): React.ReactElement => {
                             {dataPermissionsStatement?.length ? <CompletedIcon /> : <IncompleteIcon />}
                         </div>
 
-                        {dataPermissionsStatement === dataPermissionsOptions[0] && (
+                        {dataPermissionsStatement === Config.values.dataPermissionsOptions[0] && (
                             <div className="relative">
                                 <span className="block font-montserrat text-xl text-grey-800 transition-colors duration-500 dark:text-white-50">
                                     Data permissions statement provided by

--- a/ui/src/components/Publication/Creation/Review.tsx
+++ b/ui/src/components/Publication/Creation/Review.tsx
@@ -30,6 +30,11 @@ const Review: React.FC = (): React.ReactElement => {
         (state) => state.dataPermissionsStatementProvidedBy
     );
 
+    const dataPermissionsOptions: string[] = [
+        'The results and data in this publication involved access to owned or copyrighted materials',
+        'The results and data in this publication does <strong>not</strong> involve access to materials owned or copyrighted materials (except those in the private ownership of the authors)'
+    ];
+
     return (
         <>
             <Components.PublicationCreationStepTitle text="Review &#38; publish" />
@@ -105,12 +110,14 @@ const Review: React.FC = (): React.ReactElement => {
                             {dataPermissionsStatement?.length ? <CompletedIcon /> : <IncompleteIcon />}
                         </div>
 
-                        <div className="relative">
-                            <span className="block font-montserrat text-xl text-grey-800 transition-colors duration-500 dark:text-white-50">
-                                Data permissions statement provided by
-                            </span>
-                            {dataPermissionsStatementProvidedBy?.length ? <CompletedIcon /> : <IncompleteIcon />}
-                        </div>
+                        {dataPermissionsStatement === dataPermissionsOptions[0] && (
+                            <div className="relative">
+                                <span className="block font-montserrat text-xl text-grey-800 transition-colors duration-500 dark:text-white-50">
+                                    Data permissions statement provided by
+                                </span>
+                                {dataPermissionsStatementProvidedBy?.length ? <CompletedIcon /> : <IncompleteIcon />}
+                            </div>
+                        )}
                     </>
                 )}
             </div>

--- a/ui/src/components/Publication/Creation/Review.tsx
+++ b/ui/src/components/Publication/Creation/Review.tsx
@@ -31,8 +31,8 @@ const Review: React.FC = (): React.ReactElement => {
     );
 
     const dataPermissionsOptions: string[] = [
-        'The results and data in this publication involved access to owned or copyrighted materials',
-        'The results and data in this publication does <strong>not</strong> involve access to materials owned or copyrighted materials (except those in the private ownership of the authors)'
+        'The results and data in this publication involved access to owned or copyrighted materials.',
+        'The results and data in this publication does <strong>not</strong> involve access to materials owned or copyrighted materials (except those in the private ownership of the authors).'
     ];
 
     return (

--- a/ui/src/config/values.ts
+++ b/ui/src/config/values.ts
@@ -1112,6 +1112,11 @@ export const octopusInformation: Interfaces.OctopusInformation = {
     }
 };
 
+export const dataPermissionsOptions: string[] = [
+    'The results in this publication involved access to owned or copyrighted materials.',
+    'The results in this publication does <strong>not</strong> involve access to materials owned or copyrighted materials (except those in the private ownership of the authors).'
+];
+
 export const HTMLStyles = `
     custom-table 
     prose

--- a/ui/src/layouts/BuildPublication.tsx
+++ b/ui/src/layouts/BuildPublication.tsx
@@ -42,11 +42,6 @@ type BuildPublicationProps = {
     children: React.ReactNode;
 };
 
-const dataPermissionsOptions: string[] = [
-    'The results and data in this publication involved access to owned or copyrighted materials.',
-    'The results and data in this publication does <strong>not</strong> involve access to materials owned or copyrighted materials (except those in the private ownership of the authors).'
-];
-
 const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
     const router = Router.useRouter();
     const user = Stores.useAuthStore((state) => state.user);
@@ -182,8 +177,8 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
             if (store.dataPermissionsStatement === null)
                 ready = { ready: false, message: 'You must select a data permissions option' };
             if (
-                store.dataPermissionsStatementProvidedBy === null &&
-                store.dataPermissionsStatement === dataPermissionsOptions[0]
+                !store.dataPermissionsStatementProvidedBy &&
+                store.dataPermissionsStatement === Config.values.dataPermissionsOptions[0]
             )
                 ready = {
                     ready: false,

--- a/ui/src/layouts/BuildPublication.tsx
+++ b/ui/src/layouts/BuildPublication.tsx
@@ -42,6 +42,11 @@ type BuildPublicationProps = {
     children: React.ReactNode;
 };
 
+const dataPermissionsOptions: string[] = [
+    'The results and data in this publication involved access to owned or copyrighted materials',
+    'The results and data in this publication does <strong>not</strong> involve access to materials owned or copyrighted materials (except those in the private ownership of the authors)'
+];
+
 const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
     const router = Router.useRouter();
     const user = Stores.useAuthStore((state) => state.user);
@@ -163,7 +168,7 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
         if (!store.title) ready = { ready: false, message: 'You must provide a title' };
         if (!store.content) ready = { ready: false, message: 'You must provide main text' };
         if (!store.licence) ready = { ready: false, message: 'You must select a licence' };
-        if (!store.linkTo.length)
+        if (!store.linkTo?.length)
             ready = { ready: false, message: 'You must link this publication to at least one other' };
         if (store.conflictOfInterestStatus && !store.conflictOfInterestText.length) {
             ready = {
@@ -176,11 +181,18 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
                 ready = { ready: false, message: 'You must select an ethical statement option' };
             if (store.dataPermissionsStatement === null)
                 ready = { ready: false, message: 'You must select a data permissions option' };
+            if (
+                store.dataPermissionsStatementProvidedBy === null &&
+                store.dataPermissionsStatement === dataPermissionsOptions[0]
+            )
+                ready = {
+                    ready: false,
+                    message: 'You must provide details of who gave permission for the data collection and sharing'
+                };
         }
         if (!store.coAuthors.every((coAuthor) => coAuthor.confirmedCoAuthor)) {
             ready = { ready: false, message: 'All co-authors must be verified.' };
         }
-
         return ready;
     };
 
@@ -198,6 +210,7 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
         store.type,
         store.ethicalStatement,
         store.dataPermissionsStatement,
+        store.dataPermissionsStatementProvidedBy,
         store.coAuthors
     ]);
 

--- a/ui/src/layouts/BuildPublication.tsx
+++ b/ui/src/layouts/BuildPublication.tsx
@@ -43,8 +43,8 @@ type BuildPublicationProps = {
 };
 
 const dataPermissionsOptions: string[] = [
-    'The results and data in this publication involved access to owned or copyrighted materials',
-    'The results and data in this publication does <strong>not</strong> involve access to materials owned or copyrighted materials (except those in the private ownership of the authors)'
+    'The results and data in this publication involved access to owned or copyrighted materials.',
+    'The results and data in this publication does <strong>not</strong> involve access to materials owned or copyrighted materials (except those in the private ownership of the authors).'
 ];
 
 const BuildPublication: React.FC<BuildPublicationProps> = (props) => {

--- a/ui/src/pages/about.tsx
+++ b/ui/src/pages/about.tsx
@@ -206,7 +206,7 @@ const About: NextPage = (): React.ReactElement => (
                     <div className="grid grid-cols-1 gap-8 lg:grid-cols-3 lg:gap-12">
                         <Components.ActionCard
                             title="Publish your work"
-                            content="Recording your work on Octopus is different to publishing a paper. There are eight publication types that are aligned with the research process and designed to help researchers of all types share their work and be recognised for it."
+                            content="Recording your work on Octopus is different from publishing a paper. There are eight publication types that are aligned with the research process and designed to help researchers of all types share their work and be recognised for it."
                             icon={<OutlineIcons.PencilIcon className="h-8 w-8 text-teal-500" />}
                             link={Config.urls.createPublication.path}
                             linkText="Publish your work"

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -91,7 +91,7 @@ const Home: Types.NextPage<Props> = (props): React.ReactElement => {
                     <div className="grid grid-cols-1 gap-8 lg:grid-cols-2 lg:gap-12 2xl:grid-cols-3">
                         <Components.ActionCard
                             title="Publish your work"
-                            content="Recording your work on Octopus is different to publishing a paper. There are eight publication types that are aligned with the research process and designed to help researchers of all types share their work and be recognised for it."
+                            content="Recording your work on Octopus is different from publishing a paper. There are eight publication types that are aligned with the research process and designed to help researchers of all types share their work and be recognised for it."
                             icon={<OutlineIcons.PencilIcon className="h-8 w-8 text-teal-500" />}
                             link={Config.urls.createPublication.path}
                             linkText="Publish your work"

--- a/ui/src/stores/publicationCreation.ts
+++ b/ui/src/stores/publicationCreation.ts
@@ -78,7 +78,7 @@ let store: any = (set: (params: any) => void) => ({
     // Ethical statement
     ethicalStatement: null,
     ethicalStatementFreeText: null,
-    updateEthicalStatement: (ethicalStatement: boolean) => set(() => ({ ethicalStatement })),
+    updateEthicalStatement: (ethicalStatement: string) => set(() => ({ ethicalStatement })),
     updateEthicalStatementFreeText: (ethicalStatementFreeText: string) => set(() => ({ ethicalStatementFreeText })),
 
     dataAccessStatement: null,


### PR DESCRIPTION
The purpose of this PR was to fix a bug in the data permissions section of the publication flow.
JIRA Ticket: https://jiscdev.atlassian.net/browse/OCT-240

The mandatory free text field is appearing with both options but should only show when option 1 is chosen, so it is blocking the publication flow. 
I have also changed the logic so that the 'Data permissions statement provided by' section on the review page only shows when option 1 has been selected for data permissions, and corrected a few typos.

This is only for ‘Results’ types. 
Incorrect functionality at the moment:

- On the ‘review and publish’ the section ‘Data permissions statement provided by' is shown even when the second option for ‘Data permissions’ is selected so the free text field is not needed to continue with the publication.
- As this free text field is set as required even when the second option is selected, this is blocking the publication flow as the box is not shown to fill in when the second option is selected.
- Just to clarify, there should be no section shown on ‘review and publish’ page for Data Access statement as this is optional.

---

### Acceptance Criteria:

 A user wants to publish a 'Results' publication and the results does not involve access to materials owned or copyrighted materials (except those in the private ownership of the authors). They choose option two in the 'data permissions' section. On the review page, they cannot see the 'Data permissions statement provided by' section, and they can publish with no blockers from the data permissions section and the right data is sent to the database. The right information is shown on the 'preview' publication and the 'published' publication.

A user wants to publish a 'Results' publication and the results involved access to owned or copyrighted materials. They choose option one on the 'data permissions' section. The mandatory free text box appears and they do not enter anything. On the review page, they are stopped from publishing as the publish button is disabled.

A user wants to publish a 'Results' publication and the results involved access to owned or copyrighted materials. They choose option one on the 'data permissions' section. The mandatory free text box appears and they fill this in. On the review page, both sections are appearing as completed and they can publish with no blockers from the data permissions section and the right data is sent to the database. The right information is shown on the 'preview' publication and the 'published' publication.
