### PR TITLE
OCT-337 Email notifications - email when co-author is denies/is removed - FIX

### DIFF
--- a/api/src/components/coauthor/controller.ts
+++ b/api/src/components/coauthor/controller.ts
@@ -282,6 +282,19 @@ export const updateConfirmation = async (
             });
         }
 
+        if (!event.body.confirm) {
+            // notify main author about rejection
+            await email.notifyCoAuthorRejection({
+                coAuthor: {
+                    email: event.user.email || ''
+                },
+                publication: {
+                    title: publication.title || '',
+                    authorEmail: publication.user.email || ''
+                }
+            });
+        }
+
         return response.json(200, { message: 'This co-author has changed their confirmation status.' });
     } catch (err) {
         return response.json(500, { message: 'Unknown server error.' });

--- a/api/src/components/coauthor/controller.ts
+++ b/api/src/components/coauthor/controller.ts
@@ -282,19 +282,6 @@ export const updateConfirmation = async (
             });
         }
 
-        if (!event.body.confirm) {
-            // notify main author about rejection
-            await email.notifyCoAuthorRejection({
-                coAuthor: {
-                    email: event.user.email || ''
-                },
-                publication: {
-                    title: publication.title || '',
-                    authorEmail: publication.user.email || ''
-                }
-            });
-        }
-
         return response.json(200, { message: 'This co-author has changed their confirmation status.' });
     } catch (err) {
         return response.json(500, { message: 'Unknown server error.' });

--- a/api/src/components/coauthor/controller.ts
+++ b/api/src/components/coauthor/controller.ts
@@ -157,6 +157,11 @@ export const link = async (
             });
         }
 
+        // check if this user is part of co-authors list
+        if (!publication.coAuthors.find((coAuthor) => coAuthor.email === event.body.email)) {
+            return response.json(403, { message: 'You are not listed as a co-author for this publication.' });
+        }
+
         if (event.body.approve) {
             if (!event.user) {
                 return response.json(403, {


### PR DESCRIPTION
The purpose of this PR was to fix co-author rejecting same invitation multiple times and triggering a notification every time they do that.

---

### Acceptance Criteria:

---

### Tests:

---

### Screenshots:
