### PR TITLE
OCT-306 Author search - spurious dot appearing after first name

### DIFF
--- a/ui/src/__tests__/components/Users/SearchResult.test.tsx
+++ b/ui/src/__tests__/components/Users/SearchResult.test.tsx
@@ -25,7 +25,7 @@ describe('Users Search Result', () => {
             />
         );
 
-        expect(screen.getByText(`${firstName}. ${lastName}`)).toBeInTheDocument();
+        expect(screen.getByText(`${firstName} ${lastName}`)).toBeInTheDocument();
     });
 
     it('should display a Letter Avatar like: JD', () => {

--- a/ui/src/components/Users/SearchResult/index.tsx
+++ b/ui/src/components/Users/SearchResult/index.tsx
@@ -48,7 +48,7 @@ const SearchResult: React.FC<Props> = (props): React.ReactElement => (
         >
             <Components.Avatar user={props.user} className="col-span-1 lg:col-span-2" />
             <span className="col-span-6 flex h-full items-center font-medium text-grey-800 transition-colors duration-500 dark:text-white-50">
-                {props.user.firstName}. {props.user?.lastName}
+                {props.user.firstName} {props.user?.lastName}
             </span>
             <div className="relative z-20 col-span-4 flex h-full items-center font-light text-grey-600 transition-colors duration-500 dark:text-grey-100 lg:col-span-3">
                 {props.user.employment


### PR DESCRIPTION
The purpose of this PR was to remove spurious dot appearing on the user search result

---

### Acceptance Criteria:

As per [OCT-306](https://jiscdev.atlassian.net/browse/OCT-306)

--- 

### Tests:

Updated /ui/src/__tests__/Users/SearchResult.test.tsx

---

### Screenshots:
BEFORE
![image](https://user-images.githubusercontent.com/48569671/201952311-03fa76ee-7116-47e8-84f5-dc505f2622fc.png)

AFTER
![image](https://user-images.githubusercontent.com/48569671/201952366-508583a9-1f2a-45bb-8e6f-650317211e40.png)
