### PR TITLE
OCT-488 Image size issue in emails

### DIFF
--- a/api/src/components/image/service.ts
+++ b/api/src/components/image/service.ts
@@ -5,7 +5,10 @@ import * as I from 'interface';
 
 const config = {
     region: 'eu-west-1',
-    endpoint: process.env.STAGE === 'local' ? `http://${process.env.LOCALSTACK_SERVER}:4566` : 'https://s3.eu-west-1.amazonaws.com',
+    endpoint:
+        process.env.STAGE === 'local'
+            ? `http://${process.env.LOCALSTACK_SERVER}:4566`
+            : 'https://s3.eu-west-1.amazonaws.com',
     s3ForcePathStyle: true
 };
 

--- a/api/src/lib/email.ts
+++ b/api/src/lib/email.ts
@@ -129,7 +129,10 @@ export const standardHTMLEmailTemplate = (subject: string, html: string) => {
     <body>
         <div class="wrapper">
             <div class="header">
-                <img src="https://science-octopus-publishing-images-prod.s3.eu-west-1.amazonaws.com/OCTOPUS_LOGO_ILLUSTRATION_WHITE_500PX.png">
+                <img 
+                    src="https://science-octopus-publishing-images-prod.s3.eu-west-1.amazonaws.com/OCTOPUS_LOGO_ILLUSTRATION_WHITE_500PX.png"
+                    style = "width: 40px;"
+                >
                 <h3>Octopus</h3>
             </div>
             <div class="content">
@@ -138,10 +141,16 @@ export const standardHTMLEmailTemplate = (subject: string, html: string) => {
             <div class="footer">
                 <div class="footer-logo">
                     <a href="${baseURL}" style='text-decoration: none;'>
-                        <img src="https://science-octopus-publishing-images-prod.s3.eu-west-1.amazonaws.com/OCTOPUS_LOGO_ILLUSTRATION_WHITE_500PX.png">
+                        <img 
+                            src="https://science-octopus-publishing-images-prod.s3.eu-west-1.amazonaws.com/OCTOPUS_LOGO_ILLUSTRATION_WHITE_500PX.png"
+                            style = "width: 45px;"
+                        >
                     </a>
                     <a href="https://www.jisc.ac.uk/" style='text-decoration: none;'>
-                        <img src="https://www.jisc.ac.uk/sites/all/themes/jisc_clean/img/jisc-logo.svg">
+                        <img 
+                            src="https://www.jisc.ac.uk/sites/all/themes/jisc_clean/img/jisc-logo.svg"
+                            style = "width: 45px;"
+                        >
                     </a>
                 </div>
                 <div class="footer-content">


### PR DESCRIPTION
The purpose of this PR was...

Correct/standardise the image sizes sent as part of the standardHTMLEmailTemplate
Achieved with inline styling

### Acceptance Criteria:

Based on css rules from the head of the template:
header image should be width: 40px;
footer images should be width: 45px;

### Tests:

---

### Screenshots:

![oct_email_img1](https://user-images.githubusercontent.com/120393589/211570083-cdbed7db-44c9-4f0b-93b6-eeaab218d491.png)
![oct_email_img2](https://user-images.githubusercontent.com/120393589/211570085-745fe878-fa6a-4555-8ff1-d43ddb52919b.png)

