### PR TITLE
OCT-251 Email notifications - send email when co-author approves

### DIFF
--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -264,11 +264,11 @@ functions:
                   path: ${self:custom.versions.v1}/publications/{id}/link-coauthor
                   method: PATCH
                   cors: true
-    updateCoAuthor:
-        handler: src/components/coauthor/routes.update
+    updateCoAuthorConfirmation:
+        handler: src/components/coauthor/routes.updateConfirmation
         events:
             - http:
-                  path: ${self:custom.versions.v1}/publications/{id}/coauthor
+                  path: ${self:custom.versions.v1}/publications/{id}/coauthor-confirmation
                   method: PATCH
                   cors: true
     # Flags

--- a/api/src/components/coauthor/__tests__/updateCoAuthor.test.ts
+++ b/api/src/components/coauthor/__tests__/updateCoAuthor.test.ts
@@ -8,7 +8,7 @@ describe('Update co-author status', () => {
 
     test('Co-author updates their status to true', async () => {
         const coAuthor = await testUtils.agent
-            .patch('/publications/publication-hypothesis-draft/coauthor')
+            .patch('/publications/publication-hypothesis-draft/coauthor-confirmation')
             .query({ apiKey: '000000006' })
             .send({
                 confirm: true
@@ -19,10 +19,10 @@ describe('Update co-author status', () => {
 
     test('Co-author updates their status to false', async () => {
         const coAuthor = await testUtils.agent
-            .patch('/publications/publication-problem-draft/coauthor')
+            .patch('/publications/publication-problem-draft/coauthor-confirmation')
             .query({ apiKey: '000000006' })
             .send({
-                confirm: true
+                confirm: false
             });
 
         expect(coAuthor.status).toEqual(200);
@@ -30,7 +30,7 @@ describe('Update co-author status', () => {
 
     test('Cannot update co-author if not a co-author (1)', async () => {
         const coAuthor = await testUtils.agent
-            .patch('/publications/publication-problem-draft/coauthor')
+            .patch('/publications/publication-problem-draft/coauthor-confirmation')
             .query({ apiKey: '123456789' })
             .send({
                 confirm: true
@@ -41,7 +41,7 @@ describe('Update co-author status', () => {
 
     test('Cannot update co-author if not a co-author (2)', async () => {
         const coAuthor = await testUtils.agent
-            .patch('/publications/publication-problem-draft/coauthor')
+            .patch('/publications/publication-problem-draft/coauthor-confirmation')
             .query({ apiKey: '987654321' })
             .send({
                 confirm: true

--- a/api/src/components/coauthor/controller.ts
+++ b/api/src/components/coauthor/controller.ts
@@ -163,29 +163,20 @@ export const link = async (
                 });
             }
 
-            const coAuthorConfirmed = await coAuthorService.confirmCoAuthor(
-                event.user.id,
-                event.pathParameters.id,
-                event.body.email,
-                event.body.code
-            );
+            await coAuthorService.linkUser(event.user.id, event.pathParameters.id, event.body.email, event.body.code);
 
-            return response.json(200, { CoauthorsConfirmed: coAuthorConfirmed });
+            return response.json(200, 'Linked user account');
         }
 
-        const coAuthorDenied = await coAuthorService.denyCoAuthor(
-            event.pathParameters.id,
-            event.body.email,
-            event.body.code
-        );
+        await coAuthorService.removeFromPublication(event.pathParameters.id, event.body.email, event.body.code);
 
-        return response.json(200, { CoauthorsDenied: coAuthorDenied });
+        return response.json(200, 'Removed co-author from publication');
     } catch (err) {
         return response.json(500, { message: 'Unknown server error.' });
     }
 };
 
-export const update = async (
+export const updateConfirmation = async (
     event: I.AuthenticatedAPIRequest<I.ChangeCoAuthorRequestBody, undefined, I.UpdateCoAuthorPathParams>
 ): Promise<I.JSONResponse> => {
     try {
@@ -213,7 +204,7 @@ export const update = async (
         }
 
         // update coAuthor confirmation status
-        await coAuthorService.updateCoAuthor(event.pathParameters.id, event.user.id, event.body.confirm);
+        await coAuthorService.updateConfirmation(event.pathParameters.id, event.user.id, event.body.confirm);
 
         if (event.body.confirm) {
             // notify main author

--- a/api/src/components/coauthor/controller.ts
+++ b/api/src/components/coauthor/controller.ts
@@ -212,7 +212,25 @@ export const update = async (
             });
         }
 
+        // update coAuthor confirmation status
         await coAuthorService.updateCoAuthor(event.pathParameters.id, event.user.id, event.body.confirm);
+
+        if (event.body.confirm) {
+            // notify main author
+            await email.notifyCoAuthorConfirmation({
+                coAuthor: {
+                    firstName: event.user.firstName,
+                    lastName: event.user.lastName || ''
+                },
+                publication: {
+                    authorEmail: publication.user.email || '',
+                    title: publication.title || '',
+                    url: `${process.env.BASE_URL}/publications/${publication.id}`
+                },
+                remainingConfirmationsCount:
+                    publication.coAuthors.filter((coAuthor) => !coAuthor.confirmedCoAuthor).length - 1
+            });
+        }
 
         return response.json(200, { message: 'This co-author has changed their confirmation status.' });
     } catch (err) {

--- a/api/src/components/coauthor/routes.ts
+++ b/api/src/components/coauthor/routes.ts
@@ -22,8 +22,8 @@ export const link = middy(coAuthorController.link)
     .use(middleware.authentication(true))
     .use(middleware.validator(coAuthorSchema.link, 'body'));
 
-export const update = middy(coAuthorController.update)
+export const updateConfirmation = middy(coAuthorController.updateConfirmation)
     .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))
     .use(middleware.httpJsonBodyParser())
     .use(middleware.authentication())
-    .use(middleware.validator(coAuthorSchema.update, 'body'));
+    .use(middleware.validator(coAuthorSchema.updateConfirmation, 'body'));

--- a/api/src/components/coauthor/schema/index.ts
+++ b/api/src/components/coauthor/schema/index.ts
@@ -1,3 +1,3 @@
 export { default as create } from './create';
 export { default as link } from './link';
-export { default as update } from './update';
+export { default as updateConfirmation } from './updateConfirmation';

--- a/api/src/components/coauthor/schema/updateConfirmation.ts
+++ b/api/src/components/coauthor/schema/updateConfirmation.ts
@@ -1,4 +1,4 @@
-const updateCoAuthorSchema = {
+const updateConfirmationSchema = {
     type: 'object',
     properties: {
         confirm: {
@@ -9,4 +9,4 @@ const updateCoAuthorSchema = {
     additionalProperties: false
 };
 
-export default updateCoAuthorSchema;
+export default updateConfirmationSchema;

--- a/api/src/components/coauthor/service.ts
+++ b/api/src/components/coauthor/service.ts
@@ -43,8 +43,8 @@ export const resendCoAuthor = async (id: string) => {
     return resendCoAuthor;
 };
 
-export const confirmCoAuthor = async (userId: string, publicationId: string, email: string, code: string) => {
-    const confirmCoAuthor = await client.prisma.coAuthors.updateMany({
+export const linkUser = (userId: string, publicationId: string, email: string, code: string) =>
+    client.prisma.coAuthors.updateMany({
         where: {
             publicationId,
             email,
@@ -55,11 +55,8 @@ export const confirmCoAuthor = async (userId: string, publicationId: string, ema
         }
     });
 
-    return confirmCoAuthor.count;
-};
-
-export const denyCoAuthor = async (publicationId: string, email: string, code: string) => {
-    const denyCoAuthor = await client.prisma.coAuthors.deleteMany({
+export const removeFromPublication = async (publicationId: string, email: string, code: string) =>
+    client.prisma.coAuthors.deleteMany({
         where: {
             publicationId,
             email,
@@ -67,10 +64,7 @@ export const denyCoAuthor = async (publicationId: string, email: string, code: s
         }
     });
 
-    return denyCoAuthor.count;
-};
-
-export const updateCoAuthor = async (publicationId: string, userId: string, confirm: boolean) => {
+export const updateConfirmation = async (publicationId: string, userId: string, confirm: boolean) => {
     const updateCoAuthor = await client.prisma.coAuthors.updateMany({
         where: {
             publicationId,

--- a/api/src/lib/email.ts
+++ b/api/src/lib/email.ts
@@ -427,3 +427,76 @@ export const resolveRedFlagCreatorNotification = async (options: ResolveRedFlagC
         subject: 'Red flag resolved'
     });
 };
+
+type NotifyCoAuthorConfirmation = {
+    coAuthor: {
+        firstName: string;
+        lastName: string;
+    };
+    publication: {
+        title: string;
+        url: string;
+        authorEmail: string;
+    };
+    remainingConfirmationsCount: number;
+};
+
+export const notifyCoAuthorConfirmation = async (options: NotifyCoAuthorConfirmation) => {
+    if (options.remainingConfirmationsCount) {
+        // one or more confirmations left
+        const html = `
+           <p><strong>${options.coAuthor.firstName} ${
+            options.coAuthor.lastName
+        }</strong> has confirmed their involvement in <strong><i>${
+            options.publication.title
+        }</i></strong> and has confirmed that the draft is ready to publish.</p>
+            <br>
+            <p style="text-align: center;"><a class="button" href="${
+                options.publication.url
+            }" target="_blank" rel="noreferrer noopener">View publication</a></p>
+            <br>
+            <p><strong>${options.remainingConfirmationsCount}</strong> co-author${
+            options.remainingConfirmationsCount === 1 ? '' : 's'
+        } still need to confirm your draft before this publication can go live.</p> 
+            <br>
+            <p>Note that all co-authors must approve before this publication can go live.</p>
+        `;
+
+        const text = `${options.coAuthor.firstName} ${options.coAuthor.lastName} has confirmed their involvement in '${
+            options.publication.title
+        }' and has confirmed that the draft is ready to publish. You can view the publication here: ${
+            options.publication.url
+        } . ${options.remainingConfirmationsCount} co-author${
+            options.remainingConfirmationsCount === 1 ? '' : 's'
+        } still need to confirm your draft before this publication can go live. Note that all co-authors must approve before this publication can go live`;
+
+        await send({
+            html: standardHTMLEmailTemplate('A co-author has approved your Octopus publication', html),
+            text,
+            to: options.publication.authorEmail,
+            subject: 'A co-author has approved your Octopus publication'
+        });
+
+        return;
+    }
+
+    // last confirmation
+    const html = `
+                <p>All co-authors have confirmed their involvement in <strong><i>${options.publication.title}</i></strong> and have confirmed that the draft is ready to publish.</p>
+                <br>
+                <p>You are now ready to publish!</p>
+                <br>
+                <p style="text-align: center;"><a class="button" href="${options.publication.url}" target="_blank" rel="noreferrer noopener">View publication</a></p>
+                <br>
+                <p>Note that any changes to the draft publication at this stage will require co-authors to reapprove.</p>
+            `;
+
+    const text = `All co-authors have confirmed their involvement in '${options.publication.title}' and have confirmed that the draft is ready to publish. You are now ready to publish! You can view the publication here: ${options.publication.url} . Note that any changes to the draft publication at this stage will require co-authors to reapprove.`;
+
+    await send({
+        html: standardHTMLEmailTemplate('All co-authors have approved your Octopus publication', html),
+        text,
+        to: options.publication.authorEmail,
+        subject: 'All co-authors have approved your Octopus publication'
+    });
+};

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -28,8 +28,8 @@ const config: PlaywrightTestConfig = {
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  /* Running tests in parallel speeds up overall testing time but it also increases the chance of failing tests eg: one or more tests are manipulating the same DB resource */
+  workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/e2e/tests/LoggedIn/browse.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/browse.e2e.spec.ts
@@ -11,7 +11,7 @@ test.describe("Browse", () => {
     await page.goto(Helpers.UI_BASE);
     await Helpers.login(page, browser);
     await expect(page.locator(PageModel.header.usernameButton)).toHaveText(
-      `${Helpers.ORCID_TEST_NAME}`
+      `${Helpers.user1.fullName}`
     );
 
     // Navigate to browse page

--- a/e2e/tests/LoggedIn/livePublication.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/livePublication.e2e.spec.ts
@@ -102,7 +102,7 @@ test.describe("Live Publication", () => {
     await page.goto(Helpers.UI_BASE);
     await Helpers.login(page, browser);
     await expect(page.locator(PageModel.header.usernameButton)).toHaveText(
-      `${Helpers.ORCID_TEST_NAME}`
+      `${Helpers.user1.fullName}`
     );
 
     await Helpers.checkLivePublicationLayout(
@@ -120,7 +120,7 @@ test.describe("Live Publication", () => {
     await page.goto(Helpers.UI_BASE);
     await Helpers.login(page, browser);
     await expect(page.locator(PageModel.header.usernameButton)).toHaveText(
-      `${Helpers.ORCID_TEST_NAME}`
+      `${Helpers.user1.fullName}`
     );
 
     testBookmarking(page, "cl3fz14dr0001es6i5ji51rq4");
@@ -134,7 +134,7 @@ test.describe("Live Publication", () => {
     await page.goto(Helpers.UI_BASE);
     await Helpers.login(page, browser);
     await expect(page.locator(PageModel.header.usernameButton)).toHaveText(
-      `${Helpers.ORCID_TEST_NAME}`
+      `${Helpers.user1.fullName}`
     );
 
     testFlagging(
@@ -152,7 +152,7 @@ test.describe("Live Publication", () => {
     await page.goto(Helpers.UI_BASE);
     await Helpers.login(page, browser);
     await expect(page.locator(PageModel.header.usernameButton)).toHaveText(
-      `${Helpers.ORCID_TEST_NAME}`
+      `${Helpers.user1.fullName}`
     );
     await page.goto(
       `${Helpers.UI_BASE}/publications/cl3fz14dr0001es6i5ji51rq4`,
@@ -185,7 +185,7 @@ test.describe("Live Publication", () => {
     await page.goto(Helpers.UI_BASE);
     await Helpers.login(page, browser);
     await expect(page.locator(PageModel.header.usernameButton)).toHaveText(
-      `${Helpers.ORCID_TEST_NAME}`
+      `${Helpers.user1.fullName}`
     );
     await page.goto(
       `${Helpers.UI_BASE}/publications/cl3fz14dr0001es6i5ji51rq4`,

--- a/e2e/tests/LoggedIn/login.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/login.e2e.spec.ts
@@ -8,7 +8,7 @@ test.describe("Login", () => {
     await page.goto(Helpers.UI_BASE);
     await Helpers.login(page, browser);
     await expect(page.locator(PageModel.header.usernameButton)).toHaveText(
-      `${Helpers.ORCID_TEST_NAME}`
+      `${Helpers.user1.fullName}`
     );
 
     await Helpers.logout(page);

--- a/e2e/tests/LoggedIn/profile.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/profile.e2e.spec.ts
@@ -16,7 +16,7 @@ test.describe("My profile", () => {
     // login
     await Helpers.login(page, browser);
     await expect(page.locator(PageModel.header.usernameButton)).toHaveText(
-      `${Helpers.ORCID_TEST_NAME}`
+      `${Helpers.user1.fullName}`
     );
 
     // go to "My Profile" page
@@ -30,7 +30,7 @@ test.describe("My profile", () => {
 
   test("My profile contents", async () => {
     // check user full name
-    await expect(page.locator("h1")).toHaveText(`${Helpers.ORCID_TEST_NAME}`);
+    await expect(page.locator("h1")).toHaveText(`${Helpers.user1.fullName}`);
 
     // check Employment section
     expect(page.locator(PageModel.profilePage.employment)).toBeVisible();

--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -1,5 +1,5 @@
 import * as Helpers from "../helpers";
-import { expect, test, Page } from "@playwright/test";
+import { expect, test, Page, Browser } from "@playwright/test";
 import { PageModel } from "../PageModel";
 
 test.describe.configure({ mode: "serial" });
@@ -248,14 +248,6 @@ export const publicationFlowFunders = async (
   await page.locator(PageModel.publish.nextButton).click();
 };
 
-export const publicationFlowCoauthors = async (
-  page: Page,
-  pubType: string,
-  licenceType: string
-) => {
-  // Co authors
-};
-
 export const publicationFlowReview = async (
   page: Page,
   pubType: string,
@@ -269,7 +261,7 @@ const problemPublication = {
   language: "Afar",
   licence: "CC BY-NC 4.0",
   title: "test title",
-  author: Helpers.ORCID_TEST_NAME,
+  author: Helpers.user1.fullName,
   text: "main text",
   references: referencesList,
   coi: "This Research Problem does not have any specified conflicts of interest.",
@@ -282,7 +274,7 @@ const hypothesisPublication = {
   language: "Afar",
   licence: "CC BY-NC 4.0",
   title: "test title",
-  author: Helpers.ORCID_TEST_NAME,
+  author: Helpers.user1.fullName,
   text: "main text",
   references: referencesList,
   coi: "This Rationale / Hypothesis does not have any specified conflicts of interest.",
@@ -295,7 +287,7 @@ const methodPublication = {
   language: "Afar",
   licence: "CC BY-NC 4.0",
   title: "test title",
-  author: Helpers.ORCID_TEST_NAME,
+  author: Helpers.user1.fullName,
   text: "main text",
   references: referencesList,
   coi: "This Method does not have any specified conflicts of interest.",
@@ -308,7 +300,7 @@ const analysisPublication = {
   language: "Afar",
   licence: "CC BY-NC 4.0",
   title: "test title",
-  author: Helpers.ORCID_TEST_NAME,
+  author: Helpers.user1.fullName,
   text: "main text",
   references: referencesList,
   coi: "This Analysis does not have any specified conflicts of interest.",
@@ -321,7 +313,7 @@ const interpretationPublication = {
   language: "Afar",
   licence: "CC BY-NC 4.0",
   title: "test title",
-  author: Helpers.ORCID_TEST_NAME,
+  author: Helpers.user1.fullName,
   text: "main text",
   references: referencesList,
   coi: "This Interpretation does not have any specified conflicts of interest.",
@@ -334,7 +326,7 @@ const realWorldApplicationPublication = {
   language: "Afar",
   licence: "CC BY-NC 4.0",
   title: "test title",
-  author: Helpers.ORCID_TEST_NAME,
+  author: Helpers.user1.fullName,
   text: "main text",
   references: referencesList,
   coi: "This Real World Application does not have any specified conflicts of interest.",
@@ -363,7 +355,7 @@ export const checkPublication = async (
     `aside span:has-text("${publication.pubType}")`,
     `aside span:has-text("${publication.language}")`,
     `aside a:has-text("${publication.licence}")`,
-    `main > section > header > div >> a:has-text("${Helpers.ORCID_TEST_SHORT_NAME}")`,
+    `main > section > header > div >> a:has-text("${Helpers.user1.shortName}")`,
     `h1:has-text("${publication.title}")`,
     `text=${publication.references[1].text}`,
     `text=${publication.references[1].refURL}`,
@@ -388,7 +380,7 @@ test.describe("Publication flow", () => {
     await page.goto(Helpers.UI_BASE);
     await Helpers.login(page, browser);
     await expect(page.locator(PageModel.header.usernameButton)).toHaveText(
-      Helpers.ORCID_TEST_NAME
+      Helpers.user1.fullName
     );
 
     await createPublication(page, "test title", "PROBLEM");
@@ -425,7 +417,6 @@ test.describe("Publication flow", () => {
     );
 
     // Preview and check preview draft publication
-    await page.locator(PageModel.publish.nextButton).click();
     await page.locator(PageModel.publish.previewButton).click();
     await checkPublication(page, problemPublication);
 
@@ -447,7 +438,7 @@ test.describe("Publication flow", () => {
     await page.goto(Helpers.UI_BASE);
     await Helpers.login(page, browser);
     await expect(page.locator(PageModel.header.usernameButton)).toHaveText(
-      Helpers.ORCID_TEST_NAME
+      Helpers.user1.fullName
     );
 
     await createPublication(page, "test title", "HYPOTHESIS");
@@ -506,7 +497,7 @@ test.describe("Publication flow", () => {
     await page.goto(Helpers.UI_BASE);
     await Helpers.login(page, browser);
     await expect(page.locator(PageModel.header.usernameButton)).toHaveText(
-      Helpers.ORCID_TEST_NAME
+      Helpers.user1.fullName
     );
 
     await createPublication(page, "test title", "PROTOCOL");
@@ -565,7 +556,7 @@ test.describe("Publication flow", () => {
     await page.goto(Helpers.UI_BASE);
     await Helpers.login(page, browser);
     await expect(page.locator(PageModel.header.usernameButton)).toHaveText(
-      Helpers.ORCID_TEST_NAME
+      Helpers.user1.fullName
     );
 
     await createPublication(page, "test title", "ANALYSIS");
@@ -626,7 +617,7 @@ test.describe("Publication flow", () => {
     await page.goto(Helpers.UI_BASE);
     await Helpers.login(page, browser);
     await expect(page.locator(PageModel.header.usernameButton)).toHaveText(
-      Helpers.ORCID_TEST_NAME
+      Helpers.user1.fullName
     );
 
     await createPublication(page, "test title", "INTERPRETATION");
@@ -687,7 +678,7 @@ test.describe("Publication flow", () => {
     await page.goto(Helpers.UI_BASE);
     await Helpers.login(page, browser);
     await expect(page.locator(PageModel.header.usernameButton)).toHaveText(
-      Helpers.ORCID_TEST_NAME
+      Helpers.user1.fullName
     );
 
     await createPublication(page, "test title", "REAL_WORLD_APPLICATION");
@@ -736,5 +727,182 @@ test.describe("Publication flow", () => {
     await page.locator(PageModel.publish.publishButton).click();
     await page.locator(PageModel.publish.confirmPublishButton).click();
     await checkPublication(page, realWorldApplicationPublication);
+  });
+});
+
+const publicationWithCoAuthors = {
+  title: "Test co-authors",
+  content: "Testing co-authors",
+  coAuthors: [Helpers.user2, Helpers.user3],
+  type: "PROBLEM",
+};
+
+const addCoAuthor = async (page: Page, user: Helpers.TestUser) => {
+  await page.fill('input[type="email"]', user.email);
+  await Promise.all([
+    page.waitForResponse(
+      (response) => response.url().includes("/coauthor") && response.ok()
+    ),
+    page.keyboard.press("Enter"),
+  ]);
+};
+
+const confirmCoAuthorInvitation = async (
+  browser: Browser,
+  user: Helpers.TestUser
+) => {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await page.goto(Helpers.UI_BASE);
+  await Helpers.login(page, browser, user);
+  const page2 = await context.newPage();
+  await page2.goto(`http://localhost:8025/`);
+  await page2.waitForSelector(".messages > .row");
+
+  // click latest invitation link which was sent to this user and has text: "You’ve been added as a co-author on Octopus"
+  const rows = page2.locator(".messages > .row");
+  const rowsCount = await rows.count();
+
+  for (let i = 0; i < rowsCount; i++) {
+    const currentRow = rows.nth(i);
+    const textContent = await currentRow.textContent();
+    if (
+      textContent.includes(user.email) &&
+      textContent.includes("You’ve been added as a co-author on Octopus")
+    ) {
+      await currentRow.click();
+      break;
+    }
+  }
+
+  // clicking 'I am an author' link is blocked by cors
+  const invitationLink = await page2
+    .frameLocator("iframe")
+    .locator("a.button:has-text('I am an author')")
+    .getAttribute("href");
+
+  // navigate to that link instead
+  const page3 = await context.newPage();
+  await page3.goto(invitationLink);
+  await (await page3.waitForSelector('button:has-text("approve")')).click();
+
+  await (
+    await page3.waitForSelector('button[title="Yes, this is ready to publish"]')
+  ).click();
+
+  await context.close();
+};
+
+const verifyLastEmailNotification = async (
+  browser: Browser,
+  emailSubject: string
+) => {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await page.goto("http://localhost:8025/");
+  await expect(page.locator(".msglist-message").first()).toContainText(
+    emailSubject
+  );
+  await context.close();
+};
+
+test.describe("Publication flow + co-authors", () => {
+  test("Create a PROBLEM publication with co-authors", async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.goto(Helpers.UI_BASE);
+    await Helpers.login(page, browser);
+    await expect(page.locator(PageModel.header.usernameButton)).toHaveText(
+      Helpers.user1.fullName
+    );
+
+    // create new publication
+    await createPublication(
+      page,
+      publicationWithCoAuthors.title,
+      publicationWithCoAuthors.type
+    );
+
+    // add linked publication
+    await (
+      await page.waitForSelector("aside button:has-text('Linked publications')")
+    ).click();
+    await publicationFlowLinkedPublication(
+      page,
+      "living organisms",
+      "How do living organisms function, survive, reproduce and evolve?"
+    );
+
+    // add main text
+    await (
+      await page.waitForSelector("aside button:has-text('Main text')")
+    ).click();
+    await page.locator(PageModel.publish.text.editor).click();
+    await page.keyboard.type(publicationWithCoAuthors.content);
+
+    // verify 'Publish' button is enabled
+    const publishButton = page.locator(PageModel.publish.publishButton);
+    await expect(publishButton).toBeEnabled();
+
+    // add co-authors
+    await page.locator('aside button:has-text("Co-authors")').click();
+    await addCoAuthor(page, Helpers.user2);
+    await addCoAuthor(page, Helpers.user3);
+
+    // verify 'Publish' button is now disabled
+    await expect(publishButton).toBeDisabled();
+
+    // first co-author confirmation
+    await confirmCoAuthorInvitation(browser, Helpers.user2);
+
+    // verify notification triggered after first confirmation
+    await verifyLastEmailNotification(
+      browser,
+      "A co-author has approved your Octopus publication"
+    );
+
+    // second co-author confirmation
+    await confirmCoAuthorInvitation(browser, Helpers.user3);
+
+    // verify notification triggered after last confirmation
+    await verifyLastEmailNotification(
+      browser,
+      "All co-authors have approved your Octopus publication"
+    );
+
+    // save the publication
+    await page.click('button[title="Save"]:first-of-type');
+
+    await Promise.all([
+      page.click('div[role="dialog"] button[title="Save"]'),
+      page.waitForResponse(
+        (response) =>
+          response.url().includes("/publications") &&
+          response.request().method() === "PATCH" &&
+          response.ok()
+      ),
+    ]);
+
+    // refresh corresponding author page
+    await page.reload();
+
+    // verify publish button is now enabled
+    await page.waitForSelector(PageModel.publish.publishButton);
+    await expect(page.locator(PageModel.publish.publishButton)).toBeEnabled();
+
+    // publish the new publication
+    page.locator(PageModel.publish.publishButton).click();
+    await Promise.all([
+      page.waitForNavigation(),
+      page.locator(PageModel.publish.confirmPublishButton).click(),
+    ]);
+
+    // check publication title and authors
+    await expect(
+      page.locator(`h1:has-text("${publicationWithCoAuthors.title}")`)
+    ).toBeVisible();
+    await expect(page.getByText(Helpers.user1.shortName)).toBeVisible();
+    await expect(page.getByText(Helpers.user2.shortName)).toBeVisible();
+    await expect(page.getByText(Helpers.user3.shortName)).toBeVisible();
   });
 });

--- a/e2e/tests/LoggedIn/search.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/search.e2e.spec.ts
@@ -1,6 +1,6 @@
-import { expect, test } from '@playwright/test';
-import * as helpers from '../helpers';
-import { PageModel } from '../PageModel';
+import { expect, test } from "@playwright/test";
+import * as Helpers from "../helpers";
+import { PageModel } from "../PageModel";
 
 test.describe("Search", () => {
   test("Full publication title search", async ({ browser }) => {
@@ -8,14 +8,14 @@ test.describe("Search", () => {
     const page = await browser.newPage();
 
     // Login
-    await page.goto(helpers.UI_BASE);
-    await helpers.login(page, browser);
+    await page.goto(Helpers.UI_BASE);
+    await Helpers.login(page, browser);
     await expect(page.locator(PageModel.header.usernameButton)).toHaveText(
-      `${helpers.ORCID_TEST_NAME}`
+      `${Helpers.user1.fullName}`
     );
 
     // search and check result
-    await helpers.search(
+    await Helpers.search(
       page,
       "How has life on earth evolved?",
       PageModel.search.publicationSearchResult
@@ -29,46 +29,50 @@ test.describe("Search", () => {
   });
 });
 
-test.describe('Search term is persisted in URL query string', () => {
-    test('Partial search term search', async ({browser}) => {
-        // Start up test
-        const page = await browser.newPage();
-        await page.goto(helpers.UI_BASE);
+test.describe("Search term is persisted in URL query string", () => {
+  test("Partial search term search", async ({ browser }) => {
+    // Start up test
+    const page = await browser.newPage();
+    await page.goto(Helpers.UI_BASE);
 
-        // search and expect URL query string to contain search text
-        await helpers.search(page, PageModel.search.searchTerm);
-        await expect(page).toHaveURL(new RegExp(`query=${PageModel.search.searchTerm}`));
+    // search and expect URL query string to contain search text
+    await Helpers.search(page, PageModel.search.searchTerm);
+    await expect(page).toHaveURL(
+      new RegExp(`query=${PageModel.search.searchTerm}`)
+    );
 
-        // navigate to first publication (expect URL to contain path) click browser 'back'
-        await helpers.clickFirstPublication(page);
-        await page.goBack();
+    // navigate to first publication (expect URL to contain path) click browser 'back'
+    await Helpers.clickFirstPublication(page);
+    await page.goBack();
 
-        await expect(page).toHaveURL(new RegExp(`query=${PageModel.search.searchTerm}`));
-    })
+    await expect(page).toHaveURL(
+      new RegExp(`query=${PageModel.search.searchTerm}`)
+    );
+  });
 });
 
-test.describe('dateTo and dateFrom fields are persisted in URL query string', () => {
-    test('dateTo and dateFrom in query string', async ({browser}) => {
-        // Start up test
-        const page = await browser.newPage();
-        await page.goto(helpers.UI_BASE);
-        await page.locator(PageModel.header.searchButton).click();
+test.describe("dateTo and dateFrom fields are persisted in URL query string", () => {
+  test("dateTo and dateFrom in query string", async ({ browser }) => {
+    // Start up test
+    const page = await browser.newPage();
+    await page.goto(Helpers.UI_BASE);
+    await page.locator(PageModel.header.searchButton).click();
 
-        //select dateFrom & dateTo
-        const dateFromInput = page.locator(PageModel.search.dateFromInput);
-        const dateToInput = page.locator(PageModel.search.dateToInput);
+    //select dateFrom & dateTo
+    const dateFromInput = page.locator(PageModel.search.dateFromInput);
+    const dateToInput = page.locator(PageModel.search.dateToInput);
 
-        await dateFromInput.fill(PageModel.search.dateFrom);
-        await dateToInput.fill(PageModel.search.dateTo);
+    await dateFromInput.fill(PageModel.search.dateFrom);
+    await dateToInput.fill(PageModel.search.dateTo);
 
-        // expect dateFrom/dateTo input and URL to match selections
-        await helpers.testDateInput(page, dateFromInput, dateToInput);
+    // expect dateFrom/dateTo input and URL to match selections
+    await Helpers.testDateInput(page, dateFromInput, dateToInput);
 
-        // navigate to first publication (expect URL to contain path) click browser 'back'
-        await helpers.clickFirstPublication(page);
-        await page.goBack();
+    // navigate to first publication (expect URL to contain path) click browser 'back'
+    await Helpers.clickFirstPublication(page);
+    await page.goBack();
 
-        // expect dateFrom/dateTo input and URL to match selections
-        await helpers.testDateInput(page, dateFromInput, dateToInput);
-    });
+    // expect dateFrom/dateTo input and URL to match selections
+    await Helpers.testDateInput(page, dateFromInput, dateToInput);
+  });
 });

--- a/e2e/tests/LoggedIn/zRevokeOrcidAccess.spec.ts
+++ b/e2e/tests/LoggedIn/zRevokeOrcidAccess.spec.ts
@@ -76,7 +76,7 @@ test.describe("Revoke ORCID access", () => {
     await page.goto(Helpers.UI_BASE);
     await Helpers.login(page, browser);
     await expect(page.locator(PageModel.header.usernameButton)).toHaveText(
-      `${Helpers.ORCID_TEST_NAME}`
+      `${Helpers.user1.fullName}`
     );
 
     await page.click(PageModel.header.usernameButton);
@@ -103,8 +103,8 @@ test.describe("Revoke ORCID access", () => {
     ]);
 
     await page.waitForLoadState("domcontentloaded");
-    await page.fill(PageModel.login.username, Helpers.ORCID_TEST_USER);
-    await page.fill(PageModel.login.password, Helpers.ORCID_TEST_PASS);
+    await page.fill(PageModel.login.username, Helpers.user1.email);
+    await page.fill(PageModel.login.password, Helpers.user1.password);
 
     await Promise.all([
       page.waitForNavigation(), // wait to see if authorization is required

--- a/e2e/tests/LoggedOut/livePublication.e2e.spec.ts
+++ b/e2e/tests/LoggedOut/livePublication.e2e.spec.ts
@@ -63,7 +63,7 @@ test.describe("Live Publication", () => {
     await page.goto(Helpers.UI_BASE);
     await Helpers.login(page, browser);
     await expect(page.locator(PageModel.header.usernameButton)).toHaveText(
-      `${Helpers.ORCID_TEST_NAME}`
+      `${Helpers.user1.fullName}`
     );
 
     await page.locator(PageModel.header.searchButton).click();

--- a/e2e/tests/PageModel.ts
+++ b/e2e/tests/PageModel.ts
@@ -176,10 +176,9 @@ export const PageModel = {
       deleteAllReferencesModalButton: 'button[aria-label="Delete all"]',
       continueModalButton: 'button[aria-label="Continue"]',
       saveReferenceModalButton: 'div[role=dialog] button[title="Save"]',
-      deleteReferenceModalButton: 'button[title="Delete"]',
-      // using xpath to locate the elements until a better solution is found
-      deleteFirstReferenceButton: 'button[aria-label="Delete"] >> nth=0',
-      addReferenceButton: 'button[aria-label="Add below"] >> nth=0',
+      deleteReferenceModalButton: 'div[role="dialog"] button[title="Delete"]',
+      deleteFirstReferenceButton: 'tr:first-of-type button[title="Delete"]',
+      addReferenceButton: 'tr:first-of-type button[title="Add below"]',
       description:
         "text=Short descriptionInclude a short description of your publication to aid discover >> textarea",
       keywords:

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -1,24 +1,70 @@
 import { Browser, expect, Locator, Page} from '@playwright/test';
 import {PageModel} from './PageModel';
 
-export const ORCID_TEST_USER = process.env.ORCID_TEST_USER;
-export const ORCID_TEST_PASS = process.env.ORCID_TEST_PASS;
-export const ORCID_TEST_NAME = `${process.env.ORCID_TEST_FIRST_NAME} ${process.env.ORCID_TEST_LAST_NAME}`;
-export const ORCID_TEST_SHORT_NAME = `${process.env.ORCID_TEST_FIRST_NAME?.[0]}. ${process.env.ORCID_TEST_LAST_NAME}`;
-
 export const UI_BASE = process.env.UI_BASE || "https://localhost:3001";
 
-if (!ORCID_TEST_USER || !ORCID_TEST_PASS || !ORCID_TEST_NAME)
-  throw "Environment variables not set";
+const requiredEnvVariables = [
+  "ORCID_TEST_USER",
+  "ORCID_TEST_PASS",
+  "ORCID_TEST_FIRST_NAME",
+  "ORCID_TEST_LAST_NAME",
+  "ORCID_TEST_USER2",
+  "ORCID_TEST_PASS2",
+  "ORCID_TEST_FIRST_NAME2",
+  "ORCID_TEST_LAST_NAME2",
+  "ORCID_TEST_USER3",
+  "ORCID_TEST_PASS3",
+  "ORCID_TEST_FIRST_NAME3",
+  "ORCID_TEST_LAST_NAME3",
+];
 
-export const login = async (page: Page, browser: Browser) => {
+function checkEnvVariable(variableName: string) {
+  if (process.env[variableName] === undefined) {
+    throw new Error(`Environment Variable '${variableName}' is undefined.`);
+  }
+}
+
+requiredEnvVariables.forEach(checkEnvVariable);
+
+export type TestUser = {
+  email: string;
+  password: string;
+  shortName: string;
+  fullName: string;
+};
+
+// test user 1
+export const user1: TestUser = {
+  email: process.env.ORCID_TEST_USER,
+  password: process.env.ORCID_TEST_PASS,
+  shortName: `${process.env.ORCID_TEST_FIRST_NAME?.[0]}. ${process.env.ORCID_TEST_LAST_NAME}`,
+  fullName: `${process.env.ORCID_TEST_FIRST_NAME} ${process.env.ORCID_TEST_LAST_NAME}`,
+};
+
+// test user 2
+export const user2: TestUser = {
+  email: process.env.ORCID_TEST_USER2,
+  password: process.env.ORCID_TEST_PASS2,
+  shortName: `${process.env.ORCID_TEST_FIRST_NAME2?.[0]}. ${process.env.ORCID_TEST_LAST_NAME2}`,
+  fullName: `${process.env.ORCID_TEST_FIRST_NAME2} ${process.env.ORCID_TEST_LAST_NAME2}`,
+};
+
+// test user 3
+export const user3: TestUser = {
+  email: process.env.ORCID_TEST_USER3,
+  password: process.env.ORCID_TEST_PASS3,
+  shortName: `${process.env.ORCID_TEST_FIRST_NAME3?.[0]}. ${process.env.ORCID_TEST_LAST_NAME3}`,
+  fullName: `${process.env.ORCID_TEST_FIRST_NAME3} ${process.env.ORCID_TEST_LAST_NAME3}`,
+};
+
+export const login = async (page: Page, browser: Browser, user = user1) => {
   await Promise.all([
     page.waitForNavigation(),
     page.click(PageModel.header.loginButton),
   ]);
 
-  await page.fill(PageModel.login.username, ORCID_TEST_USER);
-  await page.fill(PageModel.login.password, ORCID_TEST_PASS);
+  await page.fill(PageModel.login.username, user.email);
+  await page.fill(PageModel.login.password, user.password);
 
   await Promise.all([
     page.waitForNavigation(), // wait to see if authorization is required
@@ -40,7 +86,7 @@ export const login = async (page: Page, browser: Browser) => {
       (await page.title()) === "Complete your registration";
 
   if (needsEmailVerification) {
-    await page.fill("#email", ORCID_TEST_USER);
+    await page.fill("#email", user.email);
     await page.click('button[title="Send code"]');
     await page.waitForSelector("#code");
 

--- a/ui/src/pages/publications/[id]/index.tsx
+++ b/ui/src/pages/publications/[id]/index.tsx
@@ -166,7 +166,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
     const updateCoAuthor = React.useCallback(
         async (confirm: boolean) => {
             await api.patch(
-                `/publications/${publicationData?.id}/coauthor`,
+                `/publications/${publicationData?.id}/coauthor-confirmation`,
                 {
                     confirm
                 },


### PR DESCRIPTION
The purpose of this PR was to update PATCH /publications/{id}/coauthor endpoint in order to send email notifications to the main author whenever a co-author approves the invitation.

---

### Acceptance Criteria:

As per [OCT-251](https://jiscdev.atlassian.net/browse/OCT-251)

---

### Tests:

Added e2e tests for co-authors approval and triggered notifications
<img width="769" alt="image" src="https://user-images.githubusercontent.com/48569671/211894520-8d788417-1e20-4098-bc86-a17f2fc01301.png">


---

### Screenshots:
![image](https://user-images.githubusercontent.com/48569671/211894595-3cbc047a-a359-4f63-a72b-a3a63f32e48f.png)

![image](https://user-images.githubusercontent.com/48569671/211894650-e2c3b649-14b2-4931-8417-2616ce704408.png)


[OCT-251]: https://jiscdev.atlassian.net/browse/OCT-251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ