### PR TITLE
OCT-296 Latest publications not showing in order

### DIFF
--- a/api/src/components/publication/schema/getAll.ts
+++ b/api/src/components/publication/schema/getAll.ts
@@ -1,6 +1,6 @@
 import * as I from 'interface';
 
-const getAllSchema: I.Schema = {
+const getAllSchema: I.JSONSchemaType<I.PublicationFilters> = {
     type: 'object',
     properties: {
         type: {
@@ -18,18 +18,33 @@ const getAllSchema: I.Schema = {
             default: 0
         },
         search: {
-            type: 'string'
+            type: 'string',
+            nullable: true
         },
         exclude: {
-            type: 'string'
+            type: 'string',
+            nullable: true
         },
         dateFrom: {
-            type: 'string'
+            type: 'string',
+            nullable: true
         },
         dateTo: {
-            type: 'string'
+            type: 'string',
+            nullable: true
+        },
+        orderBy: {
+            type: 'string',
+            enum: ['publishedDate'],
+            nullable: true
+        },
+        orderDirection: {
+            type: 'string',
+            enum: ['asc', 'desc'],
+            nullable: true
         }
     },
+    required: [],
     additionalProperties: false
 };
 

--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -237,12 +237,20 @@ export const createOpenSearchRecord = async (data: I.OpenSearchPublication) => {
 };
 
 export const getOpenSearchRecords = async (filters: I.PublicationFilters) => {
+    const orderBy = filters.orderBy
+        ? {
+              [filters.orderBy]: {
+                  order: filters.orderDirection || 'asc'
+              }
+          }
+        : null;
+
     const query = {
         index: 'publications',
         body: {
             from: filters.offset,
             size: filters.limit,
-            sort: ['_score'],
+            sort: [orderBy || '_score'],
             query: {
                 bool: {
                     filter: {
@@ -282,14 +290,16 @@ export const getOpenSearchRecords = async (filters: I.PublicationFilters) => {
         });
     }
 
-    must.push({
-        range: {
-            publishedDate: {
-                gte: filters.dateFrom,
-                lte: filters.dateTo
+    if (filters.dateFrom || filters.dateTo) {
+        must.push({
+            range: {
+                publishedDate: {
+                    gte: filters.dateFrom,
+                    lte: filters.dateTo
+                }
             }
-        }
-    });
+        });
+    }
 
     // @ts-ignore
     query.body.query.bool.must = must;

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -136,12 +136,14 @@ export type OrderDirection = 'asc' | 'desc';
 
 export interface PublicationFilters {
     search?: string;
-    limit?: string;
-    offset?: string;
+    limit: number;
+    offset: number;
     type: string;
     exclude?: string;
     dateFrom?: string;
     dateTo?: string;
+    orderBy?: PublicationOrderBy;
+    orderDirection?: OrderDirection;
 }
 
 export type PublicationWithMetadata = Prisma.PromiseReturnType<typeof publicationService.get>;

--- a/e2e/tests/LoggedIn/browse.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/browse.e2e.spec.ts
@@ -1,28 +1,37 @@
-import { expect, test } from '@playwright/test';
-import * as Helpers from '../helpers';
-import { PageModel } from '../PageModel';
+import { expect, test } from "@playwright/test";
+import * as Helpers from "../helpers";
+import { PageModel } from "../PageModel";
 
-test.describe('Browse', () => {
-    test('Browse contents', async ({ browser }) => {
-        // Start up test
-        const page = await browser.newPage();
+test.describe("Browse", () => {
+  test("Browse contents", async ({ browser }) => {
+    // Start up test
+    const page = await browser.newPage();
 
-        // Login
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(`${Helpers.ORCID_TEST_NAME}`);
+    // Login
+    await page.goto(Helpers.UI_BASE);
+    await Helpers.login(page);
+    await expect(page.locator(PageModel.header.usernameButton)).toHaveText(
+      `${Helpers.ORCID_TEST_NAME}`
+    );
 
-        // Navigate to browse page
-        await page.locator(PageModel.header.browseButton).click();
+    // Navigate to browse page
+    await page.locator(PageModel.header.browseButton).click();
 
-        // Check links
-        await expect(page.locator(PageModel.browse.viewAllPublications)).toHaveAttribute(
-            'href',
-            '/search?for=publications&type=PROBLEM,HYPOTHESIS,PROTOCOL,DATA,ANALYSIS,INTERPRETATION,REAL_WORLD_APPLICATION,PEER_REVIEW'
-        );
-        await expect(page.locator(PageModel.browse.viewAllAuthors)).toHaveAttribute('href', '/search?for=users');
+    // Check links
+    await expect(
+      page.locator(PageModel.browse.viewAllPublications)
+    ).toHaveAttribute(
+      "href",
+      "/search/publications?type=PROBLEM,HYPOTHESIS,PROTOCOL,DATA,ANALYSIS,INTERPRETATION,REAL_WORLD_APPLICATION,PEER_REVIEW"
+    );
+    await expect(page.locator(PageModel.browse.viewAllAuthors)).toHaveAttribute(
+      "href",
+      "/search/authors"
+    );
 
-        // Expect 5 cards
-        await expect(page.locator(PageModel.browse.card).locator('visible=true')).toHaveCount(5);
-    });
+    // Expect 5 cards
+    await expect(
+      page.locator(PageModel.browse.card).locator("visible=true")
+    ).toHaveCount(5);
+  });
 });

--- a/e2e/tests/LoggedOut/browse.e2e.spec.ts
+++ b/e2e/tests/LoggedOut/browse.e2e.spec.ts
@@ -15,11 +15,11 @@ test.describe("Browse", () => {
       page.locator(PageModel.browse.viewAllPublications)
     ).toHaveAttribute(
       "href",
-      "/search?for=publications&type=PROBLEM,HYPOTHESIS,PROTOCOL,DATA,ANALYSIS,INTERPRETATION,REAL_WORLD_APPLICATION,PEER_REVIEW"
+      "/search/publications?type=PROBLEM,HYPOTHESIS,PROTOCOL,DATA,ANALYSIS,INTERPRETATION,REAL_WORLD_APPLICATION,PEER_REVIEW"
     );
     await expect(page.locator(PageModel.browse.viewAllAuthors)).toHaveAttribute(
       "href",
-      "/search?for=users"
+      "/search/authors"
     );
 
     // Expect 5 cards

--- a/ui/src/components/Publication/Card/index.tsx
+++ b/ui/src/components/Publication/Card/index.tsx
@@ -32,9 +32,7 @@ const Card: React.FC<Props> = (props): React.ReactElement => (
                     <>
                         <Components.Link href={`${Config.urls.viewUser.path}/${props.publication.user.id}`}>
                             <>
-                                {props.publication.user.firstName ? `${props.publication.user.firstName[0]}.` : ''}
-                                &nbsp;
-                                {props.publication.user.lastName}
+                                {props.publication.user.firstName[0]}. {props.publication.user.lastName}
                             </>
                         </Components.Link>{' '}
                         <a href={`https://orcid.org/${props.publication.user.orcid}`} target="_blank" rel="noreferrer">

--- a/ui/src/components/Publication/Card/index.tsx
+++ b/ui/src/components/Publication/Card/index.tsx
@@ -32,7 +32,9 @@ const Card: React.FC<Props> = (props): React.ReactElement => (
                     <>
                         <Components.Link href={`${Config.urls.viewUser.path}/${props.publication.user.id}`}>
                             <>
-                                {props.publication.user.firstName[0]}. {props.publication.user.lastName}
+                                {props.publication.user.firstName ? `${props.publication.user.firstName[0]}.` : ''}
+                                &nbsp;
+                                {props.publication.user.lastName}
                             </>
                         </Components.Link>{' '}
                         <a href={`https://orcid.org/${props.publication.user.orcid}`} target="_blank" rel="noreferrer">
@@ -46,7 +48,7 @@ const Card: React.FC<Props> = (props): React.ReactElement => (
                     {Helpers.formatPublicationType(props.publication.type)}
                 </span>
                 <time className="text-xs font-medium tracking-wide text-grey-800 transition-colors duration-500 dark:text-grey-100">
-                    {Helpers.formatDate(props.publication.createdAt)}
+                    {Helpers.formatDate(props.publication.publishedDate)}
                 </time>
             </div>
         </div>

--- a/ui/src/pages/browse.tsx
+++ b/ui/src/pages/browse.tsx
@@ -4,44 +4,27 @@ import Head from 'next/head';
 import * as OutlineIcons from '@heroicons/react/outline';
 
 import * as Components from '@components';
-import * as Interfaces from '@interfaces';
 import * as Layouts from '@layouts';
 import * as Helpers from '@helpers';
 import * as Config from '@config';
 import * as Types from '@types';
 import * as api from '@api';
 
-interface Errors {
-    latest: null | string;
-}
-
 export const getServerSideProps: Types.GetServerSideProps = async (context) => {
-    const swrKey = `/publications?search&type=${Config.values.publicationTypes.join()}&limit=5&offset=0`;
-
-    const errors: Errors = {
-        latest: null
-    };
+    const swrKey = `/publications?limit=5&orderBy=publishedDate&orderDirection=desc`;
 
     let latest: unknown = [];
     let metadata: unknown = {};
     try {
-        const latestResponse = await api.search<Interfaces.Publication>(
-            'publications',
-            null,
-            5,
-            0,
-            Config.values.publicationTypes.join()
-        );
-        latest = latestResponse.data.reverse();
-        metadata = latestResponse.metadata;
-    } catch (err) {
-        const { message } = err as Interfaces.JSONResponseError;
-        errors.latest = message;
+        const latestResponse = await api.get(swrKey, undefined);
+        latest = latestResponse.data.data;
+        metadata = latestResponse.data.metadata;
+    } catch (error) {
+        // couldn't load the latest publications
     }
 
     return {
         props: {
-            errors,
             swrKey,
             fallback: {
                 [swrKey]: {
@@ -56,7 +39,6 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
 };
 
 type Props = {
-    errors: Errors;
     swrKey: string;
 };
 


### PR DESCRIPTION
The purpose of this PR was to fix /browse page not showing latest publications

---

### Acceptance Criteria:

As per [OCT-296](https://jiscdev.atlassian.net/browse/OCT-296)

### Tests:

Fixed e2e tests for /browse page

---

### Screenshots:

BEFORE
![image](https://user-images.githubusercontent.com/48569671/210513754-4413d3a7-2592-4c5e-8dc0-4aa152f193e8.png)



AFTER
![image](https://user-images.githubusercontent.com/48569671/210513196-67af3592-d76c-48d7-8261-914399ca7bf3.png)


[OCT-296]: https://jiscdev.atlassian.net/browse/OCT-296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OCT-296]: https://jiscdev.atlassian.net/browse/OCT-296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ