### PR TITLE
OCT-359 Output display - live and draft publications 

### DIFF
--- a/ui/src/components/Link/index.tsx
+++ b/ui/src/components/Link/index.tsx
@@ -17,7 +17,7 @@ type Props = {
 const CustomLink: React.FC<Props> = (props): React.ReactElement => (
     <Link href={props.href} scroll={props.scroll}>
         <a
-            className={`rounded border-transparent outline-0 focus:overflow-hidden focus:ring-2 focus:ring-yellow-400 ${
+            className={`rounded border-transparent decoration-teal-500 underline-offset-2 outline-0 focus:overflow-hidden focus:ring-2 focus:ring-yellow-400 ${
                 props.className ? props.className : ''
             }`}
             target={props.openNew ? '_blank' : ''}

--- a/ui/src/components/Publication/ContentSection/index.tsx
+++ b/ui/src/components/Publication/ContentSection/index.tsx
@@ -4,7 +4,7 @@ type Props = {
     id: string;
     title?: string;
     hasBreak?: boolean;
-    children: React.ReactChildren | React.ReactChild;
+    children: React.ReactNode;
 };
 
 const ContentSection: React.FC<Props> = (props): React.ReactElement => (

--- a/ui/src/components/Publication/Creation/MainText.tsx
+++ b/ui/src/components/Publication/Creation/MainText.tsx
@@ -197,11 +197,17 @@ const MainText: React.FC = (): React.ReactElement | null => {
                             if (match?.groups?.DOI) {
                                 type = 'DOI';
                                 location = match.groups.DOI;
-                                text = text.replace(match.groups.DOI, '');
+                                text = text.replace(
+                                    match.groups.DOI,
+                                    `<a href="${match.groups.DOI}" target="_blank" rel="noreferrer noopener">${match.groups.DOI}</a>`
+                                );
                             } else if (match?.groups?.URL) {
                                 type = 'URL';
                                 location = match.groups.URL;
-                                text = text.replace(match.groups.URL, '');
+                                text = text.replace(
+                                    match.groups.URL,
+                                    `<a href="${match.groups.URL}" target="_blank" rel="noreferrer noopener">${match.groups.URL}</a>`
+                                );
                             } else {
                                 type = 'TEXT';
                                 location = null;
@@ -320,11 +326,15 @@ const MainText: React.FC = (): React.ReactElement | null => {
                                 <tbody className="divide-y divide-grey-100 bg-white-50 transition-colors duration-500 dark:divide-teal-300 dark:bg-grey-600">
                                     {references.map((reference) => (
                                         <tr key={reference.id}>
-                                            <td className="space-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
-                                                <div dangerouslySetInnerHTML={{ __html: reference.text }}></div>
+                                            <td className="space-nowrap py-4 pl-4 pr-3 text-grey-900 transition-colors duration-500 children:text-sm dark:text-white-50 sm:pl-6">
+                                                <Components.ParseHTML content={reference.text}></Components.ParseHTML>
                                             </td>
                                             <td className="space-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 underline transition-colors duration-500 dark:text-white-50 sm:pl-6">
-                                                <a href={reference.location}>{reference.location}</a>
+                                                {reference.location && (
+                                                    <Components.Link href={reference.location} openNew>
+                                                        {reference.location}
+                                                    </Components.Link>
+                                                )}
                                             </td>
                                             <td className="space-nowrap py-4 px-8 text-center text-sm font-medium text-grey-900 transition-colors duration-500 dark:text-white-50">
                                                 <button

--- a/ui/src/components/Publication/SidebarCard/Actions/Button.tsx
+++ b/ui/src/components/Publication/SidebarCard/Actions/Button.tsx
@@ -9,7 +9,7 @@ const Button: React.FC<Props> = (props): React.ReactElement => (
     <button
         aria-label={props.label}
         onClick={props.onClick}
-        className="flex items-center rounded border-transparent text-sm font-medium text-teal-600 outline-0 transition-colors duration-500 hover:underline focus:overflow-hidden focus:ring-2 focus:ring-yellow-400 dark:text-teal-400"
+        className="flex items-center rounded border-transparent text-left text-sm font-medium text-teal-600 outline-0 transition-colors duration-500 hover:underline focus:overflow-hidden focus:ring-2 focus:ring-yellow-400 dark:text-teal-400"
     >
         {props.label}
     </button>

--- a/ui/src/layouts/BuildPublication.tsx
+++ b/ui/src/layouts/BuildPublication.tsx
@@ -117,6 +117,9 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
             }
 
             await api.patch(`${Config.endpoints.publications}/${props.publication.id}`, body, props.token);
+            /**
+             * @TODO - save references for this publication after OCT-360
+             */
 
             if (message) {
                 setToast({

--- a/ui/src/pages/publications/[id]/index.tsx
+++ b/ui/src/pages/publications/[id]/index.tsx
@@ -103,6 +103,11 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
         (url) => api.get(url, props.userToken || '').then((data) => data.data)
     );
 
+    const { data: references = [] } = useSWR<Interfaces.Reference[]>(
+        `${Config.endpoints.publications}/${props.publicationId}/reference`,
+        (url) => api.get(url, props.userToken).then(({ data }) => data)
+    );
+
     const [coAuthorModalState, setCoAuthorModalState] = React.useState(false);
     const [isBookmarked, setIsBookmarked] = React.useState(props.bookmark ? true : false);
 
@@ -136,6 +141,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
     const sectionList = [
         { title: 'Main text', href: 'main-text' },
         ...list,
+        { title: 'References', href: 'references' },
         { title: 'Funders', href: 'funders' },
         { title: 'Conflict of interest', href: 'coi' }
     ];
@@ -382,6 +388,15 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                         <div className="mb-4">
                             <Components.ParseHTML content={publicationData.content ?? ''} />
                         </div>
+                    </Components.PublicationContentSection>
+
+                    {/* References */}
+                    <Components.PublicationContentSection id="references" title="References" hasBreak>
+                        {references.map((reference) => (
+                            <div key={reference.id} className="py-2">
+                                <Components.ParseHTML content={reference.text} />
+                            </div>
+                        ))}
                     </Components.PublicationContentSection>
 
                     {/* Linked from problems */}


### PR DESCRIPTION
The purpose of this PR was to display the new references on the publication page.

### Acceptance Criteria:

As per [OCT-359](https://jiscdev.atlassian.net/browse/OCT-359)

### Tests:

---

### Screenshots:
BEFORE
<img width="1653" alt="image" src="https://user-images.githubusercontent.com/48569671/188085443-f7930dc7-f690-47af-8e1b-bacde99195ca.png">


AFTER
<img width="1666" alt="image" src="https://user-images.githubusercontent.com/48569671/188085540-f3c7606e-a354-4f5f-a679-792ab59453ec.png">
