### PR TITLE
OCT-448 Publication Search back button behaviour

### DIFF
--- a/api/src/components/image/service.ts
+++ b/api/src/components/image/service.ts
@@ -5,7 +5,10 @@ import * as I from 'interface';
 
 const config = {
     region: 'eu-west-1',
-    endpoint: process.env.STAGE === 'local' ? `http://${process.env.LOCALSTACK_SERVER}:4566` : 'https://s3.eu-west-1.amazonaws.com',
+    endpoint:
+        process.env.STAGE === 'local'
+            ? `http://${process.env.LOCALSTACK_SERVER}:4566`
+            : 'https://s3.eu-west-1.amazonaws.com',
     s3ForcePathStyle: true
 };
 

--- a/e2e/tests/LoggedIn/search.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/search.e2e.spec.ts
@@ -28,3 +28,25 @@ test.describe("Search", () => {
     );
   });
 });
+
+test.describe('Search term is persisted in URL query string', () => {
+    test('Partial search term search', async ({browser}) => {
+        // Start up test
+        const page = await browser.newPage();
+        await page.goto(Helpers.UI_BASE);
+
+        // search and expect URL query string to contain search text
+        await Helpers.search(page, 'evolved');
+        await expect(page).toHaveURL(/.*query=evolved*/)
+
+        // get path of first publication, navigate to first publication, expect URL to contain path
+        const firstPublication = page.locator(PageModel.search.firstPublication);
+        const firstPublicationPath = await firstPublication.getAttribute('href');
+        await firstPublication.click();
+        await expect(page).toHaveURL(`${Helpers.UI_BASE}${firstPublicationPath}`);
+
+        // click browser back btn, expect URL query string to still contain search text
+        await page.goBack();
+        await expect(page).toHaveURL(/.*query=evolved*/)
+    })
+});

--- a/e2e/tests/LoggedIn/search.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/search.e2e.spec.ts
@@ -1,6 +1,6 @@
-import { expect, test } from "@playwright/test";
-import * as Helpers from "../helpers";
-import { PageModel } from "../PageModel";
+import { expect, test } from '@playwright/test';
+import * as helpers from '../helpers';
+import { PageModel } from '../PageModel';
 
 test.describe("Search", () => {
   test("Full publication title search", async ({ browser }) => {
@@ -8,14 +8,14 @@ test.describe("Search", () => {
     const page = await browser.newPage();
 
     // Login
-    await page.goto(Helpers.UI_BASE);
-    await Helpers.login(page, browser);
+    await page.goto(helpers.UI_BASE);
+    await helpers.login(page, browser);
     await expect(page.locator(PageModel.header.usernameButton)).toHaveText(
-      `${Helpers.ORCID_TEST_NAME}`
+      `${helpers.ORCID_TEST_NAME}`
     );
 
     // search and check result
-    await Helpers.search(
+    await helpers.search(
       page,
       "How has life on earth evolved?",
       PageModel.search.publicationSearchResult
@@ -33,20 +33,42 @@ test.describe('Search term is persisted in URL query string', () => {
     test('Partial search term search', async ({browser}) => {
         // Start up test
         const page = await browser.newPage();
-        await page.goto(Helpers.UI_BASE);
+        await page.goto(helpers.UI_BASE);
 
         // search and expect URL query string to contain search text
-        await Helpers.search(page, 'evolved');
-        await expect(page).toHaveURL(/.*query=evolved*/)
+        await helpers.search(page, PageModel.search.searchTerm);
+        await expect(page).toHaveURL(new RegExp(`query=${PageModel.search.searchTerm}`));
 
-        // get path of first publication, navigate to first publication, expect URL to contain path
-        const firstPublication = page.locator(PageModel.search.firstPublication);
-        const firstPublicationPath = await firstPublication.getAttribute('href');
-        await firstPublication.click();
-        await expect(page).toHaveURL(`${Helpers.UI_BASE}${firstPublicationPath}`);
-
-        // click browser back btn, expect URL query string to still contain search text
+        // navigate to first publication (expect URL to contain path) click browser 'back'
+        await helpers.clickFirstPublication(page);
         await page.goBack();
-        await expect(page).toHaveURL(/.*query=evolved*/)
+
+        await expect(page).toHaveURL(new RegExp(`query=${PageModel.search.searchTerm}`));
     })
+});
+
+test.describe('dateTo and dateFrom fields are persisted in URL query string', () => {
+    test('dateTo and dateFrom in query string', async ({browser}) => {
+        // Start up test
+        const page = await browser.newPage();
+        await page.goto(helpers.UI_BASE);
+        await page.locator(PageModel.header.searchButton).click();
+
+        //select dateFrom & dateTo
+        const dateFromInput = page.locator(PageModel.search.dateFromInput);
+        const dateToInput = page.locator(PageModel.search.dateToInput);
+
+        await dateFromInput.fill(PageModel.search.dateFrom);
+        await dateToInput.fill(PageModel.search.dateTo);
+
+        // expect dateFrom/dateTo input and URL to match selections
+        await helpers.testDateInput(page, dateFromInput, dateToInput);
+
+        // navigate to first publication (expect URL to contain path) click browser 'back'
+        await helpers.clickFirstPublication(page);
+        await page.goBack();
+
+        // expect dateFrom/dateTo input and URL to match selections
+        await helpers.testDateInput(page, dateFromInput, dateToInput);
+    });
 });

--- a/e2e/tests/PageModel.ts
+++ b/e2e/tests/PageModel.ts
@@ -74,6 +74,7 @@ export const PageModel = {
     publicationSearchResult:
       'a[href="/publications/cl3fz14dr0001es6i5ji51rq4"]',
     noPublicationsFound: '_react=Alert[title = "No results found"]',
+    firstPublication: 'article div div:nth-child(1) > a.rounded',
   },
   livePublication: {
     visibleSections: [

--- a/e2e/tests/PageModel.ts
+++ b/e2e/tests/PageModel.ts
@@ -75,6 +75,11 @@ export const PageModel = {
       'a[href="/publications/cl3fz14dr0001es6i5ji51rq4"]',
     noPublicationsFound: '_react=Alert[title = "No results found"]',
     firstPublication: 'article div div:nth-child(1) > a.rounded',
+    searchTerm: 'evolved',
+    dateToInput: 'input#date-to',
+    dateFromInput: 'input#date-from',
+    dateFrom: '2021-01-01',
+    dateTo: '2023-01-01',
   },
   livePublication: {
     visibleSections: [

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -99,6 +99,7 @@ export const search = async (
     `Search results for ${searchTerm}`
   );
 
+  // if (publicationSearchResult passed in) expect its href anchor to be visible
   publicationSearchResult && await expect(page.locator(publicationSearchResult)).toBeVisible();
 };
 

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -86,7 +86,7 @@ export const selectFirstPublication = async (
 export const search = async (
   page: Page,
   searchTerm: string,
-  publicationSearchResult: string
+  publicationSearchResult?: string
 ) => {
   // Navigate to search page
   await page.locator(PageModel.header.searchButton).click();
@@ -98,7 +98,8 @@ export const search = async (
   await expect(page.locator("h1")).toHaveText(
     `Search results for ${searchTerm}`
   );
-  await expect(page.locator(publicationSearchResult)).toBeVisible();
+
+  publicationSearchResult && await expect(page.locator(publicationSearchResult)).toBeVisible();
 };
 
 export const checkLivePublicationLayout = async (

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -1,5 +1,5 @@
-import { Browser, expect, Page } from "@playwright/test";
-import { PageModel } from "./PageModel";
+import { Browser, expect, Locator, Page} from '@playwright/test';
+import {PageModel} from './PageModel';
 
 export const ORCID_TEST_USER = process.env.ORCID_TEST_USER;
 export const ORCID_TEST_PASS = process.env.ORCID_TEST_PASS;
@@ -37,7 +37,7 @@ export const login = async (page: Page, browser: Browser) => {
 
   // check if email verification is required
   const needsEmailVerification =
-    (await page.title()) === "Complete your registration";
+      (await page.title()) === "Complete your registration";
 
   if (needsEmailVerification) {
     await page.fill("#email", ORCID_TEST_USER);
@@ -55,9 +55,9 @@ export const login = async (page: Page, browser: Browser) => {
     await newPage.goto(`http://localhost:8025/`);
     await newPage.getByText("Verify your Octopus account").first().click();
     const verificationCode = await newPage
-      .frameLocator("iframe")
-      .locator("p.code")
-      .textContent();
+        .frameLocator("iframe")
+        .locator("p.code")
+        .textContent();
 
     // close new tab
     await newPage.close();
@@ -76,17 +76,17 @@ export const logout = async (page: Page) => {
 };
 
 export const selectFirstPublication = async (
-  page: Page,
-  type: string = "PROBLEM"
+    page: Page,
+    type: string = "PROBLEM"
 ) => {
   await page.goto(`${UI_BASE}/search?for=publications&type=${type}`);
   await page.locator(`article`).first().click();
 };
 
 export const search = async (
-  page: Page,
-  searchTerm: string,
-  publicationSearchResult?: string
+    page: Page,
+    searchTerm: string,
+    publicationSearchResult?: string
 ) => {
   // Navigate to search page
   await page.locator(PageModel.header.searchButton).click();
@@ -96,7 +96,7 @@ export const search = async (
   await page.keyboard.type(searchTerm);
   await page.keyboard.press("Enter");
   await expect(page.locator("h1")).toHaveText(
-    `Search results for ${searchTerm}`
+      `Search results for ${searchTerm}`
   );
 
   // if (publicationSearchResult passed in) expect its href anchor to be visible
@@ -104,9 +104,9 @@ export const search = async (
 };
 
 export const checkLivePublicationLayout = async (
-  page: Page,
-  id: string,
-  loggedIn?: boolean
+    page: Page,
+    id: string,
+    loggedIn?: boolean
 ) => {
   // Go to live publication page
   await page.goto(`${UI_BASE}/publications/${id}`, {
@@ -117,24 +117,41 @@ export const checkLivePublicationLayout = async (
   // Check visualisation, content, linked problems, funders, conflict of interest sections
   for (const visibleSection of PageModel.livePublication.visibleSections) {
     await expect(
-      page.locator(`${visibleSection}`).locator("visible=true")
+        page.locator(`${visibleSection}`).locator("visible=true")
     ).toBeVisible();
   }
 
   // Expect DOI link
   await expect(page.locator(PageModel.livePublication.doiLink)).toHaveAttribute(
-    "href",
-    `https://doi.org/10.82259/${id}`
+      "href",
+      `https://doi.org/10.82259/${id}`
   );
 
   if (loggedIn) {
     // Confirm review link
     await page
-      .locator(PageModel.livePublication.writeReview)
-      .locator("visible=true")
-      .click();
+        .locator(PageModel.livePublication.writeReview)
+        .locator("visible=true")
+        .click();
     await expect(page).toHaveURL(
-      `${UI_BASE}/create?for=${id}&type=PEER_REVIEW`
+        `${UI_BASE}/create?for=${id}&type=PEER_REVIEW`
     );
   }
 };
+
+export const clickFirstPublication = async (page: Page): Promise<void> => {
+  const firstPublication = page.locator(PageModel.search.firstPublication);
+  const firstPublicationPath = await firstPublication.getAttribute('href');
+  await firstPublication.click();
+
+  // expect URL to contain publication path
+  await expect(page).toHaveURL(`${UI_BASE}${firstPublicationPath}`);
+}
+
+export const testDateInput = async (page: Page, dateFromInput: Locator, dateToInput: Locator): Promise<void> => {
+  await expect(dateFromInput).toHaveAttribute('value', PageModel.search.dateFrom);
+  await expect(dateToInput).toHaveAttribute('value', PageModel.search.dateTo);
+
+  await expect(page).toHaveURL(new RegExp(`dateFrom=${PageModel.search.dateFrom}`));
+  await expect(page).toHaveURL(new RegExp(`dateTo=${PageModel.search.dateTo}`));
+}

--- a/ui/src/pages/search/publications/index.tsx
+++ b/ui/src/pages/search/publications/index.tsx
@@ -155,20 +155,23 @@ const PublicationSearch: Types.NextPage<Props> = (props): React.ReactElement => 
         setQuery(searchTerm);
     };
 
-    const handlerDateFormSubmit = async (e: React.SyntheticEvent) => {
-        e.preventDefault();
+    const handlerDateFormSubmit = async (e: React.ChangeEvent<HTMLInputElement>, name: string) => {
+        //TODO - check this date is persisted then logic for dateTo & dateFrom
+        const date = e.target.value;
 
         await router.push(
             {
                 query: {
                     ...router.query,
-                    dateTo,
+                    dateTo: date,
                     dateFrom
                 }
             },
             undefined,
-            { shallow: true }
+            {shallow: true}
         );
+
+        setDateTo(date);
     };
 
     const collatePublicationTypes = async (e: React.ChangeEvent<HTMLInputElement>, value: string) => {
@@ -191,7 +194,9 @@ const PublicationSearch: Types.NextPage<Props> = (props): React.ReactElement => 
         setPublicationTypes(uniqueArray ? uniqueArray : Config.values.publicationTypes.join(','));
     };
 
-    const resetFilters = (e: React.MouseEvent<HTMLButtonElement>) => {
+    const resetFilters = async () => {
+        await router.replace(router.route);
+
         setQuery('');
         searchInputRef.current && (searchInputRef.current.value = '');
         setOffset(0);
@@ -201,9 +206,14 @@ const PublicationSearch: Types.NextPage<Props> = (props): React.ReactElement => 
         setDateTo('');
     };
 
-    React.useEffect(() => {
+    React.useEffect((): void => {
         setOffset(0);
-    }, [query, publicationTypes, limit]);
+    }, [query, publicationTypes, limit, dateTo]);
+
+    //TODO - remove when date set working
+    // React.useEffect((): void => {
+    //     void handlerDateFormSubmit();
+    // }, [dateFrom, dateTo]);
 
     return (
         <>
@@ -345,7 +355,7 @@ const PublicationSearch: Types.NextPage<Props> = (props): React.ReactElement => 
                                         name="date-form"
                                         id="date-form"
                                         className="col-span-12 lg:col-span-3 xl:col-span-4"
-                                        onSubmit={handlerDateFormSubmit}
+                                        // onSubmit={handlerDateFormSubmit}
                                         initial={{ opacity: 0 }}
                                         animate={{ opacity: 1 }}
                                         exit={{ opacity: 0 }}
@@ -365,7 +375,9 @@ const PublicationSearch: Types.NextPage<Props> = (props): React.ReactElement => 
                                                 className="w-full rounded-md border border-grey-200 px-4 py-2 outline-none focus:ring-2 focus:ring-yellow-500 disabled:opacity-70"
                                                 disabled={isValidating}
                                                 value={dateFrom}
-                                                onChange={(e) => setDateFrom(e.target.value)}
+                                                onChange={ (e) => {
+                                                    setDateFrom(e.target.value)
+                                                }}
                                             />
                                         </label>
                                         <label htmlFor="date-to" className="relative block w-full">
@@ -380,7 +392,7 @@ const PublicationSearch: Types.NextPage<Props> = (props): React.ReactElement => 
                                                 className="w-full rounded-md border border-grey-200 px-4 py-2 outline-none focus:ring-2 focus:ring-yellow-500 disabled:opacity-70"
                                                 disabled={isValidating}
                                                 value={dateTo}
-                                                onChange={(e) => setDateTo(e.target.value)}
+                                                onChange={(e) => handlerDateFormSubmit(e, 'dateTo')}
                                             />
                                         </label>
                                     </Framer.motion.form>

--- a/ui/src/pages/search/publications/index.tsx
+++ b/ui/src/pages/search/publications/index.tsx
@@ -137,7 +137,9 @@ const PublicationSearch: Types.NextPage<Props> = (props): React.ReactElement => 
 
     const { data: { data: results = [] } = {}, error, isValidating } = useSWR(swrKey);
 
-    const handlerSearchFormSubmit: React.ReactEventHandler<HTMLFormElement> = async (e: React.SyntheticEvent<HTMLFormElement, Event>): Promise<void> => {
+    const handlerSearchFormSubmit: React.ReactEventHandler<HTMLFormElement> = async (
+        e: React.SyntheticEvent<HTMLFormElement, Event>
+    ): Promise<void> => {
         e.preventDefault();
         const searchTerm = searchInputRef.current?.value || '';
 
@@ -145,7 +147,7 @@ const PublicationSearch: Types.NextPage<Props> = (props): React.ReactElement => 
             {
                 query: {
                     ...router.query,
-                    query: searchTerm,
+                    query: searchTerm
                 }
             },
             undefined,
@@ -173,7 +175,7 @@ const PublicationSearch: Types.NextPage<Props> = (props): React.ReactElement => 
                 }
             },
             undefined,
-            {shallow: true}
+            { shallow: true }
         );
 
         setDate(newDate);
@@ -189,7 +191,7 @@ const PublicationSearch: Types.NextPage<Props> = (props): React.ReactElement => 
             {
                 query: {
                     ...router.query,
-                    type: uniqueArray,
+                    type: uniqueArray
                 }
             },
             undefined,
@@ -213,7 +215,7 @@ const PublicationSearch: Types.NextPage<Props> = (props): React.ReactElement => 
 
     React.useEffect((): void => {
         setOffset(0);
-    }, [query, publicationTypes, limit, dateTo]);
+    }, [query, publicationTypes, limit]);
 
     return (
         <>

--- a/ui/src/pages/search/publications/index.tsx
+++ b/ui/src/pages/search/publications/index.tsx
@@ -137,7 +137,7 @@ const PublicationSearch: Types.NextPage<Props> = (props): React.ReactElement => 
 
     const { data: { data: results = [] } = {}, error, isValidating } = useSWR(swrKey);
 
-    const handlerSearchFormSubmit: React.ReactEventHandler<HTMLFormElement> = async (e) => {
+    const handlerSearchFormSubmit: React.ReactEventHandler<HTMLFormElement> = async (e: React.SyntheticEvent<HTMLFormElement, Event>): Promise<void> => {
         e.preventDefault();
         const searchTerm = searchInputRef.current?.value || '';
 
@@ -155,7 +155,7 @@ const PublicationSearch: Types.NextPage<Props> = (props): React.ReactElement => 
         setQuery(searchTerm);
     };
 
-    const handlerDateFormSubmit = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const handlerDateFormSubmit = async (e: React.ChangeEvent<HTMLInputElement>): Promise<void> => {
         e.preventDefault();
         const newDate = e.target.value;
 
@@ -179,7 +179,7 @@ const PublicationSearch: Types.NextPage<Props> = (props): React.ReactElement => 
         setDate(newDate);
     };
 
-    const collatePublicationTypes = async (e: React.ChangeEvent<HTMLInputElement>, value: string) => {
+    const collatePublicationTypes = async (e: React.ChangeEvent<HTMLInputElement>, value: string): Promise<void> => {
         const current = publicationTypes ? publicationTypes.split(',') : [];
         const uniqueSet = new Set(current);
         e.target.checked ? uniqueSet.add(value) : uniqueSet.delete(value);
@@ -199,7 +199,7 @@ const PublicationSearch: Types.NextPage<Props> = (props): React.ReactElement => 
         setPublicationTypes(uniqueArray ? uniqueArray : Config.values.publicationTypes.join(','));
     };
 
-    const resetFilters = async () => {
+    const resetFilters = async (): Promise<void> => {
         await router.replace(router.route);
 
         setQuery('');
@@ -214,11 +214,6 @@ const PublicationSearch: Types.NextPage<Props> = (props): React.ReactElement => 
     React.useEffect((): void => {
         setOffset(0);
     }, [query, publicationTypes, limit, dateTo]);
-
-    //TODO - remove when date set working
-    // React.useEffect((): void => {
-    //     void handlerDateFormSubmit();
-    // }, [dateFrom, dateTo]);
 
     return (
         <>
@@ -360,7 +355,6 @@ const PublicationSearch: Types.NextPage<Props> = (props): React.ReactElement => 
                                         name="date-form"
                                         id="date-form"
                                         className="col-span-12 lg:col-span-3 xl:col-span-4"
-                                        // onSubmit={handlerDateFormSubmit}
                                         initial={{ opacity: 0 }}
                                         animate={{ opacity: 1 }}
                                         exit={{ opacity: 0 }}

--- a/ui/src/pages/search/publications/index.tsx
+++ b/ui/src/pages/search/publications/index.tsx
@@ -126,8 +126,6 @@ const PublicationSearch: Types.NextPage<Props> = (props): React.ReactElement => 
     const [limit, setLimit] = React.useState(props.limit ? parseInt(props.limit, 10) : 10);
     const [offset, setOffset] = React.useState(props.offset ? parseInt(props.offset, 10) : 0);
 
-    // ugly complex swr key
-
     const dateFromFormatted = moment.utc(dateFrom);
     const dateToFormatted = moment.utc(dateTo);
 
@@ -142,13 +140,25 @@ const PublicationSearch: Types.NextPage<Props> = (props): React.ReactElement => 
     const handlerSearchFormSubmit: React.ReactEventHandler<HTMLFormElement> = async (e) => {
         e.preventDefault();
         const searchTerm = searchInputRef.current?.value || '';
+
+        await router.push(
+            {
+                query: {
+                    ...router.query,
+                    query: searchTerm,
+                }
+            },
+            undefined,
+            { shallow: true }
+        );
+
         setQuery(searchTerm);
     };
 
     const handlerDateFormSubmit = async (e: React.SyntheticEvent) => {
         e.preventDefault();
 
-        router.push(
+        await router.push(
             {
                 query: {
                     ...router.query,
@@ -161,15 +171,22 @@ const PublicationSearch: Types.NextPage<Props> = (props): React.ReactElement => 
         );
     };
 
-    const collatePublicationTypes = (e: React.ChangeEvent<HTMLInputElement>, value: string) => {
+    const collatePublicationTypes = async (e: React.ChangeEvent<HTMLInputElement>, value: string) => {
         const current = publicationTypes ? publicationTypes.split(',') : [];
         const uniqueSet = new Set(current);
         e.target.checked ? uniqueSet.add(value) : uniqueSet.delete(value);
         const uniqueArray = Array.from(uniqueSet).join(',');
 
-        router.push({ pathname: '/search/publications', query: { type: uniqueArray } }, undefined, {
-            shallow: true
-        });
+        await router.push(
+            {
+                query: {
+                    ...router.query,
+                    type: uniqueArray,
+                }
+            },
+            undefined,
+            { shallow: true }
+        );
 
         setPublicationTypes(uniqueArray ? uniqueArray : Config.values.publicationTypes.join(','));
     };

--- a/ui/src/pages/search/publications/index.tsx
+++ b/ui/src/pages/search/publications/index.tsx
@@ -155,15 +155,20 @@ const PublicationSearch: Types.NextPage<Props> = (props): React.ReactElement => 
         setQuery(searchTerm);
     };
 
-    const handlerDateFormSubmit = async (e: React.ChangeEvent<HTMLInputElement>, name: string) => {
-        //TODO - check this date is persisted then logic for dateTo & dateFrom
-        const date = e.target.value;
+    const handlerDateFormSubmit = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        e.preventDefault();
+        const newDate = e.target.value;
+
+        const [dateFrom, dateTo, setDate] =
+            e.target.getAttribute('id') === 'date-from'
+                ? [newDate, router.query.dateTo, setDateFrom]
+                : [router.query.dateFrom, newDate, setDateTo];
 
         await router.push(
             {
                 query: {
                     ...router.query,
-                    dateTo: date,
+                    dateTo,
                     dateFrom
                 }
             },
@@ -171,7 +176,7 @@ const PublicationSearch: Types.NextPage<Props> = (props): React.ReactElement => 
             {shallow: true}
         );
 
-        setDateTo(date);
+        setDate(newDate);
     };
 
     const collatePublicationTypes = async (e: React.ChangeEvent<HTMLInputElement>, value: string) => {
@@ -375,9 +380,7 @@ const PublicationSearch: Types.NextPage<Props> = (props): React.ReactElement => 
                                                 className="w-full rounded-md border border-grey-200 px-4 py-2 outline-none focus:ring-2 focus:ring-yellow-500 disabled:opacity-70"
                                                 disabled={isValidating}
                                                 value={dateFrom}
-                                                onChange={ (e) => {
-                                                    setDateFrom(e.target.value)
-                                                }}
+                                                onChange={(e) => handlerDateFormSubmit(e)}
                                             />
                                         </label>
                                         <label htmlFor="date-to" className="relative block w-full">
@@ -392,7 +395,7 @@ const PublicationSearch: Types.NextPage<Props> = (props): React.ReactElement => 
                                                 className="w-full rounded-md border border-grey-200 px-4 py-2 outline-none focus:ring-2 focus:ring-yellow-500 disabled:opacity-70"
                                                 disabled={isValidating}
                                                 value={dateTo}
-                                                onChange={(e) => handlerDateFormSubmit(e, 'dateTo')}
+                                                onChange={(e) => handlerDateFormSubmit(e)}
                                             />
                                         </label>
                                     </Framer.motion.form>


### PR DESCRIPTION
The purpose of this PR was...

Correct browser back button functionality when viewing filtered publications

### Acceptance Criteria:

When on a publication page accessed from filtered search results clicking browser back button returns user to those search results NOT a fresh blank search. 

### Tests:

e2e tests added to check that search term query and date query is persisted in URL after clicking a publication then clicking browser back btn:



### Screenshots:
