### PR TITLE
OCT-262 - improve error handling for coauthor linking

### DIFF
--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -2,6 +2,7 @@ import * as Interfaces from '@interfaces';
 
 export type { GetServerSideProps, GetServerSidePropsContext, NextPage } from 'next';
 export type { AppProps } from 'next/app';
+export type { AxiosError } from 'axios';
 
 export type PreferencesStoreTypes = {
     darkMode: boolean;


### PR DESCRIPTION
The purpose of this PR was to improve the error handling for coauthor linking. API error messages and status codes are now shown in the UI.


---

### Acceptance Criteria:

To ensure that a user can understand what error happened when trying to link themselves as a coauthor.

---

### Tests:
Tested manually for these errors:

- 'This publication does not exist.'  
- 'This publication is LIVE and therefore cannot be edited.'  
- 'To link yourself as a co-author, you must be logged in.' Should always redirect  
- 'To link yourself as a co-author, you must have a verified email address.' Should always redirect  
- 'You cannot link yourself as the co-author, if you are the creator.'  
- 'You are already linked as another co-author'  
- 'Email not found as a co-author.' 
- 'User has already been linked to this publication.'

---

### Screenshots:
<img width="1344" alt="Screenshot 2022-07-25 at 15 26 53" src="https://user-images.githubusercontent.com/69975169/180801054-f920f7bd-f5ce-4270-ae04-9c104ae98863.png">

