### PR TITLE
OCT-356 Delete reference (single)

### DIFF
--- a/ui/src/components/Publication/Creation/MainText.tsx
+++ b/ui/src/components/Publication/Creation/MainText.tsx
@@ -8,6 +8,7 @@ import * as Types from '@types';
 import * as Interfaces from '@interfaces';
 import * as FAIcons from 'react-icons/fa';
 import * as Config from '@config';
+import * as Contexts from '@contexts';
 
 import cuid from 'cuid';
 
@@ -66,6 +67,7 @@ const MainText: React.FC = (): React.ReactElement | null => {
         updateReferences
     } = Stores.usePublicationCreationStore();
     const [selectedReference, setSelectedReference] = useState<Interfaces.Reference | null>(null);
+    const confirmation = Contexts.useConfirmationModal();
 
     const addReferences = (editorContent: string) => {
         const paragraphsArray = editorContent.match(/<p>(.*?)<\/p>/g) || [];
@@ -97,6 +99,7 @@ const MainText: React.FC = (): React.ReactElement | null => {
         }
         updateReferences(referencesArray);
     };
+
 
     const destroyReference = (id: string) => {
         updateReferences(references.filter((item) => item.id !== id));
@@ -210,7 +213,18 @@ const MainText: React.FC = (): React.ReactElement | null => {
                                         </td>
                                         <td className="py-4 px-6 text-center text-sm font-medium text-grey-900 transition-colors duration-500 dark:text-white-50">
                                             <button
-                                                onClick={() => destroyReference(reference.id)}
+                                                onClick={async () => {
+                                                    const confirmed = await confirmation(
+                                                        'Deleting a reference may affect the accuracy of your reference numbering and in-text references. Are you sure you want to delete this reference? This action cannot be undone. ',
+                                                        'Are you sure you want to delete this reference?',
+                                                        <OutlineIcons.TrashIcon
+                                                            className='h-10 w-10 text-grey-600'
+                                                            aria-hidden="true"/>
+                                                    )
+                                                    if(confirmed) {
+                                                        destroyReference(reference.id)
+                                                    }
+                                                }}
                                                 className="rounded-full"
                                             >
                                                 <OutlineIcons.TrashIcon className="h-6 w-6 text-teal-600 transition-colors duration-500 dark:text-teal-400" />

--- a/ui/src/components/Publication/Creation/MainText.tsx
+++ b/ui/src/components/Publication/Creation/MainText.tsx
@@ -219,7 +219,8 @@ const MainText: React.FC = (): React.ReactElement | null => {
                                                         <OutlineIcons.TrashIcon
                                                             className="h-10 w-10 text-grey-600"
                                                             aria-hidden="true"
-                                                        />
+                                                        />,
+                                                        'Delete'
                                                     );
                                                     if (confirmed) {
                                                         destroyReference(reference.id);

--- a/ui/src/components/Publication/Creation/MainText.tsx
+++ b/ui/src/components/Publication/Creation/MainText.tsx
@@ -100,7 +100,6 @@ const MainText: React.FC = (): React.ReactElement | null => {
         updateReferences(referencesArray);
     };
 
-
     const destroyReference = (id: string) => {
         updateReferences(references.filter((item) => item.id !== id));
     };
@@ -218,11 +217,12 @@ const MainText: React.FC = (): React.ReactElement | null => {
                                                         'Deleting a reference may affect the accuracy of your reference numbering and in-text references. Are you sure you want to delete this reference? This action cannot be undone. ',
                                                         'Are you sure you want to delete this reference?',
                                                         <OutlineIcons.TrashIcon
-                                                            className='h-10 w-10 text-grey-600'
-                                                            aria-hidden="true"/>
-                                                    )
-                                                    if(confirmed) {
-                                                        destroyReference(reference.id)
+                                                            className="h-10 w-10 text-grey-600"
+                                                            aria-hidden="true"
+                                                        />
+                                                    );
+                                                    if (confirmed) {
+                                                        destroyReference(reference.id);
                                                     }
                                                 }}
                                                 className="rounded-full"


### PR DESCRIPTION
The purpose of this PR was to add a modal to confirm that the user wishes to delete a reference and inform them of the consequences in doing so. 

---

### Acceptance Criteria:

- ‘Delete reference’ button available on all reference lines. 
- Opens a confirmation, in modal view : Deleting a reference may affect the accuracy of your reference numbering and in-text references. Are you sure you want to delete this reference? This action cannot be undone. 
- User must confirm Delete or Cancel to close the modal and complete the action. 
- The table updates to remove the reference line. 
- Only one reference can be deleted at a time using this button (see delete all ticket for mass deletion feature).

---

### Screenshots:

![image](https://user-images.githubusercontent.com/69204118/189676003-a225ef32-d7b7-4f32-bb92-6b497cf44f7b.png)


