### PR TITLE
Data access - 'other' field not being retained - BUG - (OCT-264)

### DIFF
--- a/ui/src/components/Publication/Creation/DataStatements.tsx
+++ b/ui/src/components/Publication/Creation/DataStatements.tsx
@@ -43,12 +43,10 @@ const DataStatements: React.FC = (): React.ReactElement => {
     // Data access statement
     const dataAccessStatement = Stores.usePublicationCreationStore((state) => state.dataAccessStatement);
     const updateDataAccessStatement = Stores.usePublicationCreationStore((state) => state.updateDataAccessStatement);
-    const [dataAccessStatementOther, setDataAccessStatementOther] = React.useState<string | null>('');
-
-    // dataAccessOptions.includes(dataAccessStatement) ? setDataAccessStatementOther(dataAccessStatement);
+    const [dataAccessStatementOther, setDataAccessStatementOther] = React.useState('');
 
     React.useEffect(() => {
-        if (!dataAccessOptions.includes(dataAccessStatement)) {
+        if (!dataAccessOptions.includes(dataAccessStatement) && dataAccessStatement !== null) {
             setDataAccessStatementOther(dataAccessStatement);
         }
     }, []);

--- a/ui/src/components/Publication/Creation/DataStatements.tsx
+++ b/ui/src/components/Publication/Creation/DataStatements.tsx
@@ -43,7 +43,15 @@ const DataStatements: React.FC = (): React.ReactElement => {
     // Data access statement
     const dataAccessStatement = Stores.usePublicationCreationStore((state) => state.dataAccessStatement);
     const updateDataAccessStatement = Stores.usePublicationCreationStore((state) => state.updateDataAccessStatement);
-    const [dataAccessStatementOther, setDataAccessStatementOther] = React.useState('');
+    const [dataAccessStatementOther, setDataAccessStatementOther] = React.useState<string | null>('');
+
+    // dataAccessOptions.includes(dataAccessStatement) ? setDataAccessStatementOther(dataAccessStatement);
+
+    React.useEffect(() => {
+        if (!dataAccessOptions.includes(dataAccessStatement)) {
+            setDataAccessStatementOther(dataAccessStatement);
+        }
+    }, []);
 
     return (
         <div className="space-y-12 2xl:space-y-16">

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -71,7 +71,7 @@ export type PublicationCreationStoreType = {
     ethicalStatementFreeText: string | null;
     updateEthicalStatementFreeText: (ethicalStatementFreeText: string | null) => void;
     updateEthicalStatement: (ethicalStatement: string) => void;
-    dataAccessStatement: string | null;
+    dataAccessStatement: string;
     updateDataAccessStatement: (dataAccessStatement: string | null) => void;
     dataPermissionsStatement: string | null;
     updateDataPermissionsStatemnt: (dataPermissionsStatement: string) => void;


### PR DESCRIPTION
The purpose of this PR was to fix a bug where if a user selects the 'other' the data isn't retained, along with any text the user inputs in the text field, as per this [Jira ticket.](https://jiscdev.atlassian.net/jira/software/projects/OCT/boards/836?selectedIssue=OCT-303)

This was being caused because the text field is being initialised locally as `''` and isn't referencing the global state, so although the data was being retained on the backend, the UI within the build process was giving no feedback that this was the case. I have now amended it so that once the page mounts, we check to see if the dataAccessStatement matches any of the other statements, if not the `other` field is selected and the free text field is populated with the `dataAccessStatement`.


