### PR TITLE
Fix affiliations bug - UI

### DIFF
--- a/ui/src/config/urls.ts
+++ b/ui/src/config/urls.ts
@@ -13,7 +13,7 @@ function checkEnvVariable(variable: string | undefined): string {
 if (process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF == 'local') {
     host = 'https://localhost:3001';
     mediaBucket = `http://localhost:4566/science-octopus-publishing-images-local`;
-    orcidAppiID = 'APP-0Q7JRZQZG3G0M957';
+    orcidAppiID = 'APP-ZIB7M6DHIX5K22P1';
 } else {
     host = checkEnvVariable(process.env.NEXT_PUBLIC_BASE_URL);
     mediaBucket = checkEnvVariable(process.env.NEXT_PUBLIC_MEDIA_BUCKET);

--- a/ui/src/config/urls.ts
+++ b/ui/src/config/urls.ts
@@ -13,7 +13,7 @@ function checkEnvVariable(variable: string | undefined): string {
 if (process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF == 'local') {
     host = 'https://localhost:3001';
     mediaBucket = `http://localhost:4566/science-octopus-publishing-images-local`;
-    orcidAppiID = 'APP-ZIB7M6DHIX5K22P1';
+    orcidAppiID = 'APP-0Q7JRZQZG3G0M957';
 } else {
     host = checkEnvVariable(process.env.NEXT_PUBLIC_BASE_URL);
     mediaBucket = checkEnvVariable(process.env.NEXT_PUBLIC_MEDIA_BUCKET);

--- a/ui/src/pages/publications/[id]/edit.tsx
+++ b/ui/src/pages/publications/[id]/edit.tsx
@@ -263,6 +263,8 @@ const Edit: Types.NextPage<Props> = (props): React.ReactElement => {
         store.updateCoAuthors(props.draftedPublication.coAuthors);
         store.updateFunders(props.draftedPublication.funders);
         store.updateFunderStatement(props.draftedPublication.fundersStatement);
+        store.updateAffiliations(props.draftedPublication.affiliations);
+        store.updateAffiliationsStatement(props.draftedPublication.affiliationStatement);
     }, []);
 
     React.useEffect(() => {


### PR DESCRIPTION
The purpose of this PR was to fix a bug with how the `affiliations` data is initially propagated within the form. When an author saves their draft, the `affiliations` data is sent to the DB, but when they return to their draft to edit it, the `affiliations` data isn't propagated in the form. I have fixed this by making sure that the affiliations data is pulled in alongside all of the other publication data from the DB and put into store when the publication is initially loaded in.

