### PR TITLE
OCT-253 fix hard coded links to int.octopus.ac

### DIFF
--- a/ui/lighthouserc.js
+++ b/ui/lighthouserc.js
@@ -7,7 +7,7 @@ module.exports = {
                 'http://localhost:3000/browse',
                 'http://localhost:3000/about',
                 // 'http://localhost:3000/create', // Cant yet test on create due to login
-                'http://localhost:3000/terms',
+                'http://localhost:3000/user-terms',
                 'http://localhost:3000/privacy',
                 'http://localhost:3000/search',
                 'http://localhost:3000/accessibility',

--- a/ui/src/config/urls.ts
+++ b/ui/src/config/urls.ts
@@ -147,11 +147,11 @@ const urls = {
         canonical: `${base.host}`
     },
     terms: {
-        path: '/terms',
+        path: '/user-terms',
         title: `Terms - ${base.title}`,
         description: 'Terms and conditions relevant to the Octopus site, including details on our open-source licence.',
         keywords: ['open access', 'open source', 'open license', 'open licence', 'GPLv3'],
-        canonical: `${base.host}/terms`
+        canonical: `${base.host}/user-terms`
     },
     privacy: {
         path: '/privacy',

--- a/ui/src/pages/accessibility.tsx
+++ b/ui/src/pages/accessibility.tsx
@@ -21,7 +21,7 @@ const Accessibility: Types.NextPage = (): React.ReactElement => {
                     <p>This statement applies to content published on </p>
                     <Components.Link
                         className="mb-6 w-fit rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
-                        href="/"
+                        href={Config.urls.home.path}
                     >
                         <span>https://www.octopus.ac</span>
                     </Components.Link>

--- a/ui/src/pages/accessibility.tsx
+++ b/ui/src/pages/accessibility.tsx
@@ -21,9 +21,9 @@ const Accessibility: Types.NextPage = (): React.ReactElement => {
                     <p>This statement applies to content published on </p>
                     <Components.Link
                         className="mb-6 w-fit rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
-                        href="https://int.octopus.ac/"
+                        href="/"
                     >
-                        <span>https://int.octopus.ac</span>
+                        <span>https://www.octopus.ac</span>
                     </Components.Link>
                     <p>
                         This website has been developed by Jisc. It is designed to be used by as many people as

--- a/ui/src/pages/faq.tsx
+++ b/ui/src/pages/faq.tsx
@@ -68,7 +68,7 @@ const faqContents = [
         id: 'how_account_octopus',
         heading: 'How do I create an account?',
         content:
-            "<p className='mb-2'>Every Octopus account is linked to a valid <a className='underline' href='https://orcid.org/'>ORCID</a>. You can login using your ORCID credentials. See our <a href='https://int.octopus.ac/privacy' className='underline'>Privacy Notice</a> for more information on the data we collect and process in order to provide this platform.</p><p className='mb-2'>If you do not yet have an ORCID, we encourage you to consider using this unique, persistent digital identifier developed specifically for researchers.</p><p className='mb-2'>Note that you must be logged-in to an Octopus account in order to share your own work, or to interact with the work of others.</p>"
+            "<p className='mb-2'>Every Octopus account is linked to a valid <a className='underline' href='https://orcid.org/'>ORCID</a>. You can login using your ORCID credentials. See our <a href='/privacy' className='underline'>Privacy Notice</a> for more information on the data we collect and process in order to provide this platform.</p><p className='mb-2'>If you do not yet have an ORCID, we encourage you to consider using this unique, persistent digital identifier developed specifically for researchers.</p><p className='mb-2'>Note that you must be logged-in to an Octopus account in order to share your own work, or to interact with the work of others.</p>"
     },
     {
         title: 'Does each publication get a DOI?',
@@ -84,7 +84,7 @@ const faqContents = [
         id: 'how_doi_octopus',
         heading: 'Is everything on Octopus open access?',
         content:
-            "<p className='mb-2'>All research recorded on Octopus is made available under an open access license, and anyone can read this content without creating an account.</p><p className='mb-2'>However, authors retain the copyright to their work and can select which license they publish under. So, be sure to check on a case-by-case basis before you share, adapt, or build upon another’s work.</p><p className='mb-2'>The platform itself is published under the open-source license GPLv3. The platform code is available via our public <a href='https://github.com/JiscSD/octopus' className='underline'>Github repository</a>, and we invite any interested parties to participate in the ongoing development of the service and its features. See our <a href='https://int.octopus.ac/terms' className='underline'>Terms page</a> for more information.</p>"
+            "<p className='mb-2'>All research recorded on Octopus is made available under an open access license, and anyone can read this content without creating an account.</p><p className='mb-2'>However, authors retain the copyright to their work and can select which license they publish under. So, be sure to check on a case-by-case basis before you share, adapt, or build upon another’s work.</p><p className='mb-2'>The platform itself is published under the open-source license GPLv3. The platform code is available via our public <a href='https://github.com/JiscSD/octopus' className='underline'>Github repository</a>, and we invite any interested parties to participate in the ongoing development of the service and its features. See our <a href='/terms' className='underline'>Terms page</a> for more information.</p>"
     },
     {
         title: 'What about copyright?',

--- a/ui/src/pages/faq.tsx
+++ b/ui/src/pages/faq.tsx
@@ -68,7 +68,7 @@ const faqContents = [
         id: 'how_account_octopus',
         heading: 'How do I create an account?',
         content:
-            "<p className='mb-2'>Every Octopus account is linked to a valid <a className='underline' href='https://orcid.org/'>ORCID</a>. You can login using your ORCID credentials. See our <a href='/privacy' className='underline'>Privacy Notice</a> for more information on the data we collect and process in order to provide this platform.</p><p className='mb-2'>If you do not yet have an ORCID, we encourage you to consider using this unique, persistent digital identifier developed specifically for researchers.</p><p className='mb-2'>Note that you must be logged-in to an Octopus account in order to share your own work, or to interact with the work of others.</p>"
+            `<p className='mb-2'>Every Octopus account is linked to a valid <a className='underline' href='https://orcid.org/'>ORCID</a>. You can login using your ORCID credentials. See our <a href='${Config.urls.privacy.path}/privacy' className='underline'>Privacy Notice</a> for more information on the data we collect and process in order to provide this platform.</p><p className='mb-2'>If you do not yet have an ORCID, we encourage you to consider using this unique, persistent digital identifier developed specifically for researchers.</p><p className='mb-2'>Note that you must be logged-in to an Octopus account in order to share your own work, or to interact with the work of others.</p>`
     },
     {
         title: 'Does each publication get a DOI?',
@@ -84,7 +84,7 @@ const faqContents = [
         id: 'how_doi_octopus',
         heading: 'Is everything on Octopus open access?',
         content:
-            "<p className='mb-2'>All research recorded on Octopus is made available under an open access license, and anyone can read this content without creating an account.</p><p className='mb-2'>However, authors retain the copyright to their work and can select which license they publish under. So, be sure to check on a case-by-case basis before you share, adapt, or build upon another’s work.</p><p className='mb-2'>The platform itself is published under the open-source license GPLv3. The platform code is available via our public <a href='https://github.com/JiscSD/octopus' className='underline'>Github repository</a>, and we invite any interested parties to participate in the ongoing development of the service and its features. See our <a href='/terms' className='underline'>Terms page</a> for more information.</p>"
+            `<p className='mb-2'>All research recorded on Octopus is made available under an open access license, and anyone can read this content without creating an account.</p><p className='mb-2'>However, authors retain the copyright to their work and can select which license they publish under. So, be sure to check on a case-by-case basis before you share, adapt, or build upon another’s work.</p><p className='mb-2'>The platform itself is published under the open-source license GPLv3. The platform code is available via our public <a href='https://github.com/JiscSD/octopus' className='underline'>Github repository</a>, and we invite any interested parties to participate in the ongoing development of the service and its features. See our <a href='${Config.urls.terms.path}' className='underline'>Terms page</a> for more information.</p>`
     },
     {
         title: 'What about copyright?',

--- a/ui/src/pages/faq.tsx
+++ b/ui/src/pages/faq.tsx
@@ -67,8 +67,7 @@ const faqContents = [
         href: 'how_account_octopus',
         id: 'how_account_octopus',
         heading: 'How do I create an account?',
-        content:
-            `<p className='mb-2'>Every Octopus account is linked to a valid <a className='underline' href='https://orcid.org/'>ORCID</a>. You can login using your ORCID credentials. See our <a href='${Config.urls.privacy.path}/privacy' className='underline'>Privacy Notice</a> for more information on the data we collect and process in order to provide this platform.</p><p className='mb-2'>If you do not yet have an ORCID, we encourage you to consider using this unique, persistent digital identifier developed specifically for researchers.</p><p className='mb-2'>Note that you must be logged-in to an Octopus account in order to share your own work, or to interact with the work of others.</p>`
+        content: `<p className='mb-2'>Every Octopus account is linked to a valid <a className='underline' href='https://orcid.org/'>ORCID</a>. You can login using your ORCID credentials. See our <a href='${Config.urls.privacy.path}/privacy' className='underline'>Privacy Notice</a> for more information on the data we collect and process in order to provide this platform.</p><p className='mb-2'>If you do not yet have an ORCID, we encourage you to consider using this unique, persistent digital identifier developed specifically for researchers.</p><p className='mb-2'>Note that you must be logged-in to an Octopus account in order to share your own work, or to interact with the work of others.</p>`
     },
     {
         title: 'Does each publication get a DOI?',
@@ -83,8 +82,7 @@ const faqContents = [
         href: 'how_doi_octopus',
         id: 'how_doi_octopus',
         heading: 'Is everything on Octopus open access?',
-        content:
-            `<p className='mb-2'>All research recorded on Octopus is made available under an open access license, and anyone can read this content without creating an account.</p><p className='mb-2'>However, authors retain the copyright to their work and can select which license they publish under. So, be sure to check on a case-by-case basis before you share, adapt, or build upon another’s work.</p><p className='mb-2'>The platform itself is published under the open-source license GPLv3. The platform code is available via our public <a href='https://github.com/JiscSD/octopus' className='underline'>Github repository</a>, and we invite any interested parties to participate in the ongoing development of the service and its features. See our <a href='${Config.urls.terms.path}' className='underline'>Terms page</a> for more information.</p>`
+        content: `<p className='mb-2'>All research recorded on Octopus is made available under an open access license, and anyone can read this content without creating an account.</p><p className='mb-2'>However, authors retain the copyright to their work and can select which license they publish under. So, be sure to check on a case-by-case basis before you share, adapt, or build upon another’s work.</p><p className='mb-2'>The platform itself is published under the open-source license GPLv3. The platform code is available via our public <a href='https://github.com/JiscSD/octopus' className='underline'>Github repository</a>, and we invite any interested parties to participate in the ongoing development of the service and its features. See our <a href='${Config.urls.terms.path}' className='underline'>Terms page</a> for more information.</p>`
     },
     {
         title: 'What about copyright?',

--- a/ui/src/pages/user-terms.tsx
+++ b/ui/src/pages/user-terms.tsx
@@ -83,11 +83,11 @@ const UserTerms: NextPage = (): React.ReactElement => (
                                     <span className="font-bold">About the service:</span> To see more information on the
                                     Jisc&apos;s Octopus service and what it offers see our service information page at:
                                     <Components.Link
-                                        href="https://int.octopus.ac/about"
+                                        href="/about"
                                         openNew={true}
                                         className="rounded text-teal-600 outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400 dark:text-teal-300"
                                     >
-                                        https://int.octopus.ac/about.
+                                        https://www.octopus.ac/about.
                                     </Components.Link>
                                 </li>
                                 <li className="mb-6">
@@ -121,11 +121,11 @@ const UserTerms: NextPage = (): React.ReactElement => (
                                     <span className="font-bold">Privacy Policy:</span> Our Privacy Policy also applies
                                     to your use of the Service:
                                     <Components.Link
-                                        href="https://int.octopus.ac/privacy"
+                                        href="/privacy"
                                         openNew={true}
                                         className="rounded text-teal-600 outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400 dark:text-teal-300"
                                     >
-                                        https://int.octopus.ac/privacy
+                                        https://www.octopus.ac/privacy
                                     </Components.Link>
                                 </li>
                                 <li className="mb-6">
@@ -501,11 +501,11 @@ const UserTerms: NextPage = (): React.ReactElement => (
                                     The Service&apos;s accessibility statement is set out at{' '}
                                 </span>
                                 <Components.Link
-                                    href="https://int.octopus.ac/accessibility"
+                                    href="/accessibility"
                                     openNew={true}
                                     className="rounded text-teal-600 outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400 dark:text-teal-300"
                                 >
-                                    https://int.octopus.ac/accessibility
+                                    https://www.octopus.ac/accessibility
                                 </Components.Link>
                             </>
                         </StandardText>
@@ -515,7 +515,7 @@ const UserTerms: NextPage = (): React.ReactElement => (
                                 Jisc has an internal complaints procedure. We aim to handle all complaints efficiently
                                 and quickly. If you have complaints regarding the Service please visit{' '}
                                 <Components.Link
-                                    href="https://int.octopus.ac/accessibility"
+                                    href="https://www.jisc.ac.uk/contact/complaints-and-escalations"
                                     openNew={true}
                                     className="rounded text-teal-600 outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400 dark:text-teal-300"
                                 >

--- a/ui/src/pages/user-terms.tsx
+++ b/ui/src/pages/user-terms.tsx
@@ -83,7 +83,7 @@ const UserTerms: NextPage = (): React.ReactElement => (
                                     <span className="font-bold">About the service:</span> To see more information on the
                                     Jisc&apos;s Octopus service and what it offers see our service information page at:
                                     <Components.Link
-                                        href="/about"
+                                        href={Config.urls.about.path}
                                         openNew={true}
                                         className="rounded text-teal-600 outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400 dark:text-teal-300"
                                     >
@@ -121,7 +121,7 @@ const UserTerms: NextPage = (): React.ReactElement => (
                                     <span className="font-bold">Privacy Policy:</span> Our Privacy Policy also applies
                                     to your use of the Service:
                                     <Components.Link
-                                        href="/privacy"
+                                        href={Config.urls.privacy.path}
                                         openNew={true}
                                         className="rounded text-teal-600 outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400 dark:text-teal-300"
                                     >
@@ -501,7 +501,7 @@ const UserTerms: NextPage = (): React.ReactElement => (
                                     The Service&apos;s accessibility statement is set out at{' '}
                                 </span>
                                 <Components.Link
-                                    href="/accessibility"
+                                    href={Config.urls.accessibility.path}
                                     openNew={true}
                                     className="rounded text-teal-600 outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400 dark:text-teal-300"
                                 >


### PR DESCRIPTION
The purpose of this PR was...

Summary:

There are some links in prod still pointing to int. These need to be updated.

 

Links in pages should simply be absolute paths (without the domain name)



Acceptance Criteria:

Publication flow

Linked publications – in the explanatory text theres a link for each publication type to the int/about, needs to link to [Octopus](https://prod.octopus.ac/faq#pub_type_octopus)  - **DONE IN OCT-254**

FAQS: [Octopus](https://prod.octopus.ac/faq) 

Int link under Is everything on Octopus open access? (also change to new terms page)

Terms: [Octopus](https://prod.octopus.ac/user-terms) 

Section 1, 12

Footer

Terms link needs to point to [Octopus](https://prod.octopus.ac/user-terms) 

Github:

Point to live URL. - **NOT DONE**