### PR TITLE
OCT-348

### DIFF
--- a/api/src/components/authorization/service.ts
+++ b/api/src/components/authorization/service.ts
@@ -14,8 +14,7 @@ export const validateJWT = (token: string) => {
         const decodedJWT = JWT.verify(token, SECRET);
         return decodedJWT as I.User;
     } catch (e) {
-        if (e instanceof JWT.TokenExpiredError) {
-            console.log(e)
-        }
+        console.log(e)
+        return null;
     }
 };

--- a/api/src/components/authorization/service.ts
+++ b/api/src/components/authorization/service.ts
@@ -10,6 +10,12 @@ export const createJWT = (user: I.User): string => {
 };
 
 export const validateJWT = (token: string) => {
-    const decodedJWT = JWT.verify(token, SECRET);
-    return decodedJWT as I.User;
+    try {
+        const decodedJWT = JWT.verify(token, SECRET);
+        return decodedJWT as I.User;
+    } catch (e) {
+        if (e instanceof JWT.TokenExpiredError) {
+            console.log(e)
+        }
+    }
 };

--- a/ui/src/pages/publications/[id]/index.tsx
+++ b/ui/src/pages/publications/[id]/index.tsx
@@ -69,7 +69,7 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
             if (currentUser.id) {
                 const isCoAuthor = publication?.coAuthors.some((author) => author.id == currentUser.id);
                 const isOwner = currentUser.id === publication.createdBy;
-    
+
                 if (!isCoAuthor && !isOwner) {
                     isBookmarkVisible = true;
                 }

--- a/ui/src/pages/publications/[id]/index.tsx
+++ b/ui/src/pages/publications/[id]/index.tsx
@@ -65,13 +65,14 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
     if (token) {
         //check if user is author / co author. if so the bookmark icon won't display
         const currentUser = jwt.decode(token) as any;
-
-        if (currentUser.id) {
-            const isCoAuthor = publication?.coAuthors.some((author) => author.id == currentUser.id);
-            const isOwner = currentUser.id === publication.createdBy;
-
-            if (!isCoAuthor && !isOwner) {
-                isBookmarkVisible = true;
+        if (Date.now() <= currentUser.exp * 1000) {
+            if (currentUser.id) {
+                const isCoAuthor = publication?.coAuthors.some((author) => author.id == currentUser.id);
+                const isOwner = currentUser.id === publication.createdBy;
+    
+                if (!isCoAuthor && !isOwner) {
+                    isBookmarkVisible = true;
+                }
             }
         }
     }


### PR DESCRIPTION
The purpose of this PR was 'fix' issues that were casued by an expired JWT token. This would remove the ability to see the publication visualisation when logged in with an expired token. 

`JWT.decode()` still succesfully decodes a token so have come up with a work around to understand when the token is no longer valid in order to hide the bookmark icon. 

**Logged in with expired token**

![image](https://user-images.githubusercontent.com/69204118/187466080-83806144-6b86-4226-a426-19f430a42cc7.png)
