### PR TITLE
Affiliation organisations updating across all drafts - bug - (OCT-256)

### DIFF
--- a/ui/src/config/urls.ts
+++ b/ui/src/config/urls.ts
@@ -13,7 +13,7 @@ function checkEnvVariable(variable: string | undefined): string {
 if (process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF == 'local') {
     host = 'https://localhost:3001';
     mediaBucket = `http://localhost:4566/science-octopus-publishing-images-local`;
-    orcidAppiID = 'APP-0Q7JRZQZG3G0M957';
+    orcidAppiID = 'APP-ZIB7M6DHIX5K22P1';
 } else {
     host = checkEnvVariable(process.env.NEXT_PUBLIC_BASE_URL);
     mediaBucket = checkEnvVariable(process.env.NEXT_PUBLIC_MEDIA_BUCKET);

--- a/ui/src/stores/publicationCreation.ts
+++ b/ui/src/stores/publicationCreation.ts
@@ -20,6 +20,8 @@ let store: any = (set: (params: any) => void) => ({
                 description: '',
                 funderStatement: '',
                 funders: [],
+                affiliationsStatement: '',
+                affiliations: [],
                 keywords: [],
                 licence: Config.values.octopusInformation.licences.CC_BY.value,
                 language: Config.values.octopusInformation.languages.find((entry) => entry.code === 'en'),


### PR DESCRIPTION
The purpose of this PR was to fix a bug where If you add or remove an affiliated organisation, it updates across all draft publications on: 
- Both Windows/Chrome and Mac/Safari
- Across multiple publication types. 
- When using both ror and manual input

The behaviour of the bug is as follows: 
- If I remove affiliation, it also disappears from other drafts
- If I update one of the drafts to something else, both drafts update
- If multiple are added, all appear across publications 
- Funder statement however seems to be working as intended.

Through testing and looking at the schema, I found that it isn't a problem with the backend, as affiliated organisations are being stored per `publicationId`. The bug is caused by the data persisting using global state, as when the author saves the publication the affiliations data isn't reset. I have resolved this by adding in `affiliations` and `affiliationsStatement` to the reset `function` within global store. 

