### PR TITLE
OCT-332 Change column-width breakpoint for smaller screens

### DIFF
--- a/ui/src/layouts/Publication.tsx
+++ b/ui/src/layouts/Publication.tsx
@@ -18,7 +18,7 @@ const Publication: React.FC<Props> = (props): React.ReactElement => (
                 <Components.PublicationVisulization id={props.publicationId} />
             </div>
         )}
-        <main className="container mx-auto px-8 pb-6 pt-4 lg:grid lg:pb-16 lg:pt-8 xl:grid-cols-12 xl:gap-8 2xl:gap-16">
+        <main className="container mx-auto px-8 pb-6 pt-4 lg:grid lg:grid-cols-12 lg:gap-8 lg:pb-16 lg:pt-8 2xl:gap-16">
             {props.children}
         </main>
         <Components.Footer waves={true} />

--- a/ui/src/pages/publications/[id]/index.tsx
+++ b/ui/src/pages/publications/[id]/index.tsx
@@ -236,7 +236,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                 fixedHeader={false}
                 publicationId={publicationData.type !== 'PEER_REVIEW' ? publicationData.id : undefined}
             >
-                <section className="col-span-9">
+                <section className="col-span-12 lg:col-span-8 xl:col-span-9">
                     {publicationData.currentStatus === 'DRAFT' && (
                         <Components.Alert
                             className="mb-4"
@@ -372,7 +372,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                             </div>
                         )}
 
-                        <div className="block xl:hidden">
+                        <div className="block lg:hidden">
                             {publicationData && <SidebarCard publication={publicationData} sectionList={sectionList} />}
                         </div>
                     </header>
@@ -586,7 +586,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                         </p>
                     </Components.PublicationContentSection>
                 </section>
-                <aside className="relative col-span-3 hidden xl:block">
+                <aside className="relative hidden lg:col-span-4 lg:block xl:col-span-3">
                     <div className="sticky top-12 space-y-8">
                         <SidebarCard publication={publicationData} sectionList={sectionList} />
                     </div>


### PR DESCRIPTION
The purpose of this PR was to change the current breakpoint for Publication page so that SidebarCard component would be visible on smaller screens. Changed from 1280px to 1024px.

---

### Acceptance Criteria:

As per [OCT-332](https://jiscdev.atlassian.net/browse/OCT-332)

### Tests:

---

### Screenshots:
BEFORE
<img width="825" alt="image" src="https://user-images.githubusercontent.com/48569671/185063964-46828d0e-3483-46c0-a601-4ca676378b31.png">


AFTER
<img width="853" alt="image" src="https://user-images.githubusercontent.com/48569671/185063636-4890becc-733e-45e1-9ae8-049b53a56be4.png">

