### PR TITLE
Broken co-author link - (OCT-295) - BUG

### DIFF
--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -71,7 +71,7 @@ export type PublicationCreationStoreType = {
     ethicalStatementFreeText: string | null;
     updateEthicalStatementFreeText: (ethicalStatementFreeText: string | null) => void;
     updateEthicalStatement: (ethicalStatement: string) => void;
-    dataAccessStatement: string | null;
+    dataAccessStatement: string;
     updateDataAccessStatement: (dataAccessStatement: string | null) => void;
     dataPermissionsStatement: string | null;
     updateDataPermissionsStatemnt: (dataPermissionsStatement: string) => void;

--- a/ui/src/pages/publications/[id]/index.tsx
+++ b/ui/src/pages/publications/[id]/index.tsx
@@ -354,7 +354,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                                     coAuthor.user && (
                                         <>
                                             <Components.Link
-                                                href={`${Config.urls.viewUser.path}/${coAuthor.user.orcid}`}
+                                                href={`${Config.urls.viewUser.path}/${coAuthor.linkedUser}`}
                                                 className="2 text-normal mb-8 w-fit rounded leading-relaxed text-teal-600 outline-0 transition-colors duration-500 hover:underline focus:ring-2 focus:ring-yellow-400 dark:text-teal-400"
                                             >
                                                 <>


### PR DESCRIPTION
The purpose of this PR was to fix a broken co author link on the 'view a publication' page. The link was using the user's ORCHID id in the path params for the URL, instead of the `linkedUser` id. I have now amended it so it uses the `linkedUser` id.