### PR TITLE
Conflict of interest - 'No' value consistently not being retained - BUG - (OCT-263)

### DIFF
--- a/api/prisma/migrations/20220720091606_conflict_of_interest_bug_fix/migration.sql
+++ b/api/prisma/migrations/20220720091606_conflict_of_interest_bug_fix/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Publication" ALTER COLUMN "conflictOfInterestStatus" DROP DEFAULT;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -56,7 +56,7 @@ model Publication {
     type                               PublicationType
     title                              String?
     licence                            LicenceType            @default(CC_BY)
-    conflictOfInterestStatus           Boolean?               @default(false)
+    conflictOfInterestStatus           Boolean?
     conflictOfInterestText             String?
     ethicalStatement                   String?
     ethicalStatementFreeText           String?

--- a/ui/src/components/Publication/Creation/ConflictOfInterest.tsx
+++ b/ui/src/components/Publication/Creation/ConflictOfInterest.tsx
@@ -21,6 +21,7 @@ const ConflictOfInterest: React.FC = (): React.ReactElement => {
     const updateConflictOfInterestText = Stores.usePublicationCreationStore(
         (state: Types.PublicationCreationStoreType) => state.updateConflictOfInterestText
     );
+    console.log(conflictOfInterestStatus);
 
     return (
         <div className="space-y-12 2xl:space-y-16">
@@ -38,8 +39,8 @@ const ConflictOfInterest: React.FC = (): React.ReactElement => {
                             type="radio"
                             name="coi"
                             value="true"
-                            checked={conflictOfInterestStatus}
                             id="coi-true"
+                            checked={conflictOfInterestStatus}
                             onChange={() => updateConflictOfInterestStatus(true)}
                         />
                         <span className="ml-2 text-grey-800 transition-colors duration-500 dark:text-white-50">
@@ -51,8 +52,8 @@ const ConflictOfInterest: React.FC = (): React.ReactElement => {
                             type="radio"
                             name="coi"
                             value="false"
-                            checked={!conflictOfInterestStatus}
                             id="coi-false"
+                            checked={conflictOfInterestStatus === false}
                             onChange={() => updateConflictOfInterestStatus(false)}
                         />
                         <span className="ml-2 text-grey-800 transition-colors duration-500 dark:text-white-50">No</span>

--- a/ui/src/components/Publication/Creation/ConflictOfInterest.tsx
+++ b/ui/src/components/Publication/Creation/ConflictOfInterest.tsx
@@ -53,7 +53,10 @@ const ConflictOfInterest: React.FC = (): React.ReactElement => {
                             value="false"
                             id="coi-false"
                             checked={conflictOfInterestStatus === false}
-                            onChange={() => updateConflictOfInterestStatus(false)}
+                            onChange={() => {
+                                updateConflictOfInterestStatus(false);
+                                updateConflictOfInterestText('');
+                            }}
                         />
                         <span className="ml-2 text-grey-800 transition-colors duration-500 dark:text-white-50">No</span>
                     </label>

--- a/ui/src/components/Publication/Creation/ConflictOfInterest.tsx
+++ b/ui/src/components/Publication/Creation/ConflictOfInterest.tsx
@@ -21,7 +21,6 @@ const ConflictOfInterest: React.FC = (): React.ReactElement => {
     const updateConflictOfInterestText = Stores.usePublicationCreationStore(
         (state: Types.PublicationCreationStoreType) => state.updateConflictOfInterestText
     );
-    console.log(conflictOfInterestStatus);
 
     return (
         <div className="space-y-12 2xl:space-y-16">

--- a/ui/src/components/Publication/Creation/Review.tsx
+++ b/ui/src/components/Publication/Creation/Review.tsx
@@ -79,7 +79,7 @@ const Review: React.FC = (): React.ReactElement => {
                         Conflict of interest
                     </span>
                     {conflictOfInterestStatus && conflictOfInterestText.length ? <CompletedIcon /> : <IncompleteIcon />}
-                    {!conflictOfInterestStatus && <CompletedIcon />}
+                    {conflictOfInterestStatus === false && <CompletedIcon />}
                 </div>
 
                 <div className="relative">

--- a/ui/src/config/urls.ts
+++ b/ui/src/config/urls.ts
@@ -13,7 +13,7 @@ function checkEnvVariable(variable: string | undefined): string {
 if (process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF == 'local') {
     host = 'https://localhost:3001';
     mediaBucket = `http://localhost:4566/science-octopus-publishing-images-local`;
-    orcidAppiID = 'APP-0Q7JRZQZG3G0M957';
+    orcidAppiID = 'APP-ZIB7M6DHIX5K22P1';
 } else {
     host = checkEnvVariable(process.env.NEXT_PUBLIC_BASE_URL);
     mediaBucket = checkEnvVariable(process.env.NEXT_PUBLIC_MEDIA_BUCKET);

--- a/ui/src/config/urls.ts
+++ b/ui/src/config/urls.ts
@@ -13,7 +13,7 @@ function checkEnvVariable(variable: string | undefined): string {
 if (process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF == 'local') {
     host = 'https://localhost:3001';
     mediaBucket = `http://localhost:4566/science-octopus-publishing-images-local`;
-    orcidAppiID = 'APP-ZIB7M6DHIX5K22P1';
+    orcidAppiID = 'APP-0Q7JRZQZG3G0M957';
 } else {
     host = checkEnvVariable(process.env.NEXT_PUBLIC_BASE_URL);
     mediaBucket = checkEnvVariable(process.env.NEXT_PUBLIC_MEDIA_BUCKET);

--- a/ui/src/layouts/BuildPublication.tsx
+++ b/ui/src/layouts/BuildPublication.tsx
@@ -175,9 +175,6 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
         if (typeof store.conflictOfInterestStatus == 'undefined') {
             ready = { ready: false, message: 'You must select a conflict of interest option' };
         }
-        if (store.conflictOfInterestStatus === false) {
-            ready = { ready: true, message: '' };
-        }
         if (store.type === Config.values.octopusInformation.publications.DATA.id) {
             if (store.ethicalStatement === null)
                 ready = { ready: false, message: 'You must select an ethical statement option' };

--- a/ui/src/layouts/BuildPublication.tsx
+++ b/ui/src/layouts/BuildPublication.tsx
@@ -165,7 +165,7 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
         if (!store.licence) ready = { ready: false, message: 'You must select a licence' };
         if (!store.linkTo?.length)
             ready = { ready: false, message: 'You must link this publication to at least one other' };
-        if (store.conflictOfInterestStatus === undefined) {
+        if (store.conflictOfInterestStatus !== true || store.conflictOfInterestStatus !== false) {
             ready = { ready: false, message: 'You must select a conflict of interest option' };
         }
         if (store.conflictOfInterestStatus && !store.conflictOfInterestText.length) {

--- a/ui/src/layouts/BuildPublication.tsx
+++ b/ui/src/layouts/BuildPublication.tsx
@@ -165,14 +165,15 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
         if (!store.licence) ready = { ready: false, message: 'You must select a licence' };
         if (!store.linkTo?.length)
             ready = { ready: false, message: 'You must link this publication to at least one other' };
-        if (store.conflictOfInterestStatus !== true || store.conflictOfInterestStatus !== false) {
-            ready = { ready: false, message: 'You must select a conflict of interest option' };
-        }
+
         if (store.conflictOfInterestStatus && !store.conflictOfInterestText.length) {
             ready = {
                 ready: false,
                 message: 'You have selected there is a conflict of interest, please provide a reason.'
             };
+        }
+        if (typeof store.conflictOfInterestStatus == 'undefined') {
+            ready = { ready: false, message: 'You must select a conflict of interest option' };
         }
         if (store.conflictOfInterestStatus === false) {
             ready = { ready: true, message: '' };

--- a/ui/src/layouts/BuildPublication.tsx
+++ b/ui/src/layouts/BuildPublication.tsx
@@ -165,11 +165,17 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
         if (!store.licence) ready = { ready: false, message: 'You must select a licence' };
         if (!store.linkTo?.length)
             ready = { ready: false, message: 'You must link this publication to at least one other' };
+        if (store.conflictOfInterestStatus === undefined) {
+            ready = { ready: false, message: 'You must select a conflict of interest option' };
+        }
         if (store.conflictOfInterestStatus && !store.conflictOfInterestText.length) {
             ready = {
                 ready: false,
                 message: 'You have selected there is a conflict of interest, please provide a reason.'
             };
+        }
+        if (store.conflictOfInterestStatus === false) {
+            ready = { ready: true, message: '' };
         }
         if (store.type === Config.values.octopusInformation.publications.DATA.id) {
             if (store.ethicalStatement === null)

--- a/ui/src/lib/interfaces.ts
+++ b/ui/src/lib/interfaces.ts
@@ -73,7 +73,7 @@ export interface Publication extends CorePublication {
     user: User;
     linkedFrom: LinkFrom[];
     linkedTo: LinkTo[];
-    conflictOfInterestStatus: boolean;
+    conflictOfInterestStatus: boolean | undefined;
     conflictOfInterestText: string | null;
     dataAccessStatement: string | null;
     dataPermissionsStatement: string | null;
@@ -344,7 +344,7 @@ export interface PublicationUpdateRequestBody extends JSON {
     licence: Types.LicenceType;
     fundersStatement?: string | null;
     language: Types.Languages;
-    conflictOfInterestStatus: boolean;
+    conflictOfInterestStatus: boolean | undefined;
     conflictOfInterestText: string;
     ethicalStatement?: string | null;
     ethicalStatementFreeText?: string | null;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -61,8 +61,8 @@ export type PublicationCreationStoreType = {
     updateLicence: (licence: LicenceType) => void;
     language: Languages;
     updateLanguage: (language: Languages) => void;
-    conflictOfInterestStatus: boolean;
-    updateConflictOfInterestStatus: (conflictOfInterestStatus: boolean) => void;
+    conflictOfInterestStatus: boolean | undefined;
+    updateConflictOfInterestStatus: (conflictOfInterestStatus: boolean | undefined) => void;
     conflictOfInterestText: string;
     updateConflictOfInterestText: (conflictOfInterestText: string) => void;
     linkTo: Interfaces.LinkTo[];

--- a/ui/src/pages/publications/[id]/edit.tsx
+++ b/ui/src/pages/publications/[id]/edit.tsx
@@ -227,10 +227,6 @@ const Edit: Types.NextPage<Props> = (props): React.ReactElement => {
             store.updateLanguage(props.draftedPublication.language);
         }
 
-        if (props.draftedPublication.conflictOfInterestStatus) {
-            store.updateConflictOfInterestStatus(props.draftedPublication.conflictOfInterestStatus);
-        }
-
         if (props.draftedPublication.conflictOfInterestText) {
             store.updateConflictOfInterestText(props.draftedPublication.conflictOfInterestText);
             store.updateLinkTo(props.draftedPublication.linkedTo);
@@ -265,6 +261,7 @@ const Edit: Types.NextPage<Props> = (props): React.ReactElement => {
         store.updateFunderStatement(props.draftedPublication.fundersStatement);
         store.updateAffiliations(props.draftedPublication.affiliations);
         store.updateAffiliationsStatement(props.draftedPublication.affiliationStatement);
+        store.updateConflictOfInterestStatus(props.draftedPublication.conflictOfInterestStatus);
     }, []);
 
     React.useEffect(() => {

--- a/ui/src/stores/publicationCreation.ts
+++ b/ui/src/stores/publicationCreation.ts
@@ -25,7 +25,7 @@ let store: any = (set: (params: any) => void) => ({
                 keywords: [],
                 licence: Config.values.octopusInformation.licences.CC_BY.value,
                 language: Config.values.octopusInformation.languages.find((entry) => entry.code === 'en'),
-                conflictOfInterestStatus: true,
+                conflictOfInterestStatus: undefined,
                 conflictOfInterestText: '',
                 linkTo: [],
                 ethicalStatement: null,
@@ -68,7 +68,7 @@ let store: any = (set: (params: any) => void) => ({
     updateLanguage: (language: Types.Languages) => set(() => ({ language })),
 
     // COI
-    conflictOfInterestStatus: true,
+    conflictOfInterestStatus: undefined,
     updateConflictOfInterestStatus: (conflictOfInterestStatus: boolean) => set(() => ({ conflictOfInterestStatus })),
     conflictOfInterestText: '',
     updateConflictOfInterestText: (conflictOfInterestText: string) => set(() => ({ conflictOfInterestText })),


### PR DESCRIPTION
The purpose of this PR was to fix undesired behaviour where the confilict of interest value isn't being retained when a user selects 'no', saves the draft and then returns to the publication, as per this [Jira ticket.](https://jiscdev.atlassian.net/jira/software/projects/OCT/boards/836?selectedIssue=OCT-263)

It was set up so that the `conflictOfInterestStatus` was either `true` or `false`, `false` by default on the backend and `true` on the UI. This was then overriding the value on the database if the user has selected `false`, so although the data was being retained the UI wasn't giving any feedback that this is the case. 

I have changed it so that the `conflictOfInterestStatus` now accepts three values: undefined, false and true. If a user hasn't selected any value, both radio fields will show as blank. I also needed to change checks within other stages as it wasn't differentiating between false and undefined. 