### PR TITLE
OCT-472 <strong> tag displayed in ethical statement

### DIFF
--- a/ui/src/pages/publications/[id]/index.tsx
+++ b/ui/src/pages/publications/[id]/index.tsx
@@ -508,11 +508,11 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                         <Components.PublicationContentSection id="ethical-statement" title="Ethical statement" hasBreak>
                             <>
                                 <p className="block text-grey-800 transition-colors duration-500 dark:text-white-50">
-                                    {publicationData.ethicalStatement}
+                                    {parse(publicationData.ethicalStatement)}
                                 </p>
                                 {!!publicationData.ethicalStatementFreeText && (
                                     <p className="mt-4 block text-sm text-grey-700 transition-colors duration-500 dark:text-white-100">
-                                        {publicationData.ethicalStatementFreeText}
+                                        {parse(publicationData.ethicalStatementFreeText)}
                                     </p>
                                 )}
                             </>
@@ -532,7 +532,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                                 </p>
                                 {publicationData.dataPermissionsStatementProvidedBy?.length && (
                                     <p className="mt-4 block text-sm text-grey-700 transition-colors duration-500 dark:text-white-100">
-                                        {publicationData.dataPermissionsStatementProvidedBy}
+                                        {parse(publicationData.dataPermissionsStatementProvidedBy)}
                                     </p>
                                 )}
                             </>
@@ -547,7 +547,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                             hasBreak
                         >
                             <p className="block text-grey-800 transition-colors duration-500 dark:text-white-50">
-                                {publicationData.dataAccessStatement}
+                                {parse(publicationData.dataAccessStatement)}
                             </p>
                         </Components.PublicationContentSection>
                     )}
@@ -637,7 +637,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                                 ) : null}
                                 {publicationData.fundersStatement ? (
                                     <p className="block pt-2 leading-relaxed text-grey-800 transition-colors duration-500 dark:text-grey-100">
-                                        {publicationData.fundersStatement}
+                                        {parse(publicationData.fundersStatement)}
                                     </p>
                                 ) : null}
                             </>


### PR DESCRIPTION
The purpose of this PR was to fix "statements" html text not rendering correctly on the publication page

---

### Acceptance Criteria:

As per [OCT-472](https://jiscdev.atlassian.net/browse/OCT-472)

### Tests:

---

### Screenshots:

BEFORE
![image](https://user-images.githubusercontent.com/48569671/210527984-6caaba58-c745-4ab1-9a32-85e6b61d1d06.png)


AFTER
![image](https://user-images.githubusercontent.com/48569671/210527936-430e6a60-18c5-4f47-bbd2-ff4fc7f7f4c3.png)


[OCT-472]: https://jiscdev.atlassian.net/browse/OCT-472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OCT-472]: https://jiscdev.atlassian.net/browse/OCT-472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ