### PR TITLE
OCT-441 Author Browse returning all publications and failing with Science Octopus

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -19,6 +19,7 @@
         "start:local": "nodemon --config nodemon.json",
         "seed:local": "STAGE=local npx prisma migrate reset --force",
         "test:local": "STAGE=local jest --runInBand --testTimeout=60000",
+        "test:watch": "npm run test:local -- --watch",
         "format:check": "npx prettier --check src/",
         "format:write": "npx prettier --write src/",
         "lint": "eslint src/"

--- a/api/prisma/seeds/index.ts
+++ b/api/prisma/seeds/index.ts
@@ -5,7 +5,5 @@ export { default as publicationsDevSeedData } from './publicationsDevSeedData';
 export { default as bookmarkedPublicationSeeds } from './bookmarkedPublications';
 export { default as problems } from './problems';
 export { default as referencesSeedData } from './references';
-
-
 export { default as usersProdSeedData } from './usersProdSeedData';
 export { default as problemsProd } from './problemsProd';

--- a/api/prisma/seeds/users.ts
+++ b/api/prisma/seeds/users.ts
@@ -71,6 +71,33 @@ const userSeeds = [
         email: 'test-user-7@jisc.ac.uk',
         locked: false,
         apiKey: '000000007'
+    },
+    {
+        id: 'test-user-8',
+        orcid: '0000-0000-0000-0008',
+        firstName: 'Test',
+        lastName: 'CoAuthor 4',
+        email: 'test-user-8@jisc.ac.uk',
+        locked: false,
+        apiKey: '000000008'
+    },
+    {
+        id: 'test-user-9',
+        orcid: '0000-0000-0000-0009',
+        firstName: 'Test',
+        lastName: 'CoAuthor 5',
+        email: 'test-user-9@jisc.ac.uk',
+        locked: false,
+        apiKey: '000000009'
+    },
+    {
+        id: 'test-user-10',
+        orcid: '0000-0000-0000-0010',
+        firstName: 'Test',
+        lastName: 'CoAuthor 6',
+        email: 'test-user-10@jisc.ac.uk',
+        locked: false,
+        apiKey: '000000010'
     }
 ];
 

--- a/api/src/components/user/__tests__/getUsers.test.ts
+++ b/api/src/components/user/__tests__/getUsers.test.ts
@@ -1,0 +1,60 @@
+import * as testUtils from 'lib/testUtils';
+import * as I from 'lib/interface';
+
+describe('Get Users', () => {
+    beforeEach(async () => {
+        await testUtils.clearDB();
+        await testUtils.testSeed();
+    });
+
+    test('Get all users', async () => {
+        const response = await testUtils.agent.get('/users?limit=100');
+        expect(response.status).toEqual(200);
+        expect(response.body.data.length).toEqual(11);
+        expect(response.body.metadata.total).toEqual(11);
+    });
+
+    test('Get first 10 users if "limit" param is not provided', async () => {
+        const response = await testUtils.agent.get('/users');
+        expect(response.status).toEqual(200);
+        expect(response.body.data.length).toEqual(10); // default limit is 10
+        expect(response.body.metadata.total).toEqual(11);
+    });
+
+    test('Get first 2 users', async () => {
+        const response = await testUtils.agent.get('/users?limit=2');
+        expect(response.status).toEqual(200);
+        expect(response.body.data.length).toEqual(2);
+        expect(response.body.metadata.total).toEqual(11);
+    });
+
+    test('Get first 2 users which have their first or last name "Test"', async () => {
+        const response = await testUtils.agent.get('/users?limit=2&search=Test');
+        expect(response.status).toEqual(200);
+        expect(response.body.data.length).toEqual(2);
+        expect(response.body.data.every((user: I.User) => `${user.firstName} ${user.lastName}`.includes('Test'))).toBe(
+            true
+        );
+        expect(response.body.metadata.total).toEqual(10);
+    });
+
+    test('Get "Science Octopus" user by searching for "Science"', async () => {
+        const response = await testUtils.agent.get('/users?search=Science');
+        expect(response.status).toEqual(200);
+        expect(response.body.data.length).toEqual(1);
+        const user = response.body.data[0];
+        expect(`${user.firstName} ${user.lastName}`).toEqual('Science Octopus');
+    });
+
+    test('Returns no user if searching for incomplete firstName/lastName', async () => {
+        const testResponse1 = await testUtils.agent.get('/users?search=Sci');
+        expect(testResponse1.status).toEqual(200);
+        expect(testResponse1.body.data.length).toEqual(0);
+        expect(testResponse1.body.metadata.total).toEqual(0);
+
+        const testResponse2 = await testUtils.agent.get('/users?search=Te');
+        expect(testResponse2.status).toEqual(200);
+        expect(testResponse2.body.data.length).toEqual(0);
+        expect(testResponse2.body.metadata.total).toEqual(0);
+    });
+});

--- a/api/src/components/user/service.ts
+++ b/api/src/components/user/service.ts
@@ -89,19 +89,7 @@ export const getAll = async (filters: I.UserFilters) => {
             firstName: true,
             lastName: true,
             orcid: true,
-            employment: true,
-            Publication: {
-                select: {
-                    id: true,
-                    title: true,
-                    type: true,
-                    description: true,
-                    keywords: true
-                },
-                where: {
-                    currentStatus: 'LIVE'
-                }
-            }
+            employment: true
         }
     });
 


### PR DESCRIPTION
The purpose of this PR was to remove unnecessary response load when searching for users

---

### Acceptance Criteria:

As per [OCT-441](https://jiscdev.atlassian.net/browse/OCT-441)

### Tests:

  Get Users
    ✓ Get all users (896 ms)
    ✓ Get first 10 users if "limit" param is not provided (688 ms)
    ✓ Get first 2 users (681 ms)
    ✓ Get first 2 users which have their first or last name "Test" (677 ms)
    ✓ Get "Science Octopus" user by searching for "Science" (666 ms)
    ✓ Returns no user if searching for incomplete firstName/lastName (1129 ms)

---

### Screenshots:
