### PR TITLE
Bug - Co-authors unable to approve Results publications (OCT-261) - UI

### DIFF
--- a/ui/src/pages/publications/[id]/index.tsx
+++ b/ui/src/pages/publications/[id]/index.tsx
@@ -439,7 +439,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                         <Components.PublicationContentSection id="ethical-statement" title="Ethical statement" hasBreak>
                             <>
                                 <p className="block text-grey-800 transition-colors duration-500 dark:text-white-50">
-                                    {parse(publicationData.ethicalStatement)}
+                                    {publicationData.ethicalStatement}
                                 </p>
                                 {!!publicationData.ethicalStatementFreeText && (
                                     <p className="mt-4 block text-sm text-grey-700 transition-colors duration-500 dark:text-white-100">


### PR DESCRIPTION
The purpose of this PR was to fix a bug where co-authors are unable to approve 'results' publications, as per this [Jira ticket.](https://jiscdev.atlassian.net/jira/software/projects/OCT/boards/836?selectedIssue=OCT-261)

During testing, in two cases co-authors were unable to approve results publications, as they came across the following error: 

![image](https://user-images.githubusercontent.com/100135505/179537056-5342228a-0be1-4c20-b1ac-8920c1a6f4aa.png)

Upon inspection, I found that the error is being thrown by a section within the publication page, where the `ethicalStatement` is being parsed, this is throwing an error as the data is a `string` not an `object`. This has been resolved by removing the `parse()` function from the line. 
