### PR TITLE
OCT-260 404 errors on publication creation

### DIFF
--- a/api/src/components/publication/__tests__/updatePublication.test.ts
+++ b/api/src/components/publication/__tests__/updatePublication.test.ts
@@ -39,22 +39,22 @@ describe('Update publication', () => {
         expect(updatePublication.status).toEqual(200);
     });
 
-    test('Cannot update publication content if HTML not "safe" (1)', async () => {
+    test('HTML is sanitised if not "safe" (1)', async () => {
         const updatePublication = await testUtils.agent
             .patch('/publications/publication-interpretation-draft')
             .query({ apiKey: 123456789 })
             .send({ content: '<p class="class">Hello <a href="#nathan">Nathan</a></p>' });
 
-        expect(updatePublication.status).toEqual(404);
+        expect(updatePublication.body.content).toEqual('<p>Hello <a href="#nathan">Nathan</a></p>');
     });
 
-    test('Cannot update publication content if HTML not "safe" (2)', async () => {
+    test('HTML is sanitised if not "safe" (2)', async () => {
         const updatePublication = await testUtils.agent
             .patch('/publications/publication-interpretation-draft')
             .query({ apiKey: 123456789 })
             .send({ content: '<p style="color: red;">Hello <a href="#nathan">Nathan</a></p>' });
 
-        expect(updatePublication.status).toEqual(404);
+        expect(updatePublication.body.content).toEqual('<p>Hello <a href="#nathan">Nathan</a></p>');
     });
 
     test('Can update publication id', async () => {

--- a/api/src/components/publication/controller.ts
+++ b/api/src/components/publication/controller.ts
@@ -166,14 +166,7 @@ export const update = async (
         }
 
         if (event.body.content) {
-            const isHTMLSafe = helpers.isHTMLSafe(event.body.content);
-
-            if (!isHTMLSafe) {
-                return response.json(404, {
-                    message:
-                        'HTML is not safe, please check out the <a href="https://octopus.ac/api-documentation#content">API documentation.</a>'
-                });
-            }
+            event.body.content = helpers.getSafeHTML(event.body.content);
         }
 
         if (event.body.id) {

--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -1,5 +1,5 @@
-import * as cheerio from 'cheerio';
 import axios from 'axios';
+import * as cheerio from 'cheerio';
 
 import * as I from 'interface';
 
@@ -18,6 +18,16 @@ export const isHTMLSafe = (content: string) => {
     });
 
     return !error;
+};
+
+export const getSafeHTML = (content: string) => {
+    const $ = cheerio.load(content, null, false);
+
+    $('*').map((_, element) => {
+        return $(element).removeAttr('class').removeAttr('style');
+    });
+
+    return $.html();
 };
 
 export const createEmptyDOI = async (): Promise<I.DOIResponse> => {


### PR DESCRIPTION
The purpose of this PR was to fix the 404 errors described in [OCT-260](https://jiscdev.atlassian.net/browse/OCT-260).

1. Publication main body HTML is now sanitised rather than rejected.
2. If a failure does occur, a 500 server error is returned.

---

### Acceptance Criteria:

1. Publication main body HTML should be sanitised rather than rejected.
2. If a failure does occur, a more sensible error code should be returned.

---

### Tests:

- Updated unit tests to reflect sanitised rather than rejected output.
- Manually tested using supplied Word document that was previously rejected.
