### PR TITLE
OCT-405 '& ' breaks search

### DIFF
--- a/api/src/components/user/service.ts
+++ b/api/src/components/user/service.ts
@@ -1,6 +1,7 @@
 import * as client from 'lib/client';
 
 import * as I from 'interface';
+import * as helpers from 'lib/helpers';
 
 export const upsertUser = async (orcid: string, updateUserInformation: I.UpdateUserInformation) => {
     const user = await client.prisma.user.upsert({
@@ -62,13 +63,14 @@ export const getAll = async (filters: I.UserFilters) => {
     const query = {};
 
     if (filters.search) {
+        const searchQuery = helpers.sanitizeSearchQuery(filters.search);
         // @ts-ignore
         query.where = {
             firstName: {
-                search: filters.search?.replace(/ /gi, '|')
+                search: searchQuery
             },
             lastName: {
-                search: filters.search?.replace(/ /gi, '|')
+                search: searchQuery
             }
         };
     }

--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -364,7 +364,7 @@ export const formatFlagType = (flagType: I.FlagCategory) => {
 
 export function sanitizeSearchQuery(searchQuery: string) {
     return searchQuery
-        .replace(/[+\-*^|/!=<>&~#_%\\]/g, '') // removes any characters which are used as operators or wildcards in postgresql
+        .replace(/[+\-*^|/!=<>()'&~#_%\\]/g, '') // removes any characters which are used as operators or wildcards in postgresql
         .trim()
         .replace(/\s+/g, '|'); // replace whitespace with single OR
 }

--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -361,3 +361,10 @@ export const formatFlagType = (flagType: I.FlagCategory) => {
 
     return types[flagType];
 };
+
+export function sanitizeSearchQuery(searchQuery: string) {
+    return searchQuery
+        .replace(/[+\-*^|/!=<>&~#_%\\]/g, '') // removes any characters which are used as operators or wildcards in postgresql
+        .trim()
+        .replace(/\s+/g, '|'); // replace whitespace with single OR
+}

--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -364,7 +364,7 @@ export const formatFlagType = (flagType: I.FlagCategory) => {
 
 export function sanitizeSearchQuery(searchQuery: string) {
     return searchQuery
-        .replace(/[+\-*^|/!=<>()'&~#_%\\]/g, '') // removes any characters which are used as operators or wildcards in postgresql
         .trim()
+        .replace(/[+\-*^|/!=<>()'&~#_%\\]/g, (match) => '\\' + match) // escape any characters which are used as operators or wildcards in postgresql
         .replace(/\s+/g, '|'); // replace whitespace with single OR
 }

--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -365,6 +365,6 @@ export const formatFlagType = (flagType: I.FlagCategory) => {
 export function sanitizeSearchQuery(searchQuery: string) {
     return searchQuery
         .trim()
-        .replace(/[+\-*^|/!=<>()'&~#_%\\]/g, (match) => '\\' + match) // escape any characters which are used as operators or wildcards in postgresql
+        .replace(/[^a-z0-9\s]/g, (match) => '\\' + match) // escape all the non-alphanumeric characters which may break the search
         .replace(/\s+/g, '|'); // replace whitespace with single OR
 }

--- a/ui/src/components/CommandPalette/index.tsx
+++ b/ui/src/components/CommandPalette/index.tsx
@@ -24,7 +24,7 @@ const CommandPalette: React.FC = (): React.ReactElement | null => {
         data: { data: results = [] } = {},
         error,
         isValidating
-    } = useSWR(`/${searchType}?search=${query}&limit=10`, null, {
+    } = useSWR(`/${searchType}?search=${encodeURIComponent(query)}&limit=10`, null, {
         fallback: {
             '/publications': []
         },

--- a/ui/src/pages/search.tsx
+++ b/ui/src/pages/search.tsx
@@ -72,7 +72,7 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
     const dateFromFormatted = moment.utc(dateFrom);
     const dateToFormatted = moment.utc(dateTo);
 
-    const swrKey = `/${searchType}?search=${query || ''}${
+    const swrKey = `/${searchType}?search=${encodeURIComponent(query || '')}${
         searchType === 'publications' ? `&type=${publicationTypes}` : ''
     }&limit=${limit || '10'}&offset=${offset || '0'}${
         dateFromFormatted.isValid() ? `&dateFrom=${dateFromFormatted.format()}` : ''
@@ -126,7 +126,7 @@ const Search: Types.NextPage<Props> = (props): React.ReactElement => {
     const dateFromFormatted = moment.utc(dateFrom);
     const dateToFormatted = moment.utc(dateTo);
 
-    const swrKey = `/${searchType}?search=${query || ''}${
+    const swrKey = `/${searchType}?search=${encodeURIComponent(query || '')}${
         searchType === 'publications' ? `&type=${publicationTypes}` : ''
     }&limit=${limit || '10'}&offset=${offset || '0'}${
         dateFromFormatted.isValid() ? `&dateFrom=${dateFromFormatted.format()}` : ''

--- a/ui/src/pages/search.tsx
+++ b/ui/src/pages/search.tsx
@@ -440,7 +440,7 @@ const Search: Types.NextPage<Props> = (props): React.ReactElement => {
                             />
                         ) : (
                             <Framer.AnimatePresence>
-                                {!!error && (
+                                {error && (
                                     <Components.Alert
                                         severity="ERROR"
                                         title={error}
@@ -459,7 +459,7 @@ const Search: Types.NextPage<Props> = (props): React.ReactElement => {
                                     />
                                 )}
 
-                                {!error && !isValidating && !!results?.data && (
+                                {!isValidating && results?.data?.length && (
                                     <>
                                         <div className="rounded">
                                             {results.data.map((result: any, index: number) => {

--- a/ui/src/pages/search.tsx
+++ b/ui/src/pages/search.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import useSWR from 'swr';
 import moment from 'moment';
 import Head from 'next/head';
+
 import * as Router from 'next/router';
 import * as Framer from 'framer-motion';
 import * as SolidIcons from '@heroicons/react/solid';
-
 import * as Interfaces from '@interfaces';
 import * as Components from '@components';
 import * as Helpers from '@helpers';
@@ -13,6 +13,13 @@ import * as Layouts from '@layouts';
 import * as Config from '@config';
 import * as Types from '@types';
 import * as api from '@api';
+
+/**
+ *
+ * @TODO - refactor getServerSideProps
+ * 1. remove unnecessary if statements
+ * 2. make sure correct publicationTypes are passed via props
+ */
 
 export const getServerSideProps: Types.GetServerSideProps = async (context) => {
     // defaults to possible query params
@@ -58,7 +65,13 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
         // ensure the value of the seach type is acceptable
         if (searchType === 'publications' || searchType === 'users') {
             try {
-                const response = await api.search(searchType, query, publicationTypes, limit, offset);
+                const response = await api.search(
+                    searchType,
+                    encodeURIComponent(query || ''),
+                    publicationTypes,
+                    limit,
+                    offset
+                );
                 results = response.data;
                 metadata = response.metadata;
                 error = null;
@@ -72,7 +85,7 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
     const dateFromFormatted = moment.utc(dateFrom);
     const dateToFormatted = moment.utc(dateTo);
 
-    const swrKey = `/${searchType}?search=${encodeURIComponent(query || '')}${
+    const swrKey = `/${searchType}?search=${encodeURIComponent((Array.isArray(query) ? query[0] : query) || '')}${
         searchType === 'publications' ? `&type=${publicationTypes}` : ''
     }&limit=${limit || '10'}&offset=${offset || '0'}${
         dateFromFormatted.isValid() ? `&dateFrom=${dateFromFormatted.format()}` : ''


### PR DESCRIPTION
The purpose of this PR was to fix a bug where when the user uses special characters in their search query it breaks the page and returns a 422 error, as per this [Jira ticket](https://jiscdev.atlassian.net/jira/software/projects/OCT/boards/836?selectedIssue=OCT-405). 

This is because the query isn't encoded. I have used `encodeURIComponent()`  to encode the characters but this needs decoding on the backend so the API can interpret the search query.


