### PR TITLE
OCT-277 Preview page - remove restrictions

### DIFF
--- a/ui/src/components/Button/index.tsx
+++ b/ui/src/components/Button/index.tsx
@@ -62,7 +62,7 @@ const Button: React.FC<Props> = (props): React.ReactElement | null => {
         >
             <>
                 {props.startIcon}
-                <span className={childStyles}>{props.title}</span>
+                <span className={childStyles}>{props.children || props.title}</span>
                 {props.endIcon}
             </>
         </Components.Link>
@@ -77,7 +77,7 @@ const Button: React.FC<Props> = (props): React.ReactElement | null => {
             className={`rounded border-transparent outline-0 focus:overflow-hidden focus:ring-2 focus:ring-yellow-400 ${parentStyles}`}
         >
             {props.startIcon}
-            <span className={childStyles}>{props.title}</span>
+            <span className={childStyles}>{props.children || props.title}</span>
             {props.endIcon}
         </button>
     );

--- a/ui/src/components/IconButton/index.tsx
+++ b/ui/src/components/IconButton/index.tsx
@@ -4,34 +4,21 @@ type IconButtonProps = {
     className?: string;
     disabled?: boolean;
     icon: React.ReactElement;
-    title?: string;
+    title: string;
     onClick?: () => void;
 };
 
-const IconButton: React.FC<IconButtonProps> = (props) =>
-    props.title ? (
-        <Components.Tooltip message={props.title}>
-            <button
-                disabled={props.disabled}
-                className={`${
-                    props.className ? props.className : ''
-                } font-lg flex items-center p-1 text-teal-500 outline-none transition-colors duration-500 focus:rounded focus:ring-2 focus:ring-yellow-400 disabled:opacity-50 disabled:hover:cursor-not-allowed`}
-                onClick={props.onClick}
-                aria-label={props.title}
-            >
-                {props.icon}
-            </button>
-        </Components.Tooltip>
-    ) : (
-        <button
-            disabled={props.disabled}
-            className={`${
-                props.className ? props.className : ''
-            } font-lg flex items-center p-1 text-teal-500 outline-none transition-colors duration-500 focus:rounded focus:ring-2 focus:ring-yellow-400 disabled:opacity-50 disabled:hover:cursor-not-allowed`}
-            onClick={props.onClick}
-        >
-            {props.icon}
-        </button>
-    );
+const IconButton: React.FC<IconButtonProps> = (props) => (
+    <button
+        title={props.title}
+        disabled={props.disabled}
+        className={`${
+            props.className ? props.className : ''
+        } font-lg flex items-center p-1 text-teal-500 outline-none transition-colors duration-500 focus:rounded focus:ring-2 focus:ring-yellow-400 disabled:opacity-50 disabled:hover:cursor-not-allowed`}
+        onClick={props.onClick}
+    >
+        {props.icon}
+    </button>
+);
 
 export default IconButton;

--- a/ui/src/components/Publication/Creation/Review.tsx
+++ b/ui/src/components/Publication/Creation/Review.tsx
@@ -1,15 +1,21 @@
 import React from 'react';
-import * as OutlineIcons from '@heroicons/react/outline';
 
+import * as OutlineIcons from '@heroicons/react/outline';
 import * as Components from '@components';
 import * as Stores from '@stores';
 import * as Config from '@config';
+import * as Helpers from '@helpers';
 
 const CompletedIcon = () => (
     <OutlineIcons.BadgeCheckIcon className="absolute right-1 top-1 z-10 h-6 w-6 bg-teal-50 text-teal-500 transition-colors duration-500 dark:bg-grey-800" />
 );
+
 const IncompleteIcon = () => (
     <OutlineIcons.ExclamationCircleIcon className="absolute right-1 top-1 z-10 h-6 w-6 bg-teal-50 text-yellow-600 transition-colors duration-500 dark:bg-grey-800 dark:text-yellow-500" />
+);
+
+const MandatoryIcon = () => (
+    <OutlineIcons.ExclamationCircleIcon className="absolute right-1 top-1 z-10 h-6 w-6 bg-teal-50 text-red-600 transition-colors duration-500 dark:bg-grey-800 dark:text-red-500" />
 );
 
 /**
@@ -50,7 +56,7 @@ const Review: React.FC = (): React.ReactElement => {
                     <span className="block font-montserrat text-xl text-grey-800 transition-colors duration-500 dark:text-white-50">
                         Title
                     </span>
-                    {title.length ? <CompletedIcon /> : <IncompleteIcon />}
+                    {title.trim() ? <CompletedIcon /> : <MandatoryIcon />}
                 </div>
 
                 <div className="relative">
@@ -86,7 +92,7 @@ const Review: React.FC = (): React.ReactElement => {
                     <span className="block font-montserrat text-xl text-grey-800 transition-colors duration-500 dark:text-white-50">
                         Full text
                     </span>
-                    {content.length > 7 ? <CompletedIcon /> : <IncompleteIcon />}
+                    {!Helpers.isEmptyContent(content) ? <CompletedIcon /> : <MandatoryIcon />}
                 </div>
 
                 {type === Config.values.octopusInformation.publications.DATA.id && (

--- a/ui/src/layouts/BuildPublication.tsx
+++ b/ui/src/layouts/BuildPublication.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useMemo, useState } from 'react';
 import * as Router from 'next/router';
 import * as ReactIconsFA from 'react-icons/fa';
 import * as OutlineIcons from '@heroicons/react/outline';
-
 import * as Interfaces from '@interfaces';
 import * as Types from '@types';
 import * as Components from '@components';
@@ -211,7 +210,15 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
         }
     }, [props.publication?.id, router, saveCurrent, store]);
 
-    const isReadyToPreview = useMemo(() => checkRequired(store).ready, [checkRequired, store]);
+    const isReadyToPreview = useMemo(
+        () => Boolean(store.title.trim()) && !Helpers.isEmptyContent(store.content),
+        [store.content, store.title]
+    );
+
+    const isReadyToPublish = useMemo(
+        () => isReadyToPreview && checkRequired(store).ready,
+        [checkRequired, isReadyToPreview, store]
+    );
 
     return (
         <>
@@ -222,7 +229,7 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
                 positiveButtonText="Save"
                 cancelButtonText="Cancel"
                 title="Are you sure you want to save your changes?"
-                icon={<OutlineIcons.SaveIcon className="h-10 w-10 text-grey-600" aria-hidden="true" />}
+                icon={<ReactIconsFA.FaRegSave className="h-8 w-8 text-grey-600" aria-hidden="true" />}
             >
                 <p className="text-gray-500 text-sm">
                     Changes to your publication will be saved and it will be stored as a draft.
@@ -351,19 +358,32 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
                                 <>
                                     <div className="flex gap-4">
                                         <Components.Button
-                                            title="Preview"
+                                            title={
+                                                isReadyToPreview
+                                                    ? 'Preview'
+                                                    : 'Publication must contain a title and main text before previewing'
+                                            }
                                             onClick={handlePreview}
                                             disabled={!isReadyToPreview}
                                             endIcon={<OutlineIcons.EyeIcon className="text-white-500 h-5 w-5" />}
                                             className="rounded border-2 border-transparent bg-teal-600 px-2.5 text-white-50 shadow-sm focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 children:border-0 children:text-white-50"
-                                        />
+                                        >
+                                            Preview
+                                        </Components.Button>
+
                                         <Components.Button
-                                            title="Publish"
+                                            title={
+                                                isReadyToPublish
+                                                    ? 'Publish'
+                                                    : 'All sections must be completed before publishing'
+                                            }
                                             onClick={() => setPublishModalVisibility(true)}
-                                            disabled={!isReadyToPreview}
+                                            disabled={!isReadyToPublish}
                                             endIcon={<OutlineIcons.CloudUploadIcon className="h-5 w-5 text-white-50" />}
                                             className="rounded border-2 border-transparent bg-teal-600 px-2.5 text-white-50 shadow-sm focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 children:border-0 children:text-white-50"
-                                        />
+                                        >
+                                            Publish
+                                        </Components.Button>
                                         <Components.Button
                                             title="Save"
                                             onClick={() => setSaveModalVisibility(true)}
@@ -401,13 +421,21 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
                                         <Components.IconButton
                                             icon={<OutlineIcons.EyeIcon className="h-5 w-5" />}
                                             disabled={!isReadyToPreview}
-                                            title="Preview"
+                                            title={
+                                                isReadyToPreview
+                                                    ? 'Preview'
+                                                    : 'Publication must contain a title and main text before previewing'
+                                            }
                                             onClick={handlePreview}
                                         />
                                         <Components.IconButton
-                                            title="Publish"
+                                            title={
+                                                isReadyToPublish
+                                                    ? 'Publish'
+                                                    : 'All sections must be completed before publishing'
+                                            }
                                             icon={<OutlineIcons.CloudUploadIcon className="h-5 w-5" />}
-                                            disabled={!isReadyToPreview}
+                                            disabled={!isReadyToPublish}
                                             onClick={() => setPublishModalVisibility(true)}
                                         />
                                         <Components.IconButton
@@ -484,34 +512,54 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
                             xl ? (
                                 <>
                                     <Components.Button
-                                        title="Preview"
+                                        title={
+                                            isReadyToPreview
+                                                ? 'Preview'
+                                                : 'Publication must contain a title and main text before previewing'
+                                        }
                                         disabled={!isReadyToPreview}
                                         endIcon={<OutlineIcons.EyeIcon className="text-white-500 h-5 w-5" />}
                                         className="rounded border-2 border-transparent bg-teal-600 px-2.5 text-white-50 shadow-sm focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 children:border-0 children:text-white-50"
                                         onClick={handlePreview}
-                                    />
+                                    >
+                                        Preview
+                                    </Components.Button>
 
                                     <Components.Button
+                                        title={
+                                            isReadyToPublish
+                                                ? 'Publish'
+                                                : 'All sections must be completed before publishing'
+                                        }
                                         className="rounded border-2 border-transparent bg-teal-600 px-2.5 text-white-50 shadow-sm focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 children:border-0 children:text-white-50"
-                                        disabled={!isReadyToPreview}
+                                        disabled={!isReadyToPublish}
                                         endIcon={<OutlineIcons.CloudUploadIcon className="h-5 w-5 text-white-50" />}
-                                        title="Publish"
                                         onClick={() => setPublishModalVisibility(true)}
-                                    />
+                                    >
+                                        Publish
+                                    </Components.Button>
                                 </>
                             ) : (
                                 <>
                                     <Components.IconButton
                                         disabled={!isReadyToPreview}
                                         icon={<OutlineIcons.EyeIcon className="h-5 w-5" />}
-                                        title="Preview"
+                                        title={
+                                            isReadyToPreview
+                                                ? 'Preview'
+                                                : 'Publication must contain a title and main text before previewing'
+                                        }
                                         onClick={handlePreview}
                                     />
 
                                     <Components.IconButton
-                                        disabled={!isReadyToPreview}
+                                        disabled={!isReadyToPublish}
                                         icon={<OutlineIcons.CloudUploadIcon className="h-5 w-5" />}
-                                        title="Publish"
+                                        title={
+                                            isReadyToPublish
+                                                ? 'Publish'
+                                                : 'All sections must be completed before publishing'
+                                        }
                                         onClick={() => setPublishModalVisibility(true)}
                                     />
                                 </>

--- a/ui/src/lib/helpers.tsx
+++ b/ui/src/lib/helpers.tsx
@@ -337,3 +337,5 @@ export const getFullDOIsStrings = (text: string) =>
 export const getDOIsFromText = (text: string) => text.match(/(10\.[0-9a-zA-Z]+\/(?:(?!["&\'])\S)+)\b/g) || [];
 
 export const validateDOI = (value: string) => /(10\.[0-9a-zA-Z]+\/(?:(?!["&\'])\S)+)\b/.test(value);
+
+export const isEmptyContent = (content: string) => !content || /<p>\s*<\/p>/.test(content);


### PR DESCRIPTION
The purpose of this PR was to change "Preview" button restrictions to allow users to preview a draft publication after they filled the title and the main text of it

---

### Acceptance Criteria:

As per [OCT-277](https://jiscdev.atlassian.net/browse/OCT-277)

---

### Tests:

---

### Screenshots:

![image](https://user-images.githubusercontent.com/48569671/210782622-57fc9b83-6bdf-42d8-9a53-df908e800925.png)

![image](https://user-images.githubusercontent.com/48569671/210782735-10736adc-a49c-4ecc-bc23-bc89c3cc46e9.png)

![image](https://user-images.githubusercontent.com/48569671/210782889-be5e28e6-a42e-4064-889e-38222804773d.png)

![image](https://user-images.githubusercontent.com/48569671/210782944-a5e1b086-c44f-48bc-8f9a-28218369d70c.png)



[OCT-277]: https://jiscdev.atlassian.net/browse/OCT-277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ