### PR TITLE
Unable to publish or preview publications of type "Peer Review" - OCT-377 (BUG)

### DIFF
--- a/ui/src/components/Publication/SidebarCard/Actions/index.tsx
+++ b/ui/src/components/Publication/SidebarCard/Actions/index.tsx
@@ -178,44 +178,48 @@ const Actions: React.FC<ActionProps> = (props): React.ReactElement => {
             </div>
             {user && user.email ? (
                 <>
-                    {Helpers.linkedPublicationTypes[
-                        props.publication.type as keyof typeof Helpers.linkedPublicationTypes
-                    ].map((item: any) => {
-                        return (
-                            <Components.PublicationSidebarCardActionsButton
-                                label={`Write a linked ${Helpers.formatPublicationType(item)}`}
-                                key={item}
-                                onClick={() => {
-                                    router.push({
-                                        pathname: `${Config.urls.createPublication.path}`,
-                                        query: {
-                                            for: props.publication.id,
-                                            type: item
-                                        }
-                                    });
-                                }}
-                            />
-                        );
-                    })}
-
-                    {props.publication.type !== 'PEER_REVIEW' && props.publication.user.id !== user.id && (
+                    {/* if the publication is a peer review, no options shall be given to write a linked publication */}
+                    {props.publication.type !== 'PEER_REVIEW' && (
                         <>
-                            <Components.PublicationSidebarCardActionsButton
-                                label="Write a review"
-                                onClick={() => {
-                                    router.push({
-                                        pathname: `${Config.urls.createPublication.path}`,
-                                        query: {
-                                            for: props.publication.id,
-                                            type: 'PEER_REVIEW'
-                                        }
-                                    });
-                                }}
-                            />
-                            <Components.PublicationSidebarCardActionsButton
-                                label="Flag a concern with this publication"
-                                onClick={() => setShowRedFlagModel(true)}
-                            />
+                            {Helpers.linkedPublicationTypes[
+                                props.publication.type as keyof typeof Helpers.linkedPublicationTypes
+                            ].map((item: any) => {
+                                return (
+                                    <Components.PublicationSidebarCardActionsButton
+                                        label={`Write a linked ${Helpers.formatPublicationType(item)}`}
+                                        key={item}
+                                        onClick={() => {
+                                            router.push({
+                                                pathname: `${Config.urls.createPublication.path}`,
+                                                query: {
+                                                    for: props.publication.id,
+                                                    type: item
+                                                }
+                                            });
+                                        }}
+                                    />
+                                );
+                            })}
+                            {props.publication.user.id !== user.id && (
+                                <>
+                                    <Components.PublicationSidebarCardActionsButton
+                                        label="Write a review"
+                                        onClick={() => {
+                                            router.push({
+                                                pathname: `${Config.urls.createPublication.path}`,
+                                                query: {
+                                                    for: props.publication.id,
+                                                    type: 'PEER_REVIEW'
+                                                }
+                                            });
+                                        }}
+                                    />
+                                    <Components.PublicationSidebarCardActionsButton
+                                        label="Flag a concern with this publication"
+                                        onClick={() => setShowRedFlagModel(true)}
+                                    />
+                                </>
+                            )}
                         </>
                     )}
                 </>


### PR DESCRIPTION
The purpose of this PR was to fix a bug where an error page is being displayed when a user tries to publish a 'Peer Review' publication, as per this [Jira Ticket](https://jiscdev.atlassian.net/browse/OCT-377). 

This error was due to there being no `PEER_REVIEW` key in the `Helpers.LinkedPublication` object, as well as there being no check to see if the publication is a Peer Review before rendering the linked publication button.