### PR TITLE
OCT-451 Upgrade postgres (12.12)

### DIFF
--- a/infra/create-app/int.tfvars
+++ b/infra/create-app/int.tfvars
@@ -2,7 +2,7 @@ domain_name = "int.octopus.ac"
 
 allocated_storage       = 50
 instance                = "db.m5.large"
-db_version              = "12.5"
+db_version              = "12.12"
 backup_retention_period = 1
 
 elasticsearch_instance_size = "t3.small.elasticsearch"

--- a/infra/create-app/prod.tfvars
+++ b/infra/create-app/prod.tfvars
@@ -2,7 +2,7 @@ domain_name = "octopus.ac"
 
 allocated_storage       = 50
 instance                = "db.m5.large"
-db_version              = "12.5"
+db_version              = "12.12"
 backup_retention_period = 35
 
 elasticsearch_instance_size = "t3.medium.elasticsearch"

--- a/infra/modules/postgres/main.tf
+++ b/infra/modules/postgres/main.tf
@@ -49,6 +49,8 @@ resource "aws_db_instance" "rds" {
   db_subnet_group_name    = aws_db_subnet_group.database_subnet.name
 
   auto_minor_version_upgrade = false
+  allow_major_version_upgrade = true
+  apply_immediately = true
 
 
   tags = {


### PR DESCRIPTION
The purpose of this PR was to upgrade postgres to version 12.12 for straight upgrade to 14.5.

---

### Acceptance Criteria:
Per [OCT-451](https://jiscdev.atlassian.net/browse/OCT-451?atlOrigin=eyJpIjoiNjEwZTVmNGI2YTQyNGM1NDlkYzQyNWExZWQ4MTg3ZmYiLCJwIjoiaiJ9)
