### PR TITLE
OCT-338 Pen test: Session Cookie Without Secure Flag

### DIFF
--- a/ui/src/lib/helpers.tsx
+++ b/ui/src/lib/helpers.tsx
@@ -141,7 +141,7 @@ export const randomWholeNumberInRange = (min: number, max: number): number => {
  */
 export const setAndReturnJWT = (token: string) => {
     const expireTime = 8 / 24;
-    Cookies.set(Config.keys.cookieStorage.token, token, { expires: expireTime });
+    Cookies.set(Config.keys.cookieStorage.token, token, { expires: expireTime, secure: true });
     return JWT.decode(token);
 };
 


### PR DESCRIPTION
The purpose of this PR was to add a secure flag to the `production-octopus-token` cookie to resolve the issue raised in the pen testing report.

---

### Acceptance Criteria:

- Cookie ` production-octopus-token` has the secure flag set to: `true`

---