### PR TITLE
Fix OCT-200 bug where the linked publication buttons aren't displaying when a user views their own publication

### DIFF
--- a/ui/src/components/Publication/SidebarCard/Actions/index.tsx
+++ b/ui/src/components/Publication/SidebarCard/Actions/index.tsx
@@ -176,31 +176,30 @@ const Actions: React.FC<ActionProps> = (props): React.ReactElement => {
                     <span className="ml-1">json</span>
                 </button>
             </div>
-
             {user && user.email ? (
-                props.publication.user.id !== user.id && (
-                    <>
-                        {Helpers.linkedPublicationTypes[
-                            props.publication.type as keyof typeof Helpers.linkedPublicationTypes
-                        ].map((item: any) => {
-                            return (
-                                <Components.PublicationSidebarCardActionsButton
-                                    label={`Write a linked ${Helpers.formatPublicationType(item)}`}
-                                    key={item}
-                                    onClick={() => {
-                                        router.push({
-                                            pathname: `${Config.urls.createPublication.path}`,
-                                            query: {
-                                                for: props.publication.id,
-                                                type: item
-                                            }
-                                        });
-                                    }}
-                                />
-                            );
-                        })}
+                <>
+                    {Helpers.linkedPublicationTypes[
+                        props.publication.type as keyof typeof Helpers.linkedPublicationTypes
+                    ].map((item: any) => {
+                        return (
+                            <Components.PublicationSidebarCardActionsButton
+                                label={`Write a linked ${Helpers.formatPublicationType(item)}`}
+                                key={item}
+                                onClick={() => {
+                                    router.push({
+                                        pathname: `${Config.urls.createPublication.path}`,
+                                        query: {
+                                            for: props.publication.id,
+                                            type: item
+                                        }
+                                    });
+                                }}
+                            />
+                        );
+                    })}
 
-                        {props.publication.type !== 'PEER_REVIEW' && (
+                    {props.publication.type !== 'PEER_REVIEW' && props.publication.user.id !== user.id && (
+                        <>
                             <Components.PublicationSidebarCardActionsButton
                                 label="Write a review"
                                 onClick={() => {
@@ -213,14 +212,14 @@ const Actions: React.FC<ActionProps> = (props): React.ReactElement => {
                                     });
                                 }}
                             />
-                        )}
-
-                        <Components.PublicationSidebarCardActionsButton
-                            label="Flag a concern with this publication"
-                            onClick={() => setShowRedFlagModel(true)}
-                        />
-                    </>
-                )
+                            )
+                            <Components.PublicationSidebarCardActionsButton
+                                label="Flag a concern with this publication"
+                                onClick={() => setShowRedFlagModel(true)}
+                            />
+                        </>
+                    )}
+                </>
             ) : user && !user.email ? (
                 <>
                     <Components.Link

--- a/ui/src/components/Publication/SidebarCard/Actions/index.tsx
+++ b/ui/src/components/Publication/SidebarCard/Actions/index.tsx
@@ -212,7 +212,6 @@ const Actions: React.FC<ActionProps> = (props): React.ReactElement => {
                                     });
                                 }}
                             />
-                            )
                             <Components.PublicationSidebarCardActionsButton
                                 label="Flag a concern with this publication"
                                 onClick={() => setShowRedFlagModel(true)}


### PR DESCRIPTION
The purpose of this PR was to fix undesired behaviour on the [OCT-200 feature ](https://github.com/JiscSD/octopus/pull/220) where the 'Write a linked [relavent publication type]' buttons don't display when a user is accessing their own publication.

I have now amended it so the buttons display on every publication page, provided the user is logged in and has verified their email address.

