### PR TITLE
Draft: OCT-356 Delete reference (single)

### DIFF
--- a/ui/src/components/Publication/Creation/MainText.tsx
+++ b/ui/src/components/Publication/Creation/MainText.tsx
@@ -141,8 +141,8 @@ const MainText: React.FC = (): React.ReactElement | null => {
         references,
         updateReferences
     } = Stores.usePublicationCreationStore();
+    const [selectedReference, setSelectedReference] = useState<Interfaces.Reference | null>(null);
     const [deleteModalVisibility, setDeleteModalVisibility] = React.useState(false);
-    const [selectedReferenceDelete, setSelectedReferenceDelete] = useState<Interfaces.Reference | null>(null);
 
     const addReferences = (editorContent: string) => {
         const paragraphsArray = editorContent.match(/<p>(.*?)<\/p>/g) || [];
@@ -211,12 +211,12 @@ const MainText: React.FC = (): React.ReactElement | null => {
 
     const destroyReference = (id: string) => {
         updateReferences(references.filter((item) => item.id !== id));
-        setSelectedReferenceDelete(null)
+        setSelectedReference(null)
         setDeleteModalVisibility(false);
     };
 
     const handleDeleteReference = (reference: Interfaces.Reference) => {
-        setSelectedReferenceDelete(reference);
+        setSelectedReference(reference);
         setDeleteModalVisibility(true);
     }
 
@@ -227,8 +227,8 @@ const MainText: React.FC = (): React.ReactElement | null => {
                 open={deleteModalVisibility}
                 setOpen={setDeleteModalVisibility}
                 positiveActionCallback={() => {
-                    if(selectedReferenceDelete) {
-                        destroyReference(selectedReferenceDelete.id);                
+                    if(selectedReference) {
+                        destroyReference(selectedReference.id);                
                     }
                 }}
                 positiveButtonText="Delete"

--- a/ui/src/components/Publication/Creation/MainText.tsx
+++ b/ui/src/components/Publication/Creation/MainText.tsx
@@ -6,6 +6,7 @@ import * as OutlineIcons from '@heroicons/react/outline';
 import * as Stores from '@stores';
 import * as Types from '@types';
 import * as tiptap from '@tiptap/react';
+import * as Interfaces from '@interfaces';
 import * as FAIcons from 'react-icons/fa';
 import * as Config from '@config';
 
@@ -140,6 +141,8 @@ const MainText: React.FC = (): React.ReactElement | null => {
         references,
         updateReferences
     } = Stores.usePublicationCreationStore();
+    const [deleteModalVisibility, setDeleteModalVisibility] = React.useState(false);
+    const [selectedReferenceDelete, setSelectedReferenceDelete] = useState<Interfaces.Reference | null>(null);
 
     const addReferences = (editorContent: string) => {
         const paragraphsArray = editorContent.match(/<p>(.*?)<\/p>/g) || [];
@@ -208,143 +211,168 @@ const MainText: React.FC = (): React.ReactElement | null => {
 
     const destroyReference = (id: string) => {
         updateReferences(references.filter((item) => item.id !== id));
+        setSelectedReferenceDelete(null)
+        setDeleteModalVisibility(false);
     };
 
+    const handleDeleteReference = (reference: Interfaces.Reference) => {
+        setSelectedReferenceDelete(reference);
+        setDeleteModalVisibility(true);
+    }
+
+
     return (
-        <div className="space-y-12 2xl:space-y-16">
-            <div>
-                <Components.PublicationCreationStepTitle text="Main text" required />
-                {publicationId && (
-                    <Components.TextEditor
-                        defaultContent={content}
-                        contentChangeHandler={updateContent}
-                        references={references}
-                    />
-                )}
-            </div>
-
-            <div>
-                <Components.PublicationCreationStepTitle text="Language" required />
-                <select
-                    name="language"
-                    id="language"
-                    onChange={(e) => updateLanguage(e.target.value as Types.Languages)}
-                    className="mb-4 block w-full rounded-md border border-grey-100 bg-white-50 text-grey-800 shadow outline-0 focus:ring-2 focus:ring-yellow-400 lg:mb-0 xl:w-1/2"
-                    required
-                    defaultValue={
-                        Config.values.octopusInformation.languages.find((entry) => entry.code === language)?.code ||
-                        'en'
+        <>
+            <Components.Modal
+                open={deleteModalVisibility}
+                setOpen={setDeleteModalVisibility}
+                positiveActionCallback={() => {
+                    if(selectedReferenceDelete) {
+                        destroyReference(selectedReferenceDelete.id);                
                     }
-                >
-                    {Config.values.octopusInformation.languages.map((entry) => (
-                        <option key={entry.code} value={entry.code}>
-                            {entry.name}
-                        </option>
-                    ))}
-                </select>
-            </div>
-
-            <div className="space-y-4">
-                <Components.PublicationCreationStepTitle text="References" />
-                <span className="mb-2 block text-sm leading-snug text-grey-700 transition-colors duration-500 dark:text-white-50">
-                    Include your reference list for this publication. References should be line-separated and include a
-                    DOI or other URL. Once you have added your references, you can create reference links in the main
-                    text editor.
-                </span>
-                <div className="flex flex-col items-end space-y-4">
-                    <AddReferences addReferences={addReferences} />
-                    {references && references.length > 0 && (
-                        <div className="w-full overflow-hidden pt-8 shadow ring-1 ring-black ring-opacity-5 dark:ring-transparent md:rounded-lg">
-                            <table className="min-w-full table-fixed divide-y divide-grey-100 dark:divide-teal-300">
-                                <thead className="bg-grey-50 transition-colors duration-500 dark:bg-grey-700">
-                                    <tr>
-                                        <th className="whitespace-pre py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-grey-900 transition-colors duration-500 dark:text-grey-50 sm:pl-6 ">
-                                            Title
-                                        </th>
-                                        <th className="whitespace-pre py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-grey-900 transition-colors duration-500 dark:text-grey-50 sm:pl-6">
-                                            Location
-                                        </th>
-                                        <th className="whitespace-pre py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-grey-900 transition-colors duration-500 dark:text-grey-50 sm:pl-6 "></th>
-                                    </tr>
-                                </thead>
-                                <tbody className="divide-y divide-grey-100 bg-white-50 transition-colors duration-500 dark:divide-teal-300 dark:bg-grey-600">
-                                    {references.map((reference) => (
-                                        <tr key={reference.id}>
-                                            <td className="space-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 children:text-sm dark:text-white-50 sm:pl-6">
-                                                <Components.ParseHTML
-                                                    content={
-                                                        reference.location
-                                                            ? reference.text.replaceAll(
-                                                                  reference.location,
-                                                                  `<a href="${reference.location}" target="_blank" rel="noreferrer noopener">${reference.location}</a>`
-                                                              )
-                                                            : reference.text
-                                                    }
-                                                ></Components.ParseHTML>
-                                            </td>
-                                            <td className="space-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 underline transition-colors duration-500 dark:text-white-50 sm:pl-6">
-                                                {reference.location && (
-                                                    <Components.Link href={reference.location} openNew>
-                                                        {reference.location}
-                                                    </Components.Link>
-                                                )}
-                                            </td>
-                                            <td className="space-nowrap py-4 px-8 text-center text-sm font-medium text-grey-900 transition-colors duration-500 dark:text-white-50">
-                                                <button
-                                                    onClick={(e) => destroyReference(reference.id)}
-                                                    className="rounded-full"
-                                                >
-                                                    <OutlineIcons.TrashIcon className="h-6 w-6 text-teal-600 transition-colors duration-500 dark:text-teal-400" />
-                                                </button>
-                                            </td>
-                                        </tr>
-                                    ))}
-                                </tbody>
-                            </table>
-                        </div>
+                }}
+                positiveButtonText="Delete"
+                cancelButtonText="Cancel"
+                title="Are you sure you want to delete this reference"
+                icon={<OutlineIcons.TrashIcon className="h-10 w-10 text-grey-600" aria-hidden="true" />}
+            >
+                <p className="text-gray-500 text-sm"> Deleting a reference may affect the accuracy of your reference numbering and in-text references. Are you sure you want to delete this reference? This action cannot be undone. </p>
+            </Components.Modal>
+            <div className="space-y-12 2xl:space-y-16">
+                <div>
+                    <Components.PublicationCreationStepTitle text="Main text" required />
+                    {publicationId && (
+                        <Components.TextEditor
+                            defaultContent={content}
+                            contentChangeHandler={updateContent}
+                            references={references}
+                        />
                     )}
                 </div>
-            </div>
 
-            <div>
-                <Components.PublicationCreationStepTitle text="Short description" />
-                <span className="mb-2 block text-sm leading-snug text-grey-700 transition-colors duration-500 dark:text-white-50">
-                    Include a short description of your publication to aid discovery. This can be no more than 160
-                    characters in length.
-                </span>
-                <textarea
-                    required
-                    rows={3}
-                    maxLength={160}
-                    value={description}
-                    onChange={(e) => updateDescription(e.target.value)}
-                    className="block w-full rounded-md border border-grey-100 bg-white-50 text-grey-800 shadow outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400"
-                />
-                <div className="mt-2 flex justify-end">
-                    <span className="text-xs text-grey-500 dark:text-white-50">{description.length} / 160</span>
+                <div>
+                    <Components.PublicationCreationStepTitle text="Language" required />
+                    <select
+                        name="language"
+                        id="language"
+                        onChange={(e) => updateLanguage(e.target.value as Types.Languages)}
+                        className="mb-4 block w-full rounded-md border border-grey-100 bg-white-50 text-grey-800 shadow outline-0 focus:ring-2 focus:ring-yellow-400 lg:mb-0 xl:w-1/2"
+                        required
+                        defaultValue={
+                            Config.values.octopusInformation.languages.find((entry) => entry.code === language)?.code ||
+                            'en'
+                        }
+                    >
+                        {Config.values.octopusInformation.languages.map((entry) => (
+                            <option key={entry.code} value={entry.code}>
+                                {entry.name}
+                            </option>
+                        ))}
+                    </select>
                 </div>
-            </div>
 
-            <div>
-                <Components.PublicationCreationStepTitle text="Keywords" />
-                <span className="mb-2 block text-sm leading-snug text-grey-700 transition-colors duration-500 dark:text-white-50">
-                    Include up to 10 keywords relating to your content. These can be comma-separated and/or line
-                    separated.
-                </span>
-                <textarea
-                    required
-                    rows={5}
-                    value={keywords}
-                    onChange={(e) => updateKeywords(e.target.value)}
-                    className="block w-full rounded-md border border-grey-100 bg-white-50 text-grey-800 shadow outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400"
-                />
-                <div className="mt-2 flex justify-end">
-                    <span className="text-xs text-grey-500 dark:text-white-50">
-                        {Helpers.formatKeywords(keywords).length} / 10
+                <div className="space-y-4">
+                    <Components.PublicationCreationStepTitle text="References" />
+                    <span className="mb-2 block text-sm leading-snug text-grey-700 transition-colors duration-500 dark:text-white-50">
+                        Include your reference list for this publication. References should be line-separated and include a
+                        DOI or other URL. Once you have added your references, you can create reference links in the main
+                        text editor.
                     </span>
+                    <div className="flex flex-col items-end space-y-4">
+                        <AddReferences addReferences={addReferences} />
+                        {references && references.length > 0 && (
+                            <div className="w-full overflow-hidden pt-8 shadow ring-1 ring-black ring-opacity-5 dark:ring-transparent md:rounded-lg">
+                                <table className="min-w-full table-fixed divide-y divide-grey-100 dark:divide-teal-300">
+                                    <thead className="bg-grey-50 transition-colors duration-500 dark:bg-grey-700">
+                                        <tr>
+                                            <th className="whitespace-pre py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-grey-900 transition-colors duration-500 dark:text-grey-50 sm:pl-6 ">
+                                                Title
+                                            </th>
+                                            <th className="whitespace-pre py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-grey-900 transition-colors duration-500 dark:text-grey-50 sm:pl-6">
+                                                Location
+                                            </th>
+                                            <th className="whitespace-pre py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-grey-900 transition-colors duration-500 dark:text-grey-50 sm:pl-6 "></th>
+                                        </tr>
+                                    </thead>
+                                    <tbody className="divide-y divide-grey-100 bg-white-50 transition-colors duration-500 dark:divide-teal-300 dark:bg-grey-600">
+                                        {references.map((reference) => (
+                                            <tr key={reference.id}>
+                                                <td className="space-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 children:text-sm dark:text-white-50 sm:pl-6">
+                                                    <Components.ParseHTML
+                                                        content={
+                                                            reference.location
+                                                                ? reference.text.replaceAll(
+                                                                    reference.location,
+                                                                    `<a href="${reference.location}" target="_blank" rel="noreferrer noopener">${reference.location}</a>`
+                                                                )
+                                                                : reference.text
+                                                        }
+                                                    ></Components.ParseHTML>
+                                                </td>
+                                                <td className="space-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 underline transition-colors duration-500 dark:text-white-50 sm:pl-6">
+                                                    {reference.location && (
+                                                        <Components.Link href={reference.location} openNew>
+                                                            {reference.location}
+                                                        </Components.Link>
+                                                    )}
+                                                </td>
+                                                <td className="space-nowrap py-4 px-8 text-center text-sm font-medium text-grey-900 transition-colors duration-500 dark:text-white-50">
+                                                    <button
+                                                        onClick={(e) => handleDeleteReference(reference)}
+                                                        className="rounded-full"
+                                                    >
+                                                        <OutlineIcons.TrashIcon className="h-6 w-6 text-teal-600 transition-colors duration-500 dark:text-teal-400" />
+                                                    </button>
+                                                </td>
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </table>
+                            </div>
+                        )}
+                    </div>
+                </div>
+
+                <div>
+                    <Components.PublicationCreationStepTitle text="Short description" />
+                    <span className="mb-2 block text-sm leading-snug text-grey-700 transition-colors duration-500 dark:text-white-50">
+                        Include a short description of your publication to aid discovery. This can be no more than 160
+                        characters in length.
+                    </span>
+                    <textarea
+                        required
+                        rows={3}
+                        maxLength={160}
+                        value={description}
+                        onChange={(e) => updateDescription(e.target.value)}
+                        className="block w-full rounded-md border border-grey-100 bg-white-50 text-grey-800 shadow outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400"
+                    />
+                    <div className="mt-2 flex justify-end">
+                        <span className="text-xs text-grey-500 dark:text-white-50">{description.length} / 160</span>
+                    </div>
+                </div>
+
+                <div>
+                    <Components.PublicationCreationStepTitle text="Keywords" />
+                    <span className="mb-2 block text-sm leading-snug text-grey-700 transition-colors duration-500 dark:text-white-50">
+                        Include up to 10 keywords relating to your content. These can be comma-separated and/or line
+                        separated.
+                    </span>
+                    <textarea
+                        required
+                        rows={5}
+                        value={keywords}
+                        onChange={(e) => updateKeywords(e.target.value)}
+                        className="block w-full rounded-md border border-grey-100 bg-white-50 text-grey-800 shadow outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400"
+                    />
+                    <div className="mt-2 flex justify-end">
+                        <span className="text-xs text-grey-500 dark:text-white-50">
+                            {Helpers.formatKeywords(keywords).length} / 10
+                        </span>
+                    </div>
                 </div>
             </div>
-        </div>
+        </>
     );
 };
 

--- a/ui/src/components/Publication/Creation/MainText.tsx
+++ b/ui/src/components/Publication/Creation/MainText.tsx
@@ -211,15 +211,14 @@ const MainText: React.FC = (): React.ReactElement | null => {
 
     const destroyReference = (id: string) => {
         updateReferences(references.filter((item) => item.id !== id));
-        setSelectedReference(null)
+        setSelectedReference(null);
         setDeleteModalVisibility(false);
     };
 
     const handleDeleteReference = (reference: Interfaces.Reference) => {
         setSelectedReference(reference);
         setDeleteModalVisibility(true);
-    }
-
+    };
 
     return (
         <>
@@ -227,8 +226,8 @@ const MainText: React.FC = (): React.ReactElement | null => {
                 open={deleteModalVisibility}
                 setOpen={setDeleteModalVisibility}
                 positiveActionCallback={() => {
-                    if(selectedReference) {
-                        destroyReference(selectedReference.id);                
+                    if (selectedReference) {
+                        destroyReference(selectedReference.id);
                     }
                 }}
                 positiveButtonText="Delete"
@@ -236,7 +235,11 @@ const MainText: React.FC = (): React.ReactElement | null => {
                 title="Are you sure you want to delete this reference"
                 icon={<OutlineIcons.TrashIcon className="h-10 w-10 text-grey-600" aria-hidden="true" />}
             >
-                <p className="text-gray-500 text-sm"> Deleting a reference may affect the accuracy of your reference numbering and in-text references. Are you sure you want to delete this reference? This action cannot be undone. </p>
+                <p className="text-gray-500 text-sm">
+                    {' '}
+                    Deleting a reference may affect the accuracy of your reference numbering and in-text references. Are
+                    you sure you want to delete this reference? This action cannot be undone.{' '}
+                </p>
             </Components.Modal>
             <div className="space-y-12 2xl:space-y-16">
                 <div>
@@ -274,9 +277,9 @@ const MainText: React.FC = (): React.ReactElement | null => {
                 <div className="space-y-4">
                     <Components.PublicationCreationStepTitle text="References" />
                     <span className="mb-2 block text-sm leading-snug text-grey-700 transition-colors duration-500 dark:text-white-50">
-                        Include your reference list for this publication. References should be line-separated and include a
-                        DOI or other URL. Once you have added your references, you can create reference links in the main
-                        text editor.
+                        Include your reference list for this publication. References should be line-separated and
+                        include a DOI or other URL. Once you have added your references, you can create reference links
+                        in the main text editor.
                     </span>
                     <div className="flex flex-col items-end space-y-4">
                         <AddReferences addReferences={addReferences} />
@@ -302,9 +305,9 @@ const MainText: React.FC = (): React.ReactElement | null => {
                                                         content={
                                                             reference.location
                                                                 ? reference.text.replaceAll(
-                                                                    reference.location,
-                                                                    `<a href="${reference.location}" target="_blank" rel="noreferrer noopener">${reference.location}</a>`
-                                                                )
+                                                                      reference.location,
+                                                                      `<a href="${reference.location}" target="_blank" rel="noreferrer noopener">${reference.location}</a>`
+                                                                  )
                                                                 : reference.text
                                                         }
                                                     ></Components.ParseHTML>

--- a/ui/src/components/Publication/Creation/MainText.tsx
+++ b/ui/src/components/Publication/Creation/MainText.tsx
@@ -236,9 +236,8 @@ const MainText: React.FC = (): React.ReactElement | null => {
                 icon={<OutlineIcons.TrashIcon className="h-10 w-10 text-grey-600" aria-hidden="true" />}
             >
                 <p className="text-gray-500 text-sm">
-                    {' '}
                     Deleting a reference may affect the accuracy of your reference numbering and in-text references. Are
-                    you sure you want to delete this reference? This action cannot be undone.{' '}
+                    you sure you want to delete this reference? This action cannot be undone.
                 </p>
             </Components.Modal>
             <div className="space-y-12 2xl:space-y-16">


### PR DESCRIPTION
The purpose of this PR was to add a modal to confirm that the user wishes to delete a reference and inform them of the consequences in doing so. 

---

### Acceptance Criteria:

- ‘Delete reference’ button available on all reference lines. 
- Opens a confirmation, in modal view : Deleting a reference may affect the accuracy of your reference numbering and in-text references. Are you sure you want to delete this reference? This action cannot be undone. 
- User must confirm Delete or Cancel to close the modal and complete the action. 
- The table updates to remove the reference line. 
- Only one reference can be deleted at a time using this button (see delete all ticket for mass deletion feature).

---

### Screenshots:

![image](https://user-images.githubusercontent.com/69204118/189676003-a225ef32-d7b7-4f32-bb92-6b497cf44f7b.png)


