### PR TITLE
OCT-373 Email verification page shown after account setup (UPDATE)

### DIFF
--- a/ui/src/pages/login.tsx
+++ b/ui/src/pages/login.tsx
@@ -46,7 +46,7 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
             undefined
         );
         token = response.data as string;
-    } catch (err) {
+    } catch (error) {
         console.log(error);
         return {
             props: {

--- a/ui/src/pages/verify.tsx
+++ b/ui/src/pages/verify.tsx
@@ -135,11 +135,16 @@ const Verify: Types.NextPage<Props> = (props): React.ReactElement => {
                         text={props.newUser ? 'Complete your registration' : 'Update your email address'}
                     />
                     <p className="mb-6 block text-grey-700 transition-colors duration-500 dark:text-grey-50 lg:w-3/4">
-                        Your Octopus account has been created, and is linked to your ORCID® iD. To complete your account
-                        setup, please verify your email address.
-                        <br />
-                        <br />A verified email is required for essential service notifications. We’ll use it as
-                        described in our privacy notice (at{' '}
+                        {props.newUser && (
+                            <>
+                                Your Octopus account has been created, and is linked to your ORCID® iD. To complete your
+                                account setup, please verify your email address.
+                                <br />
+                                <br />
+                            </>
+                        )}
+                        A verified email is required for essential service notifications. We’ll use it as described in
+                        our privacy notice (at{' '}
                         <Components.Link
                             href={Config.urls.privacy.canonical}
                             className="rounded border-transparent underline decoration-teal-500 underline-offset-2 outline-0 focus:overflow-hidden focus:ring-2 focus:ring-yellow-400"


### PR DESCRIPTION
The purpose of this PR was to add conditional rendering for the new text added so that only the users without a verified email will see the updated text: "Your Octopus account has been created..."

---

### Acceptance Criteria:

As per [OCT-373](https://jiscdev.atlassian.net/browse/OCT-373)

### Tests:

---

### Screenshots:
