### PR TITLE
Amendments to banner & footer to make the help email more prominent - UI (OCT-

### DIFF
--- a/ui/src/components/Banner/index.tsx
+++ b/ui/src/components/Banner/index.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
 type Props = {
-    text: string;
+    children: React.ReactChildren | React.ReactChild | React.ReactElement[];
 };
 
 const Banner: React.FC<Props> = (props): React.ReactElement => (
     <span className="block w-full items-center bg-teal-300 p-2 text-center text-sm text-black transition-colors duration-500 dark:bg-teal-700 dark:text-grey-100">
-        {props.text}
+        {props.children}
     </span>
 );
 

--- a/ui/src/components/Footer/index.tsx
+++ b/ui/src/components/Footer/index.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import * as Components from '@components';
 import * as Config from '@config';
 import * as Assets from '@assets';
+import * as SolidIcons from '@heroicons/react/solid';
 
 type Props = {
     waves: boolean;
@@ -39,6 +40,15 @@ const Footer: React.FC<Props> = (props: Props): React.ReactElement => (
                     >
                         <Assets.Twitter width={25} height={25} className="fill-white-50" />
                     </Components.Link>
+                    <Components.Link href="mailto:help@jisc.ac.uk" openNew={true} ariaLabel="Email" className="h-fit">
+                        <SolidIcons.MailIcon width={26} height={26} className="fill-white-50" />
+                    </Components.Link>
+                </div>
+                {/* contact us section */}
+                <div className="col-span-1 mb-6 md:col-span-4">
+                    <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">
+                        Contact us: <Components.Link href="mailto:help@jisc.ac.uk">help@jisc.ac.uk</Components.Link>
+                    </h3>
                 </div>
                 {/** Links */}
                 <div className="col-span-1 mb-14 md:col-span-2 lg:col-span-1">
@@ -72,7 +82,6 @@ const Footer: React.FC<Props> = (props: Props): React.ReactElement => (
                         </h3>
                     </Components.Link>
                 </div>
-
                 {/** Socket */}
                 <div className="col-span-1 md:col-span-2 lg:col-span-1">
                     <h4 className="text-md mb-8 block font-montserrat text-sm font-bold text-white-50 dark:text-teal-200">
@@ -107,12 +116,6 @@ const Footer: React.FC<Props> = (props: Props): React.ReactElement => (
                         &nbsp;
                     </h4>
                     <div className="flex"></div>
-                </div>
-                {/* contact us section */}
-                <div className="col-span-1 mb-4 mt-14 md:col-span-2 lg:col-span-3">
-                    <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">
-                        Contact us: <Components.Link href="mailto:help@jisc.ac.uk">help@jisc.ac.uk</Components.Link>
-                    </h3>
                 </div>
             </div>
             <Components.ScrollToTop />

--- a/ui/src/components/Header/index.tsx
+++ b/ui/src/components/Header/index.tsx
@@ -20,7 +20,26 @@ const Header: React.FC<Props> = (props): React.ReactElement => {
 
     return (
         <>
-            <Components.Banner text="This is a beta release still under active development. Please don't use it for recording your real work... yet!" />
+            <Components.Banner>
+                <>
+                    This is a beta release under active development. Help us improve by providing{' '}
+                    <Components.Link
+                        href="https://forms.office.com/pages/responsepage.aspx?id=TTn5SBSKJ02CpvNfEjYSBdQdk25FM49NmnYND3Z_nExUNE5TNzVQNTdXNTY0UFdOT05CNkZUVDBZSy4u"
+                        className="w-fit underline  underline-offset-4"
+                        openNew
+                    >
+                        feedback
+                    </Components.Link>{' '}
+                    or contacting{' '}
+                    <Components.Link
+                        href="mailto:help@jisc.ac.uk"
+                        openNew
+                        className="w-fit underline  underline-offset-4"
+                    >
+                        help@jisc.ac.uk
+                    </Components.Link>
+                </>
+            </Components.Banner>
             {/* Confirm email banner */}
             {user && !user?.email && router.pathname !== Config.urls.verify.path && (
                 <div className="bg-yellow-200 text-sm text-grey-800 dark:bg-yellow-500">


### PR DESCRIPTION
The purpose of this PR was to make the help & feedback links more prominent across the website. 

### Acceptance Criteria:

- Update site banner to read:
This is a beta release under active development. Help us improve by providing [feedback ](https://forms.office.com/pages/responsepage.aspx?id=TTn5SBSKJ02CpvNfEjYSBdQdk25FM49NmnYND3Z_nExUNE5TNzVQNTdXNTY0UFdOT05CNkZUVDBZSy4u)or contacting [help@jisc.ac.uk](mailto:help@jisc.ac.uk) With 'feedback' linking to https://forms.office.com/pages/responsepage.aspx?id=TTn5SBSKJ02CpvNfEjYSBdQdk25FM49NmnYND3Z_nExUNE5TNzVQNTdXNTY0UFdOT05CNkZUVDBZSy4u 
- Make helpdesk email more prominent - e.g. move higher in footer or add mail icon alongside social ones.

## Screenshots:
### Banner:
![Screenshot 2022-07-14 at 16 13 52](https://user-images.githubusercontent.com/100135505/179016584-d28036bf-f71e-4f4f-939c-f204cb61499f.png)

### Footer: 
![Screenshot 2022-07-14 at 16 14 01](https://user-images.githubusercontent.com/100135505/179016641-04cc81bc-1fa2-42ca-a4ea-9bff7676d8b8.png)

