### PR TITLE
OCT-533 Standardise eslint rules, remove prettier, introduce automation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,85 @@
+{
+  "rules": {
+    // Base rules
+    "object-curly-newline": "off",
+    "no-restricted-syntax": "off",
+    "no-underscore-dangle": "off",
+    "consistent-return": "off",
+    "no-useless-return": "off",
+    "no-await-in-loop": "off",
+    "no-extra-semi": "off",
+    "no-console": "off",
+    "semi": "off",
+    // imports
+    "import/no-extraneous-dependencies": "off",
+    "import/prefer-default-export": "off",
+    "import/extensions": "off",
+    // TS
+    "@typescript-eslint/restrict-template-expressions": "off", // accessing possible undefined in template lit, e.g `https://${process.env.STAGE}.example.com` - process.env.stage could be undefined
+    "@typescript-eslint/no-unsafe-member-access": "off", // accessing a value from type any
+    "@typescript-eslint/no-unsafe-assignment": "off", // assigning a value from an any
+    "@typescript-eslint/no-empty-interface": "error", // no empty interfaces
+    "@typescript-eslint/no-unsafe-argument": "off", // For use of any as a param
+    "@typescript-eslint/no-extra-semi": "error",
+    "@typescript-eslint/ban-ts-comment": "off", // For use of ts-ignore & other ts- comments
+    "@typescript-eslint/no-unsafe-call": "off", // For calls on type `any`
+    "@typescript-eslint/no-shadow": "off", // out of module scope func names
+    "require-await": "off",
+    "@typescript-eslint/require-await": "error",
+    "@typescript-eslint/indent":  ["error", 4],
+    "padding-line-between-statements": "off",
+    "@typescript-eslint/semi": "error",
+    "@typescript-eslint/no-explicit-any": "warn",
+    "@typescript-eslint/no-unsafe-return": "warn",
+    "comma-dangle": "off",
+    "arrow-spacing": "error",
+    "no-multi-spaces": "error",
+    "no-return-await": "off",
+    "@typescript-eslint/return-await": "off",
+    "space-before-blocks": "off",
+    "@typescript-eslint/space-before-blocks": "error",
+    "@typescript-eslint/explicit-function-return-type": ["error"],
+    "no-multiple-empty-lines": [
+      "error",
+      {
+        "max": 1
+      }
+    ],
+    "@typescript-eslint/comma-dangle": ["error",
+      {
+        "arrays": "only-multiline",
+        "objects": "only-multiline",
+        "imports": "only-multiline"
+      }
+    ],
+    "@typescript-eslint/padding-line-between-statements": [
+      "error",
+      {
+        "blankLine": "always",
+        "prev": "*",
+        "next": ["return", "block-like"]
+      },
+      {
+        "blankLine": "always",
+        "prev": "block-like",
+        "next": "*"
+      }
+    ],
+    "@typescript-eslint/naming-convention": [
+      "error",
+      {
+        "selector": "default",
+        "format": ["camelCase", "UPPER_CASE"],
+        "leadingUnderscore": "allow"
+      },
+      {
+        "selector": ["objectLiteralProperty", "typeProperty"],
+        "format": null
+      },
+      {
+        "selector": ["enum", "enumMember", "interface", "typeAlias", "typeParameter"],
+        "format": ["PascalCase"]
+      }
+    ]
+  }
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,7 +26,7 @@
     "@typescript-eslint/no-shadow": "off", // out of module scope func names
     "require-await": "off",
     "@typescript-eslint/require-await": "error",
-    "@typescript-eslint/indent":  ["error", 4],
+    //"@typescript-eslint/indent":  ["error", 4],
     "padding-line-between-statements": "off",
     "@typescript-eslint/semi": "error",
     "@typescript-eslint/no-explicit-any": "warn",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -81,5 +81,19 @@
         "format": ["PascalCase"]
       }
     ]
-  }
+  },
+  "overrides": [
+    {
+      "files": ["./src/components/**/service.ts"],
+      "rules": {
+        "@typescript-eslint/explicit-function-return-type": "off"
+      }
+    },
+    {
+      "files": ["./src/components/**/controller.ts", "./src/middleware/validator.ts"],
+      "rules": {
+        "@typescript-eslint/require-await": "off"
+      }
+    }
+  ]
 }

--- a/.github/workflows/api-build.yml
+++ b/.github/workflows/api-build.yml
@@ -1,0 +1,43 @@
+name: API-build
+on: [push]
+
+jobs:
+  prettier:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node 14.x Environment
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+
+      - name: Install dependencies
+        working-directory: ./api
+        run: npm ci
+
+      - name: Run prettier check
+        working-directory: ./api
+        run: npm run format:check
+
+  eslint:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node 14.x Environment
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+
+      - name: Install dependencies
+        working-directory: ./api
+        run: npm ci
+
+      - name: Run lint
+        working-directory: ./api
+        run: npm run lint:check

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -12,6 +12,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        
+      - name: Run prettier check
+        working-directory: ./api
+        run: npm run format:check
+
+      - name: Run eslint check
+        working-directory: ./api
+        run: npm run lint:check
+
 
       # Note: this step is only required locally when using act since the ubuntu image
       # does not come with docker-compose installed, however the alternative to the reinstall

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -4,46 +4,6 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:
-  prettier:
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup Node 14.x Environment
-        uses: actions/setup-node@v2
-        with:
-          node-version: "14.x"
-
-      - name: Install dependencies
-        working-directory: ./api
-        run: npm ci
-
-      - name: Run prettier check
-        working-directory: ./api
-        run: npm run format:check
-
-  eslint:
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup Node 14.x Environment
-        uses: actions/setup-node@v2
-        with:
-          node-version: "14.x"
-
-      - name: Install dependencies
-        working-directory: ./api
-        run: npm ci
-
-      - name: Run lint
-        working-directory: ./api
-        run: npm run lint:check
-
   api-tests:
     timeout-minutes: 15
     runs-on: ubuntu-latest

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -17,11 +17,11 @@ jobs:
           node-version: "14.x"
 
       - name: Install dependencies
-        working-directory: ./ui
+        working-directory: ./api
         run: npm ci
 
       - name: Run prettier check
-        working-directory: ./ui
+        working-directory: ./api
         run: npm run format:check
 
   eslint:

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -4,6 +4,46 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:
+  prettier:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node 14.x Environment
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+
+      - name: Install dependencies
+        working-directory: ./ui
+        run: npm ci
+
+      - name: Run prettier check
+        working-directory: ./ui
+        run: npm run format:check
+
+  eslint:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node 14.x Environment
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+
+      - name: Install dependencies
+        working-directory: ./api
+        run: npm ci
+
+      - name: Run lint
+        working-directory: ./api
+        run: npm run lint:check
+
   api-tests:
     timeout-minutes: 15
     runs-on: ubuntu-latest
@@ -13,14 +53,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         
-      - name: Run prettier check
-        working-directory: ./api
-        run: npm run format:check
-
-      - name: Run eslint check
-        working-directory: ./api
-        run: npm run lint:check
-
 
       # Note: this step is only required locally when using act since the ubuntu image
       # does not come with docker-compose installed, however the alternative to the reinstall

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-echo "Husky pre-commit ran"
-#cd api || exit
-#npm run lint
+cd api || exit
+#npm run lint:fix
+echo "eslint pre-commit checks: COMMENTED OUT"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,6 +2,6 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 cd api || exit
-npm run lint:fix || exit
-npm run format:write
+npm run format:write || exit
+npm run lint:fix
 echo "eslint pre-commit checks: SUCCESSFUL"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,5 +3,5 @@
 
 cd api || exit
 npm run format:write || exit
-npm run lint:fix
+npx lint-staged
 echo "eslint pre-commit checks: SUCCESSFUL"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+echo "Husky pre-commit ran"
+#cd api || exit
+#npm run lint

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,5 +2,6 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 cd api || exit
-npm run lint:fix
+npm run lint:fix || exit
+npm run format:write
 echo "eslint pre-commit checks: SUCCESSFUL"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,5 +2,5 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 cd api || exit
-#npm run lint:fix
-echo "eslint pre-commit checks: COMMENTED OUT"
+npm run lint:fix
+echo "eslint pre-commit checks: SUCCESSFUL"

--- a/api/.eslintrc.json
+++ b/api/.eslintrc.json
@@ -22,7 +22,8 @@
         "eslint:recommended",
         "plugin:@typescript-eslint/recommended",
         "plugin:@typescript-eslint/recommended-requiring-type-checking",
-        "airbnb-typescript/base"
+        "airbnb-typescript/base",
+        "prettier"
     ],
     "overrides": [
         {

--- a/api/.eslintrc.json
+++ b/api/.eslintrc.json
@@ -26,14 +26,15 @@
         "airbnb-typescript/base"
     ],
     "rules": {
+        // TODO: OCT-533 remove prettier when eslint configured
         // Prettier
-        "prettier/prettier": [
-            "error",
-            {},
-            {
-                "usePrettierrc": true
-            }
-        ],
+        //        "prettier/prettier": [
+        //            "error",
+        //            {},
+        //            {
+        //                "usePrettierrc": true
+        //            }
+        //        ],
         // Base rules
         "object-curly-newline": "off",
         "no-restricted-syntax": "off",
@@ -45,6 +46,14 @@
         "comma-dangle": "off",
         "no-console": "off",
         "semi": "off",
+        "arrow-spacing": "error",
+        "no-multi-spaces": "error",
+        "no-multiple-empty-lines": [
+            "error",
+            {
+                "max": 1
+            }
+        ],
         // imports
         "import/no-extraneous-dependencies": "off",
         "import/prefer-default-export": "off",
@@ -55,17 +64,62 @@
         "@typescript-eslint/no-unsafe-assignment": "off", // assigning a value from an any
         "@typescript-eslint/no-empty-interface": "error", // no empty interfaces
         "@typescript-eslint/no-unsafe-argument": "off", // For use of any as a param
-        "@typescript-eslint/no-unsafe-return": "warn", // warn if returning un typed values
         "@typescript-eslint/no-extra-semi": "error", // prettier handles removing this, but error anyway
-        "@typescript-eslint/no-explicit-any": "off", // For use of `any`
         "@typescript-eslint/ban-ts-comment": "off", // For use of ts-ignore & other ts- comments
         "@typescript-eslint/no-unsafe-call": "off", // For calls on type `any`
-        "@typescript-eslint/comma-dangle": "off", // prettier says no trailing comma
         "@typescript-eslint/no-shadow": "off", // out of module scope func names
-        "@typescript-eslint/quotes": "warn", // prettier says single quotes for strings
         "@typescript-eslint/semi": "warn", // preitter says always huse semis
-        "@typescript-eslint/indent": 0 // prettier handles indenting
+
+        // TODO: OCT-533 edits below - discuss with team
+        "@typescript-eslint/no-explicit-any": "error", // For use of `any`
+        "@typescript-eslint/no-unsafe-return": "error", // warn if returning un typed values
+
+        // enforcing trailing comma improves clarity of diffs when editing arrays etc.
+        "@typescript-eslint/comma-dangle": ["error",
+            {
+                "arrays": "only-multiline",
+                "objects": "only-multiline",
+                "imports": "only-multiline"
+            }
+        ],
+
+        // eslint tabbed indent
+        "@typescript-eslint/indent":  ["error", 4],
+        // TODO: check this variable modifier array
+        "@typescript-eslint/naming-convention": [
+            "error",
+            {
+                "selector": "variable",
+                "modifiers": ["exported"],
+                "format": ["camelCase"]
+            }
+        ],
+        // blank line before return statement & around {blocks}
+        "padding-line-between-statements": "off",
+        "@typescript-eslint/padding-line-between-statements": [
+            "error",
+            {
+                "blankLine": "always",
+                "prev": "*",
+                "next": ["return", "block-like"]
+            },
+            {
+                "blankLine": "always",
+                "prev": "block-like",
+                "next": "*"
+            }
+        ],
+        // many rules request base rule is disabled before configuring ts version to avoid odd behaviour
+        "require-await": "off",
+        "@typescript-eslint/require-await": "error",
+        "no-return-await": "off",
+        "@typescript-eslint/return-await": "off",
+        "space-before-blocks": "off",
+        "@typescript-eslint/space-before-blocks": "error"
     },
+
+    // TODO: end of main OCT-533 edits
+
     "overrides": [
         {
             "files": [
@@ -76,6 +130,14 @@
             "rules": {
                 "require-jsdoc": "off",
                 "func-names": "off"
+            }
+        },
+        {
+            // TODO: OCT-533 change check if override is necessary!!
+            // enable function return types specifically for ts files
+            "files": ["*.ts", "*.tsx"],
+            "rules": {
+                "@typescript-eslint/explicit-function-return-type": ["error"]
             }
         }
     ]

--- a/api/.eslintrc.json
+++ b/api/.eslintrc.json
@@ -26,12 +26,10 @@
         "prettier"
     ],
     "overrides": [
-        {
+        { // in theory we have no .js files but just in case..
             "files": [
-                "src/*.js",
-                "src/*.ts"
+                "src/*.js"
             ],
-            "excludedFiles": "*.test.js",
             "rules": {
                 "require-jsdoc": "off",
                 "func-names": "off"

--- a/api/.eslintrc.json
+++ b/api/.eslintrc.json
@@ -16,8 +16,7 @@
         "jest.config.ts"
     ],
     "plugins": [
-        "@typescript-eslint",
-        "prettier"
+        "@typescript-eslint"
     ],
     "extends": [
         "eslint:recommended",
@@ -25,101 +24,6 @@
         "plugin:@typescript-eslint/recommended-requiring-type-checking",
         "airbnb-typescript/base"
     ],
-    "rules": {
-        // TODO: OCT-533 remove prettier when eslint configured
-        // Prettier
-        //        "prettier/prettier": [
-        //            "error",
-        //            {},
-        //            {
-        //                "usePrettierrc": true
-        //            }
-        //        ],
-        // Base rules
-        "object-curly-newline": "off",
-        "no-restricted-syntax": "off",
-        "no-underscore-dangle": "off",
-        "consistent-return": "off",
-        "no-useless-return": "off",
-        "no-await-in-loop": "off",
-        "no-extra-semi": "off",
-        "comma-dangle": "off",
-        "no-console": "off",
-        "semi": "off",
-        "arrow-spacing": "error",
-        "no-multi-spaces": "error",
-        "no-multiple-empty-lines": [
-            "error",
-            {
-                "max": 1
-            }
-        ],
-        // imports
-        "import/no-extraneous-dependencies": "off",
-        "import/prefer-default-export": "off",
-        "import/extensions": "off",
-        // TS
-        "@typescript-eslint/restrict-template-expressions": "off", // accessing possible undefined in template lit, e.g `https://${process.env.STAGE}.example.com` - process.env.stage could be undefined
-        "@typescript-eslint/no-unsafe-member-access": "off", // accessing a value from type any
-        "@typescript-eslint/no-unsafe-assignment": "off", // assigning a value from an any
-        "@typescript-eslint/no-empty-interface": "error", // no empty interfaces
-        "@typescript-eslint/no-unsafe-argument": "off", // For use of any as a param
-        "@typescript-eslint/no-extra-semi": "error", // prettier handles removing this, but error anyway
-        "@typescript-eslint/ban-ts-comment": "off", // For use of ts-ignore & other ts- comments
-        "@typescript-eslint/no-unsafe-call": "off", // For calls on type `any`
-        "@typescript-eslint/no-shadow": "off", // out of module scope func names
-        "@typescript-eslint/semi": "warn", // preitter says always huse semis
-
-        // TODO: OCT-533 edits below - discuss with team
-        "@typescript-eslint/no-explicit-any": "error", // For use of `any`
-        "@typescript-eslint/no-unsafe-return": "error", // warn if returning un typed values
-
-        // enforcing trailing comma improves clarity of diffs when editing arrays etc.
-        "@typescript-eslint/comma-dangle": ["error",
-            {
-                "arrays": "only-multiline",
-                "objects": "only-multiline",
-                "imports": "only-multiline"
-            }
-        ],
-
-        // eslint tabbed indent
-        "@typescript-eslint/indent":  ["error", 4],
-        // TODO: check this variable modifier array
-        "@typescript-eslint/naming-convention": [
-            "error",
-            {
-                "selector": "variable",
-                "modifiers": ["exported"],
-                "format": ["camelCase"]
-            }
-        ],
-        // blank line before return statement & around {blocks}
-        "padding-line-between-statements": "off",
-        "@typescript-eslint/padding-line-between-statements": [
-            "error",
-            {
-                "blankLine": "always",
-                "prev": "*",
-                "next": ["return", "block-like"]
-            },
-            {
-                "blankLine": "always",
-                "prev": "block-like",
-                "next": "*"
-            }
-        ],
-        // many rules request base rule is disabled before configuring ts version to avoid odd behaviour
-        "require-await": "off",
-        "@typescript-eslint/require-await": "error",
-        "no-return-await": "off",
-        "@typescript-eslint/return-await": "off",
-        "space-before-blocks": "off",
-        "@typescript-eslint/space-before-blocks": "error"
-    },
-
-    // TODO: end of main OCT-533 edits
-
     "overrides": [
         {
             "files": [
@@ -133,12 +37,11 @@
             }
         },
         {
-            // TODO: OCT-533 change check if override is necessary!!
-            // enable function return types specifically for ts files
+            // enforce precedence of root .eslintrc.json
             "files": ["*.ts", "*.tsx"],
-            "rules": {
-                "@typescript-eslint/explicit-function-return-type": ["error"]
-            }
+            "extends": [
+                "../.eslintrc.json"
+            ]
         }
     ]
 }

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -2692,6 +2692,16 @@
                 "debug": "4"
             }
         },
+        "aggregate-error": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+            "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+            "dev": true,
+            "requires": {
+                "clean-stack": "^2.0.0",
+                "indent-string": "^4.0.0"
+            }
+        },
         "ajv": {
             "version": "8.11.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
@@ -2903,6 +2913,12 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
             "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
+        },
+        "astral-regex": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+            "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+            "dev": true
         },
         "asynckit": {
             "version": "0.4.0",
@@ -3391,6 +3407,12 @@
             "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
             "dev": true
         },
+        "clean-stack": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+            "dev": true
+        },
         "cli-boxes": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
@@ -3411,6 +3433,50 @@
             "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
             "integrity": "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g==",
             "dev": true
+        },
+        "cli-truncate": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-3.1.0.tgz",
+            "integrity": "sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==",
+            "dev": true,
+            "requires": {
+                "slice-ansi": "^5.0.0",
+                "string-width": "^5.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+                    "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+                    "dev": true
+                },
+                "emoji-regex": {
+                    "version": "9.2.2",
+                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+                    "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+                    "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+                    "dev": true,
+                    "requires": {
+                        "eastasianwidth": "^0.2.0",
+                        "emoji-regex": "^9.2.2",
+                        "strip-ansi": "^7.0.1"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
+                    "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^6.0.1"
+                    }
+                }
+            }
         },
         "cli-width": {
             "version": "3.0.0",
@@ -3468,6 +3534,12 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "colorette": {
+            "version": "2.0.19",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+            "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
+            "dev": true
         },
         "combined-stream": {
             "version": "1.0.8",
@@ -3898,6 +3970,12 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
             "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+            "dev": true
+        },
+        "eastasianwidth": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
             "dev": true
         },
         "ecdsa-sig-formatter": {
@@ -5090,6 +5168,12 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
             "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "dev": true
+        },
+        "indent-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
             "dev": true
         },
         "inflight": {
@@ -6319,11 +6403,165 @@
                 "immediate": "~3.0.5"
             }
         },
+        "lilconfig": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
+            "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
+            "dev": true
+        },
         "lines-and-columns": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
             "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
             "dev": true
+        },
+        "lint-staged": {
+            "version": "13.1.2",
+            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-13.1.2.tgz",
+            "integrity": "sha512-K9b4FPbWkpnupvK3WXZLbgu9pchUJ6N7TtVZjbaPsoizkqFUDkUReUL25xdrCljJs7uLUF3tZ7nVPeo/6lp+6w==",
+            "dev": true,
+            "requires": {
+                "cli-truncate": "^3.1.0",
+                "colorette": "^2.0.19",
+                "commander": "^9.4.1",
+                "debug": "^4.3.4",
+                "execa": "^6.1.0",
+                "lilconfig": "2.0.6",
+                "listr2": "^5.0.5",
+                "micromatch": "^4.0.5",
+                "normalize-path": "^3.0.0",
+                "object-inspect": "^1.12.2",
+                "pidtree": "^0.6.0",
+                "string-argv": "^0.3.1",
+                "yaml": "^2.1.3"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "9.5.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+                    "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+                    "dev": true
+                },
+                "execa": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+                    "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^7.0.3",
+                        "get-stream": "^6.0.1",
+                        "human-signals": "^3.0.1",
+                        "is-stream": "^3.0.0",
+                        "merge-stream": "^2.0.0",
+                        "npm-run-path": "^5.1.0",
+                        "onetime": "^6.0.0",
+                        "signal-exit": "^3.0.7",
+                        "strip-final-newline": "^3.0.0"
+                    }
+                },
+                "human-signals": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
+                    "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
+                    "dev": true
+                },
+                "is-stream": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+                    "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+                    "dev": true
+                },
+                "mimic-fn": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+                    "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+                    "dev": true
+                },
+                "npm-run-path": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+                    "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^4.0.0"
+                    }
+                },
+                "object-inspect": {
+                    "version": "1.12.3",
+                    "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+                    "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+                    "dev": true
+                },
+                "onetime": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+                    "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+                    "dev": true,
+                    "requires": {
+                        "mimic-fn": "^4.0.0"
+                    }
+                },
+                "path-key": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+                    "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+                    "dev": true
+                },
+                "strip-final-newline": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+                    "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+                    "dev": true
+                }
+            }
+        },
+        "listr2": {
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/listr2/-/listr2-5.0.7.tgz",
+            "integrity": "sha512-MD+qXHPmtivrHIDRwPYdfNkrzqDiuaKU/rfBcec3WMyMF3xylQj3jMq344OtvQxz7zaCFViRAeqlr2AFhPvXHw==",
+            "dev": true,
+            "requires": {
+                "cli-truncate": "^2.1.0",
+                "colorette": "^2.0.19",
+                "log-update": "^4.0.0",
+                "p-map": "^4.0.0",
+                "rfdc": "^1.3.0",
+                "rxjs": "^7.8.0",
+                "through": "^2.3.8",
+                "wrap-ansi": "^7.0.0"
+            },
+            "dependencies": {
+                "cli-truncate": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+                    "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+                    "dev": true,
+                    "requires": {
+                        "slice-ansi": "^3.0.0",
+                        "string-width": "^4.2.0"
+                    }
+                },
+                "rxjs": {
+                    "version": "7.8.0",
+                    "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+                    "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+                    "dev": true,
+                    "requires": {
+                        "tslib": "^2.1.0"
+                    }
+                },
+                "slice-ansi": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+                    "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.0.0",
+                        "astral-regex": "^2.0.0",
+                        "is-fullwidth-code-point": "^3.0.0"
+                    }
+                }
+            }
         },
         "loader-runner": {
             "version": "4.2.0",
@@ -6441,6 +6679,42 @@
             "requires": {
                 "chalk": "^4.1.0",
                 "is-unicode-supported": "^0.1.0"
+            }
+        },
+        "log-update": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+            "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "^4.3.0",
+                "cli-cursor": "^3.1.0",
+                "slice-ansi": "^4.0.0",
+                "wrap-ansi": "^6.2.0"
+            },
+            "dependencies": {
+                "slice-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+                    "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.0.0",
+                        "astral-regex": "^2.0.0",
+                        "is-fullwidth-code-point": "^3.0.0"
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+                    "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.0.0",
+                        "string-width": "^4.1.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                }
             }
         },
         "long-timeout": {
@@ -7030,6 +7304,15 @@
                 "p-limit": "^1.1.0"
             }
         },
+        "p-map": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+            "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+            "dev": true,
+            "requires": {
+                "aggregate-error": "^3.0.0"
+            }
+        },
         "p-memoize": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/p-memoize/-/p-memoize-4.0.4.tgz",
@@ -7237,6 +7520,12 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "dev": true
+        },
+        "pidtree": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+            "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
             "dev": true
         },
         "pirates": {
@@ -7667,6 +7956,12 @@
             "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
             "dev": true
         },
+        "rfdc": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+            "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+            "dev": true
+        },
         "rimraf": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -8058,6 +8353,30 @@
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
             "dev": true
         },
+        "slice-ansi": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+            "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^6.0.0",
+                "is-fullwidth-code-point": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "6.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+                    "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+                    "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+                    "dev": true
+                }
+            }
+        },
         "smtp-address-parser": {
             "version": "1.0.10",
             "resolved": "https://registry.npmjs.org/smtp-address-parser/-/smtp-address-parser-1.0.10.tgz",
@@ -8137,6 +8456,12 @@
                     "dev": true
                 }
             }
+        },
+        "string-argv": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
+            "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
+            "dev": true
         },
         "string-collapse-leading-whitespace": {
             "version": "6.0.12",
@@ -9106,6 +9431,12 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        },
+        "yaml": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
+            "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
+            "dev": true
         },
         "yargs": {
             "version": "16.2.0",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -5022,6 +5022,12 @@
             "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
             "dev": true
         },
+        "husky": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+            "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+            "dev": true
+        },
         "iconv-lite": {
             "version": "0.4.24",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -4214,6 +4214,12 @@
                 "eslint-config-airbnb-base": "^15.0.0"
             }
         },
+        "eslint-config-prettier": {
+            "version": "8.6.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz",
+            "integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
+            "dev": true
+        },
         "eslint-import-resolver-node": {
             "version": "0.3.6",
             "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",

--- a/api/package.json
+++ b/api/package.json
@@ -23,7 +23,8 @@
         "reindex": "ts-node prisma/reindex.ts",
         "format:check": "npx prettier --check src/",
         "format:write": "npx prettier --write src/",
-        "lint": "eslint src/"
+        "lint:check": "eslint src/",
+        "lint:fix": "eslint --fix src/"
     },
     "dependencies": {
         "@aws-sdk/client-ses": "^3.76.0",

--- a/api/package.json
+++ b/api/package.json
@@ -16,6 +16,7 @@
         "seed": "ts-node prisma/seed.ts"
     },
     "scripts": {
+        "prepare": "cd .. && husky install",
         "start:local": "nodemon --config nodemon.json",
         "seed:local": "STAGE=local npx prisma migrate reset --force",
         "test:local": "STAGE=local jest --runInBand --testTimeout=60000",
@@ -68,6 +69,7 @@
         "eslint-config-prettier": "^8.6.0",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-prettier": "^4.0.0",
+        "husky": "^8.0.3",
         "jest": "^27.4.7",
         "msw": "^0.36.4",
         "nodemon": "^2.0.15",

--- a/api/package.json
+++ b/api/package.json
@@ -65,6 +65,7 @@
         "aws-lambda": "^1.0.7",
         "eslint": "^8.6.0",
         "eslint-config-airbnb-typescript": "^16.1.0",
+        "eslint-config-prettier": "^8.6.0",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-prettier": "^4.0.0",
         "jest": "^27.4.7",

--- a/api/package.json
+++ b/api/package.json
@@ -71,6 +71,7 @@
         "eslint-plugin-prettier": "^4.0.0",
         "husky": "^8.0.3",
         "jest": "^27.4.7",
+        "lint-staged": "^13.1.2",
         "msw": "^0.36.4",
         "nodemon": "^2.0.15",
         "prettier": "^2.5.1",

--- a/api/src/components/affiliations/controller.ts
+++ b/api/src/components/affiliations/controller.ts
@@ -34,6 +34,7 @@ export const create = async (
         return response.json(200, affiliation);
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };
@@ -69,6 +70,7 @@ export const destroy = async (
         return response.json(200, affiliation);
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };

--- a/api/src/components/authorization/controller.ts
+++ b/api/src/components/authorization/controller.ts
@@ -101,6 +101,7 @@ export const authorize = async (event: I.APIRequest<I.AuthorizeRequestBody>): Pr
         return response.json(200, token);
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };

--- a/api/src/components/authorization/controller.ts
+++ b/api/src/components/authorization/controller.ts
@@ -106,11 +106,11 @@ export const authorize = async (event: I.APIRequest<I.AuthorizeRequestBody>): Pr
     }
 };
 
-export const getDecodedUserToken = async (event: I.AuthenticatedAPIRequest) => {
+export const getDecodedUserToken = async (event: I.AuthenticatedAPIRequest): Promise<I.JSONResponse> => {
     return response.json(200, event.user);
 };
 
-export const verifyOrcidAccess = async (event: I.AuthenticatedAPIRequest) => {
+export const verifyOrcidAccess = async (event: I.AuthenticatedAPIRequest): Promise<I.JSONResponse> => {
     try {
         await authorizationService.verifyOrcidAccess(event.user.orcid);
     } catch (error) {
@@ -120,7 +120,7 @@ export const verifyOrcidAccess = async (event: I.AuthenticatedAPIRequest) => {
     return response.json(200, 'OK');
 };
 
-export const revokeOrcidAccess = async (event: I.AuthenticatedAPIRequest) => {
+export const revokeOrcidAccess = async (event: I.AuthenticatedAPIRequest): Promise<I.JSONResponse> => {
     try {
         await authorizationService.revokeOrcidAccess(event.user.orcid);
     } catch (error) {

--- a/api/src/components/authorization/service.ts
+++ b/api/src/components/authorization/service.ts
@@ -8,15 +8,18 @@ const SECRET = process.env.JWT_SECRET as string;
 
 export const createJWT = (user: I.User): string => {
     const jwt = JWT.sign(user, SECRET, { expiresIn: '8h' });
+
     return jwt;
 };
 
 export const validateJWT = (token: string) => {
     try {
         const decodedJWT = JWT.verify(token, SECRET);
+
         return decodedJWT as I.User;
     } catch (e) {
         console.log(e);
+
         return null;
     }
 };

--- a/api/src/components/bookmark/controller.ts
+++ b/api/src/components/bookmark/controller.ts
@@ -46,6 +46,7 @@ export const create = async (
         return response.json(200, { message: 'You have bookmarked this publication.' });
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };

--- a/api/src/components/coauthor/controller.ts
+++ b/api/src/components/coauthor/controller.ts
@@ -9,6 +9,7 @@ export const get = async (
 ): Promise<I.JSONResponse> => {
     try {
         const coAuthors = await coAuthorService.getAllByPublication(event.pathParameters.id);
+
         return response.json(200, coAuthors);
     } catch (err) {
         return response.json(500, { message: 'Unknown server error.' });
@@ -90,6 +91,7 @@ export const updateAll = async (
         return response.json(200, 'Successfully updated publication authors');
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };

--- a/api/src/components/coauthor/controller.ts
+++ b/api/src/components/coauthor/controller.ts
@@ -170,6 +170,7 @@ export const link = async (
         }
 
         const coAuthorByEmail = publication.coAuthors.find((coAuthor) => coAuthor.email === event.body.email);
+
         // check if this user is part of co-authors list
         if (!coAuthorByEmail) {
             return response.json(403, { message: 'You are not currently listed as an author on this draft' });

--- a/api/src/components/coauthor/service.ts
+++ b/api/src/components/coauthor/service.ts
@@ -139,6 +139,7 @@ export const updateConfirmation = async (publicationId: string, userId: string, 
             confirmedCoAuthor: confirm
         }
     });
+
     return updateCoAuthor;
 };
 
@@ -152,6 +153,7 @@ export const resetCoAuthors = async (publicationId: string) => {
             code: cuid()
         }
     });
+
     return resetCoAuthors;
 };
 

--- a/api/src/components/coauthor/service.ts
+++ b/api/src/components/coauthor/service.ts
@@ -169,7 +169,7 @@ export const isUserAlreadyCoAuthor = async (email: string, publicationId: string
 };
 
 export const getPendingApprovalForPublication = async (publicationId: string) => {
-    const CoAuthors = await client.prisma.coAuthors.findMany({
+    const coAuthors = await client.prisma.coAuthors.findMany({
         where: {
             confirmedCoAuthor: false,
             approvalRequested: false,
@@ -180,11 +180,11 @@ export const getPendingApprovalForPublication = async (publicationId: string) =>
         }
     });
 
-    return CoAuthors;
+    return coAuthors;
 };
 
 export const updateRequestApprovalStatus = async (publicationId: string, email: string) => {
-    const CoAuthors = await client.prisma.coAuthors.updateMany({
+    const coAuthors = await client.prisma.coAuthors.updateMany({
         where: {
             publicationId,
             email
@@ -194,5 +194,5 @@ export const updateRequestApprovalStatus = async (publicationId: string, email: 
         }
     });
 
-    return CoAuthors;
+    return coAuthors;
 };

--- a/api/src/components/flag/controller.ts
+++ b/api/src/components/flag/controller.ts
@@ -7,7 +7,7 @@ import * as I from 'interface';
 import * as helpers from 'lib/helpers';
 import * as email from 'lib/email';
 
-export const get = async (event: I.APIRequest<undefined, undefined, I.GetFlagByID>) => {
+export const get = async (event: I.APIRequest<undefined, undefined, I.GetFlagByID>): Promise<I.JSONResponse> => {
     try {
         const flag = await flagService.get(event.pathParameters.id);
 
@@ -19,7 +19,7 @@ export const get = async (event: I.APIRequest<undefined, undefined, I.GetFlagByI
     }
 };
 
-export const getPublicationFlags = async (event: I.APIRequest<undefined, undefined, I.GetFlagsByPublicationID>) => {
+export const getPublicationFlags = async (event: I.APIRequest<undefined, undefined, I.GetFlagsByPublicationID>): Promise<I.JSONResponse> => {
     try {
         const flags = await flagService.getByPublicationID(event.pathParameters.id);
 
@@ -31,7 +31,7 @@ export const getPublicationFlags = async (event: I.APIRequest<undefined, undefin
     }
 };
 
-export const getUserFlags = async (event: I.APIRequest<undefined, undefined, I.GetFlagsByUserID>) => {
+export const getUserFlags = async (event: I.APIRequest<undefined, undefined, I.GetFlagsByUserID>): Promise<I.JSONResponse> => {
     try {
         const flags = await flagService.getByUserID(event.pathParameters.id);
 
@@ -45,7 +45,7 @@ export const getUserFlags = async (event: I.APIRequest<undefined, undefined, I.G
 
 export const createFlag = async (
     event: I.AuthenticatedAPIRequest<I.CreateFlagRequestBody, undefined, I.CreateFlagPathParams>
-) => {
+): Promise<I.JSONResponse> => {
     try {
         const publication = await publicationService.get(event.pathParameters.id);
 
@@ -122,7 +122,7 @@ export const createFlag = async (
 
 export const createFlagComment = async (
     event: I.AuthenticatedAPIRequest<I.CreateFlagCommentBody, undefined, I.CreateFlagCommentPathParams>
-) => {
+): Promise<I.JSONResponse> => {
     try {
         if (event.body.comment) {
             const isHTMLSafe = helpers.isHTMLSafe(event.body.comment);
@@ -206,7 +206,7 @@ export const createFlagComment = async (
     }
 };
 
-export const resolveFlag = async (event: I.AuthenticatedAPIRequest<undefined, undefined, I.ResolveFlagPathParams>) => {
+export const resolveFlag = async (event: I.AuthenticatedAPIRequest<undefined, undefined, I.ResolveFlagPathParams>): Promise<I.JSONResponse> => {
     try {
         const flag = await flagService.getFlag(event.pathParameters.id);
 

--- a/api/src/components/flag/controller.ts
+++ b/api/src/components/flag/controller.ts
@@ -10,9 +10,11 @@ import * as email from 'lib/email';
 export const get = async (event: I.APIRequest<undefined, undefined, I.GetFlagByID>) => {
     try {
         const flag = await flagService.get(event.pathParameters.id);
+
         return response.json(200, flag);
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };
@@ -20,9 +22,11 @@ export const get = async (event: I.APIRequest<undefined, undefined, I.GetFlagByI
 export const getPublicationFlags = async (event: I.APIRequest<undefined, undefined, I.GetFlagsByPublicationID>) => {
     try {
         const flags = await flagService.getByPublicationID(event.pathParameters.id);
+
         return response.json(200, flags);
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };
@@ -30,9 +34,11 @@ export const getPublicationFlags = async (event: I.APIRequest<undefined, undefin
 export const getUserFlags = async (event: I.APIRequest<undefined, undefined, I.GetFlagsByUserID>) => {
     try {
         const flags = await flagService.getByUserID(event.pathParameters.id);
+
         return response.json(200, flags);
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };
@@ -76,6 +82,7 @@ export const createFlag = async (
 
         // send email to the author aka the creator of the flagged publication
         const emailPromises: Promise<nodemailer.SentMessageInfo>[] = [];
+
         if (publication?.user?.email) {
             emailPromises.push(
                 email.newRedFlagAuthorNotification({
@@ -108,6 +115,7 @@ export const createFlag = async (
         return response.json(200, flag);
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };
@@ -160,6 +168,7 @@ export const createFlagComment = async (
 
         // send email to the author aka the creator of the flagged publication and to the creator of the flag
         const emailPromises: Promise<nodemailer.SentMessageInfo>[] = [];
+
         if (publication?.user.email) {
             emailPromises.push(
                 email.updateRedFlagNotification({
@@ -192,6 +201,7 @@ export const createFlagComment = async (
         return response.json(200, flagComment);
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };
@@ -224,6 +234,7 @@ export const resolveFlag = async (event: I.AuthenticatedAPIRequest<undefined, un
 
         // send email to the author aka the creator of the flagged publication
         const emailPromises: Promise<nodemailer.SentMessageInfo>[] = [];
+
         if (publication?.user?.email) {
             emailPromises.push(
                 email.resolveRedFlagAuthorNotification({
@@ -254,6 +265,7 @@ export const resolveFlag = async (event: I.AuthenticatedAPIRequest<undefined, un
         return response.json(200, resolveFlag);
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };

--- a/api/src/components/flag/controller.ts
+++ b/api/src/components/flag/controller.ts
@@ -19,7 +19,9 @@ export const get = async (event: I.APIRequest<undefined, undefined, I.GetFlagByI
     }
 };
 
-export const getPublicationFlags = async (event: I.APIRequest<undefined, undefined, I.GetFlagsByPublicationID>): Promise<I.JSONResponse> => {
+export const getPublicationFlags = async (
+    event: I.APIRequest<undefined, undefined, I.GetFlagsByPublicationID>
+): Promise<I.JSONResponse> => {
     try {
         const flags = await flagService.getByPublicationID(event.pathParameters.id);
 
@@ -31,7 +33,9 @@ export const getPublicationFlags = async (event: I.APIRequest<undefined, undefin
     }
 };
 
-export const getUserFlags = async (event: I.APIRequest<undefined, undefined, I.GetFlagsByUserID>): Promise<I.JSONResponse> => {
+export const getUserFlags = async (
+    event: I.APIRequest<undefined, undefined, I.GetFlagsByUserID>
+): Promise<I.JSONResponse> => {
     try {
         const flags = await flagService.getByUserID(event.pathParameters.id);
 
@@ -206,7 +210,9 @@ export const createFlagComment = async (
     }
 };
 
-export const resolveFlag = async (event: I.AuthenticatedAPIRequest<undefined, undefined, I.ResolveFlagPathParams>): Promise<I.JSONResponse> => {
+export const resolveFlag = async (
+    event: I.AuthenticatedAPIRequest<undefined, undefined, I.ResolveFlagPathParams>
+): Promise<I.JSONResponse> => {
     try {
         const flag = await flagService.getFlag(event.pathParameters.id);
 

--- a/api/src/components/funder/controller.ts
+++ b/api/src/components/funder/controller.ts
@@ -34,6 +34,7 @@ export const create = async (
         return response.json(200, funder);
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };
@@ -69,6 +70,7 @@ export const destroy = async (
         return response.json(200, funder);
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };

--- a/api/src/components/image/controller.ts
+++ b/api/src/components/image/controller.ts
@@ -51,7 +51,7 @@ export const destroy = async (
     }
 };
 
-export const getAll = async (event: I.AuthenticatedAPIRequest) => {
+export const getAll = async (event: I.AuthenticatedAPIRequest): Promise<I.JSONResponse> => {
     try {
         const images = await imageService.getAll(event.user.id);
 

--- a/api/src/components/image/controller.ts
+++ b/api/src/components/image/controller.ts
@@ -24,6 +24,7 @@ export const create = async (event: I.AuthenticatedAPIRequest<I.ImageSentBody>):
         return response.json(201, imageReference);
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: `Failed to upload "${event.body.name}". Unknown server error.` });
     }
 };

--- a/api/src/components/link/controller.ts
+++ b/api/src/components/link/controller.ts
@@ -65,7 +65,9 @@ export const create = async (event: I.AuthenticatedAPIRequest<I.CreateLinkBody>)
     }
 };
 
-export const deleteLink = async (event: I.AuthenticatedAPIRequest<undefined, undefined, I.DeleteLinkPathParams>): Promise<I.JSONResponse> => {
+export const deleteLink = async (
+    event: I.AuthenticatedAPIRequest<undefined, undefined, I.DeleteLinkPathParams>
+): Promise<I.JSONResponse> => {
     try {
         const link = await linkService.get(event.pathParameters.id);
 

--- a/api/src/components/link/controller.ts
+++ b/api/src/components/link/controller.ts
@@ -60,6 +60,7 @@ export const create = async (event: I.AuthenticatedAPIRequest<I.CreateLinkBody>)
         return response.json(200, link);
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };
@@ -88,6 +89,7 @@ export const deleteLink = async (event: I.AuthenticatedAPIRequest<undefined, und
         return response.json(200, { message: 'Link deleted' });
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };

--- a/api/src/components/link/controller.ts
+++ b/api/src/components/link/controller.ts
@@ -4,7 +4,7 @@ import * as publicationService from 'publication/service';
 
 import * as I from 'interface';
 
-export const create = async (event: I.AuthenticatedAPIRequest<I.CreateLinkBody>) => {
+export const create = async (event: I.AuthenticatedAPIRequest<I.CreateLinkBody>): Promise<I.JSONResponse> => {
     try {
         // function checks if the user has permission to see it in DRAFT mode
         const fromPublication = await publicationService.get(event.body.from);
@@ -65,7 +65,7 @@ export const create = async (event: I.AuthenticatedAPIRequest<I.CreateLinkBody>)
     }
 };
 
-export const deleteLink = async (event: I.AuthenticatedAPIRequest<undefined, undefined, I.DeleteLinkPathParams>) => {
+export const deleteLink = async (event: I.AuthenticatedAPIRequest<undefined, undefined, I.DeleteLinkPathParams>): Promise<I.JSONResponse> => {
     try {
         const link = await linkService.get(event.pathParameters.id);
 

--- a/api/src/components/publication/controller.ts
+++ b/api/src/components/publication/controller.ts
@@ -165,7 +165,7 @@ export const create = async (
 
 export const update = async (
     event: I.AuthenticatedAPIRequest<I.UpdatePublicationRequestBody, undefined, I.UpdatePublicationPathParams>
-) => {
+): Promise<I.JSONResponse> => {
     try {
         const publication = await publicationService.get(event.pathParameters.id);
 

--- a/api/src/components/publication/controller.ts
+++ b/api/src/components/publication/controller.ts
@@ -28,6 +28,7 @@ export const getAll = async (
         });
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };
@@ -63,6 +64,7 @@ export const get = async (
         });
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };
@@ -72,11 +74,13 @@ export const getSeedDataPublications = async (
 ): Promise<I.JSONResponse> => {
     try {
         const publications = await publicationService.getSeedDataPublications(event.queryStringParameters.title);
+
         return response.json(200, {
             publications
         });
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };
@@ -116,6 +120,7 @@ export const deletePublication = async (
         return response.json(200, { message: `Publication ${event.pathParameters.id} deleted` });
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };
@@ -153,6 +158,7 @@ export const create = async (
         return response.json(201, publication);
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };
@@ -218,6 +224,7 @@ export const update = async (
         return response.json(200, updatedPublication);
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };
@@ -277,6 +284,7 @@ export const updateStatus = async (
         return response.json(200, updatedPublication);
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };
@@ -294,6 +302,7 @@ export const getLinksForPublication = async (
         return response.json(200, data);
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };

--- a/api/src/components/publication/schema/create.ts
+++ b/api/src/components/publication/schema/create.ts
@@ -44,7 +44,7 @@ const createPublicationSchema: I.Schema = {
         },
         language: {
             type: 'string',
-            enum: H.OctopusInformation.languages
+            enum: H.octopusInformation.languages
         },
         ethicalStatement: {
             type: 'string'

--- a/api/src/components/publication/schema/update.ts
+++ b/api/src/components/publication/schema/update.ts
@@ -34,7 +34,7 @@ const updatePublicationSchema: I.Schema = {
         },
         language: {
             type: 'string',
-            enum: H.OctopusInformation.languages
+            enum: H.octopusInformation.languages
         },
         ethicalStatement: {
             type: 'string'

--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -302,7 +302,7 @@ export const getOpenSearchRecords = async (filters: I.PublicationFilters) => {
         }
     };
 
-    const must: any[] = [];
+    const must: unknown[] = [];
 
     if (filters.search) {
         // @ts-ignore

--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -266,10 +266,10 @@ export const createOpenSearchRecord = async (data: I.OpenSearchPublication) => {
 export const getOpenSearchRecords = async (filters: I.PublicationFilters) => {
     const orderBy = filters.orderBy
         ? {
-              [filters.orderBy]: {
-                  order: filters.orderDirection || 'asc'
-              }
-          }
+            [filters.orderBy]: {
+                order: filters.orderDirection || 'asc'
+            }
+        }
         : null;
 
     const query = {

--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -266,10 +266,10 @@ export const createOpenSearchRecord = async (data: I.OpenSearchPublication) => {
 export const getOpenSearchRecords = async (filters: I.PublicationFilters) => {
     const orderBy = filters.orderBy
         ? {
-            [filters.orderBy]: {
-                order: filters.orderDirection || 'asc'
-            }
-        }
+              [filters.orderBy]: {
+                  order: filters.orderDirection || 'asc'
+              }
+          }
         : null;
 
     const query = {

--- a/api/src/components/reference/controller.ts
+++ b/api/src/components/reference/controller.ts
@@ -3,7 +3,7 @@ import * as response from 'lib/response';
 import * as referenceService from 'reference/service';
 import * as publicationService from 'publication/service';
 
-export const get = async (event: I.AuthenticatedAPIRequest<undefined, undefined, I.CreateReferencePath>) => {
+export const get = async (event: I.AuthenticatedAPIRequest<undefined, undefined, I.CreateReferencePath>): Promise<I.JSONResponse> => {
     try {
         const references = await referenceService.getAllByPublication(event.pathParameters.id);
 
@@ -13,7 +13,7 @@ export const get = async (event: I.AuthenticatedAPIRequest<undefined, undefined,
     }
 };
 
-export const updateAll = async (event: I.AuthenticatedAPIRequest<I.Reference[], undefined, I.CreateReferencePath>) => {
+export const updateAll = async (event: I.AuthenticatedAPIRequest<I.Reference[], undefined, I.CreateReferencePath>): Promise<I.JSONResponse> => {
     try {
         const publication = await publicationService.get(event.pathParameters.id);
 

--- a/api/src/components/reference/controller.ts
+++ b/api/src/components/reference/controller.ts
@@ -3,7 +3,9 @@ import * as response from 'lib/response';
 import * as referenceService from 'reference/service';
 import * as publicationService from 'publication/service';
 
-export const get = async (event: I.AuthenticatedAPIRequest<undefined, undefined, I.CreateReferencePath>): Promise<I.JSONResponse> => {
+export const get = async (
+    event: I.AuthenticatedAPIRequest<undefined, undefined, I.CreateReferencePath>
+): Promise<I.JSONResponse> => {
     try {
         const references = await referenceService.getAllByPublication(event.pathParameters.id);
 
@@ -13,7 +15,9 @@ export const get = async (event: I.AuthenticatedAPIRequest<undefined, undefined,
     }
 };
 
-export const updateAll = async (event: I.AuthenticatedAPIRequest<I.Reference[], undefined, I.CreateReferencePath>): Promise<I.JSONResponse> => {
+export const updateAll = async (
+    event: I.AuthenticatedAPIRequest<I.Reference[], undefined, I.CreateReferencePath>
+): Promise<I.JSONResponse> => {
     try {
         const publication = await publicationService.get(event.pathParameters.id);
 

--- a/api/src/components/reference/controller.ts
+++ b/api/src/components/reference/controller.ts
@@ -47,6 +47,7 @@ export const updateAll = async (event: I.AuthenticatedAPIRequest<I.Reference[], 
         return response.json(200, reference);
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };

--- a/api/src/components/reference/service.ts
+++ b/api/src/components/reference/service.ts
@@ -6,6 +6,7 @@ export const getAllByPublication = async (publicationId: string) => {
             publicationId
         }
     });
+
     return references;
 };
 
@@ -19,5 +20,6 @@ export const updateAll = async (publicationId, data) => {
     const created = await client.prisma.references.createMany({
         data
     });
+
     return created;
 };

--- a/api/src/components/user/controller.ts
+++ b/api/src/components/user/controller.ts
@@ -14,7 +14,9 @@ export const getAll = async (event: I.APIRequest<undefined, I.UserFilters>): Pro
     }
 };
 
-export const get = async (event: I.OptionalAuthenticatedAPIRequest<undefined, undefined, I.GetUserParameters>): Promise<I.JSONResponse> => {
+export const get = async (
+    event: I.OptionalAuthenticatedAPIRequest<undefined, undefined, I.GetUserParameters>
+): Promise<I.JSONResponse> => {
     try {
         // Authenticated account owners can retrieve private fields (such as email)
         const isAccountOwner = Boolean(event.user?.id === event.pathParameters.id);

--- a/api/src/components/user/controller.ts
+++ b/api/src/components/user/controller.ts
@@ -2,7 +2,7 @@ import * as response from 'lib/response';
 import * as userService from 'user/service';
 import * as I from 'interface';
 
-export const getAll = async (event: I.APIRequest<undefined, I.UserFilters>) => {
+export const getAll = async (event: I.APIRequest<undefined, I.UserFilters>): Promise<I.JSONResponse> => {
     try {
         const users = await userService.getAll(event.queryStringParameters);
 
@@ -14,7 +14,7 @@ export const getAll = async (event: I.APIRequest<undefined, I.UserFilters>) => {
     }
 };
 
-export const get = async (event: I.OptionalAuthenticatedAPIRequest<undefined, undefined, I.GetUserParameters>) => {
+export const get = async (event: I.OptionalAuthenticatedAPIRequest<undefined, undefined, I.GetUserParameters>): Promise<I.JSONResponse> => {
     try {
         // Authenticated account owners can retrieve private fields (such as email)
         const isAccountOwner = Boolean(event.user?.id === event.pathParameters.id);
@@ -35,7 +35,7 @@ export const get = async (event: I.OptionalAuthenticatedAPIRequest<undefined, un
 
 export const getPublications = async (
     event: I.OptionalAuthenticatedAPIRequest<undefined, I.UserPublicationsFilters, I.GetUserParameters>
-) => {
+): Promise<I.JSONResponse> => {
     try {
         const isAccountOwner = Boolean(event.user?.id === event.pathParameters.id);
 

--- a/api/src/components/user/controller.ts
+++ b/api/src/components/user/controller.ts
@@ -9,6 +9,7 @@ export const getAll = async (event: I.APIRequest<undefined, I.UserFilters>) => {
         return response.json(200, users);
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };
@@ -27,6 +28,7 @@ export const get = async (event: I.OptionalAuthenticatedAPIRequest<undefined, un
         return response.json(200, user);
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };
@@ -52,6 +54,7 @@ export const getPublications = async (
         return response.json(200, userPublications);
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };

--- a/api/src/components/user/service.ts
+++ b/api/src/components/user/service.ts
@@ -195,8 +195,8 @@ export const getPublications = async (id: string, params: I.UserPublicationsFilt
         orderBy:
             orderBy && orderDirection
                 ? {
-                      [orderBy]: orderDirection
-                  }
+                    [orderBy]: orderDirection
+                }
                 : undefined
     });
 

--- a/api/src/components/user/service.ts
+++ b/api/src/components/user/service.ts
@@ -48,6 +48,7 @@ export const updateEmail = async (orcid: string, email: string) => {
             orcid
         }
     });
+
     return user;
 };
 
@@ -184,8 +185,8 @@ export const getPublications = async (id: string, params: I.UserPublicationsFilt
         orderBy:
             orderBy && orderDirection
                 ? {
-                      [orderBy]: orderDirection
-                  }
+                    [orderBy]: orderDirection
+                }
                 : undefined
     });
 

--- a/api/src/components/user/service.ts
+++ b/api/src/components/user/service.ts
@@ -185,8 +185,8 @@ export const getPublications = async (id: string, params: I.UserPublicationsFilt
         orderBy:
             orderBy && orderDirection
                 ? {
-                    [orderBy]: orderDirection
-                }
+                      [orderBy]: orderDirection
+                  }
                 : undefined
     });
 

--- a/api/src/components/user/service.ts
+++ b/api/src/components/user/service.ts
@@ -195,8 +195,8 @@ export const getPublications = async (id: string, params: I.UserPublicationsFilt
         orderBy:
             orderBy && orderDirection
                 ? {
-                    [orderBy]: orderDirection
-                }
+                      [orderBy]: orderDirection
+                  }
                 : undefined
     });
 

--- a/api/src/components/verification/controller.ts
+++ b/api/src/components/verification/controller.ts
@@ -9,7 +9,7 @@ import * as verificationService from 'verification/service';
 
 export const requestCode = async (
     event: I.AuthenticatedAPIRequest<undefined, I.RequestVerificationCodeParameters, I.GetUserParameters>
-) => {
+): Promise<I.JSONResponse> => {
     try {
         // generate code
         const code = cryptoRandomString({ length: 7, type: 'distinguishable' });
@@ -39,7 +39,7 @@ export const requestCode = async (
 
 export const confirmCode = async (
     event: I.AuthenticatedAPIRequest<I.ConfirmVerificationCodeBody, undefined, I.GetUserParameters>
-) => {
+): Promise<I.JSONResponse> => {
     try {
         const verification = await verificationService.find(event.pathParameters.id);
 

--- a/api/src/components/verification/controller.ts
+++ b/api/src/components/verification/controller.ts
@@ -32,6 +32,7 @@ export const requestCode = async (
         return response.json(200, { message: 'OK' });
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };
@@ -52,6 +53,7 @@ export const confirmCode = async (
             Number(process.env.VALIDATION_CODE_EXPIRY)
         ) {
             await verificationService.deleteVerification(verification.orcid);
+
             return response.json(404, { message: 'Not found' });
         }
 
@@ -74,12 +76,14 @@ export const confirmCode = async (
         // Expire code on repeated failures to enter correct value
         if (increment.attempts >= Number(process.env.VALIDATION_CODE_ATTEMPTS)) {
             await verificationService.deleteVerification(verification.orcid);
+
             return response.json(404, { message: 'Not found' });
         }
 
         return response.json(422, { message: 'Incorrect code' });
     } catch (err) {
         console.log(err);
+
         return response.json(500, { message: 'Unknown server error.' });
     }
 };

--- a/api/src/components/verification/service.ts
+++ b/api/src/components/verification/service.ts
@@ -31,6 +31,7 @@ export const upsert = async (request: I.UpdateVerificationInformation) => {
 
 export const find = async (orcid: string) => {
     const verification = await client.prisma.verification.findUnique({ where: { orcid } });
+
     return verification;
 };
 
@@ -47,5 +48,6 @@ export const incrementAttempts = async (orcid: string) => {
             }
         }
     });
+
     return verification;
 };

--- a/api/src/lib/email.ts
+++ b/api/src/lib/email.ts
@@ -122,7 +122,7 @@ const styles = {
     `
 };
 
-export const standardHTMLEmailTemplate = (subject: string, html: string) => {
+export const standardHTMLEmailTemplate = (subject: string, html: string): string => {
     return `
         <!DOCTYPE html>
         <html lang="en">
@@ -467,18 +467,18 @@ export const notifyCoAuthorConfirmation = async (options: NotifyCoAuthorConfirma
         // one or more confirmations left
         const html = `
            <p><strong>${options.coAuthor.firstName} ${
-            options.coAuthor.lastName
-        }</strong> has confirmed their involvement in <strong><i>${
-            options.publication.title
-        }</i></strong> and has confirmed that the draft is ready to publish.</p>
+    options.coAuthor.lastName
+}</strong> has confirmed their involvement in <strong><i>${
+    options.publication.title
+}</i></strong> and has confirmed that the draft is ready to publish.</p>
             <br>
             <p style="text-align: center;"><a style="${styles.button}" href="${
-            options.publication.url
-        }" target="_blank" rel="noreferrer noopener">View publication</a></p>
+    options.publication.url
+}" target="_blank" rel="noreferrer noopener">View publication</a></p>
             <br>
             <p><strong>${options.remainingConfirmationsCount}</strong> co-author${
-            options.remainingConfirmationsCount === 1 ? '' : 's'
-        } still need to confirm your draft before this publication can go live.</p> 
+    options.remainingConfirmationsCount === 1 ? '' : 's'
+} still need to confirm your draft before this publication can go live.</p> 
             <br>
             <p>Note that all co-authors must approve before this publication can go live.</p>
         `;

--- a/api/src/lib/email.ts
+++ b/api/src/lib/email.ts
@@ -512,7 +512,7 @@ type NotifyCoAuthorRejection = {
     };
 };
 
-export const notifyCoAuthorRejection = async (options: NotifyCoAuthorRejection) => {
+export const notifyCoAuthorRejection = async (options: NotifyCoAuthorRejection):Promise<void> => {
     const html = `
                 <p>The request that you sent to <strong>${options.coAuthor.email}</strong> to be registered as a co-author of <strong><i>${options.publication.title}</i></strong> has been rejected, and this individual has denied their involvement.</p>
                 <br>
@@ -540,7 +540,7 @@ type NotifyCoAuthorRemoval = {
     };
 };
 
-export const notifyCoAuthorRemoval = async (options: NotifyCoAuthorRemoval) => {
+export const notifyCoAuthorRemoval = async (options: NotifyCoAuthorRemoval): Promise<void> => {
     const html = `
                 <p>You are no longer listed as a co-author on <strong><i>${options.publication.title}</i></strong> and will not receive emails about updates to this publication in future. If you feel that this may have been a mistake, you may wish to contact the author directly to discuss your involvement.</p>
             `;

--- a/api/src/lib/email.ts
+++ b/api/src/lib/email.ts
@@ -1,4 +1,5 @@
 import nodemailer from 'nodemailer';
+import SMTPTransport from 'nodemailer/lib/smtp-transport';
 import * as aws from '@aws-sdk/client-ses';
 import * as I from 'interface';
 
@@ -27,7 +28,7 @@ switch (process.env.STAGE) {
 
 const transporter = nodemailer.createTransport(mailConfig);
 
-export const standardHTMLEmailTemplate = (subject: string, html: string) => {
+export const standardHTMLEmailTemplate = (subject: string, html: string): string => {
     return `
     <!DOCTYPE html>
     <html lang="en">
@@ -175,7 +176,7 @@ export const standardHTMLEmailTemplate = (subject: string, html: string) => {
     `;
 };
 
-export const send = async (options: I.EmailSendOptions) => {
+export const send = async (options: I.EmailSendOptions): Promise<SMTPTransport.SentMessageInfo> => {
     const emailResponse = await transporter.sendMail({
         from,
         to: options.to,
@@ -198,7 +199,7 @@ type NotifyCoAuthor = {
     code: string;
 };
 
-export const notifyCoAuthor = async (options: NotifyCoAuthor) => {
+export const notifyCoAuthor = async (options: NotifyCoAuthor): Promise<void> => {
     const html = `
     <p>${options.userFirstName} ${options?.userLastName} has added you as an author of the following publication on Octopus:</p>
     <br>
@@ -234,7 +235,7 @@ type VerificationCode = {
     userLastName: string | null;
 };
 
-export const verificationCode = async (options: VerificationCode) => {
+export const verificationCode = async (options: VerificationCode): Promise<void> => {
     const html = `
     <p>Hi ${options.userFirstName} ${options?.userLastName},</p>
     <br>
@@ -274,7 +275,7 @@ type NewRedFlagAuthorNotification = {
     flagReason: string;
 };
 
-export const newRedFlagAuthorNotification = async (options: NewRedFlagAuthorNotification) => {
+export const newRedFlagAuthorNotification = async (options: NewRedFlagAuthorNotification): Promise<SMTPTransport.SentMessageInfo> => {
     const html = `
     <p>A potential concern has been flagged with your publication, <strong><i>${options.publicationName}</i></strong>. This will be displayed on the platform until resolved. You can respond to the red flag via the publication page.</p>
     <br>
@@ -310,7 +311,7 @@ type NewRedFlagCreatorNotification = {
     flagId: string;
 };
 
-export const newRedFlagCreatorNotification = async (options: NewRedFlagCreatorNotification) => {
+export const newRedFlagCreatorNotification = async (options: NewRedFlagCreatorNotification): Promise<SMTPTransport.SentMessageInfo> => {
     const html = `
     <p>Thank you for flagging a potential concern with <strong><i>${options.publicationName}</i></strong>. The submitting author has been notified, and has the option to respond to your message.</p>
     <br>
@@ -342,7 +343,7 @@ type UpdateRedFlagNotification = {
     submitter: string;
 };
 
-export const updateRedFlagNotification = async (options: UpdateRedFlagNotification) => {
+export const updateRedFlagNotification = async (options: UpdateRedFlagNotification): Promise<SMTPTransport.SentMessageInfo> => {
     const html = `
     <p>A new comment has been received against the following red flag.</p>
     <br>
@@ -379,7 +380,7 @@ type ResolveRedFlagAuthorNotification = {
     type: string;
 };
 
-export const resolveRedFlagAuthorNotification = async (options: ResolveRedFlagAuthorNotification) => {
+export const resolveRedFlagAuthorNotification = async (options: ResolveRedFlagAuthorNotification): Promise<SMTPTransport.SentMessageInfo> => {
     const html = `
     <p>A red flag for <strong>${options.type}</strong> has been resolved for <strong><i>${options.publicationName}</i></strong>. The red flag 
     warning banner is no longer prominently displayed on the publication page.</p>
@@ -407,7 +408,7 @@ type ResolveRedFlagCreatorNotification = {
     flagId: string;
 };
 
-export const resolveRedFlagCreatorNotification = async (options: ResolveRedFlagCreatorNotification) => {
+export const resolveRedFlagCreatorNotification = async (options: ResolveRedFlagCreatorNotification): Promise<SMTPTransport.SentMessageInfo> => {
     const html = `
     <p>Thank you for resolving the red flag you created for <strong><i>${options.publicationName}</i></strong>. The submitting 
     author has been notified, and the warning banner is no longer prominently displayed on the publication page.</p>
@@ -441,7 +442,7 @@ type NotifyCoAuthorConfirmation = {
     remainingConfirmationsCount: number;
 };
 
-export const notifyCoAuthorConfirmation = async (options: NotifyCoAuthorConfirmation) => {
+export const notifyCoAuthorConfirmation = async (options: NotifyCoAuthorConfirmation): Promise<void> => {
     if (options.remainingConfirmationsCount) {
         // one or more confirmations left
         const html = `

--- a/api/src/lib/email.ts
+++ b/api/src/lib/email.ts
@@ -467,18 +467,18 @@ export const notifyCoAuthorConfirmation = async (options: NotifyCoAuthorConfirma
         // one or more confirmations left
         const html = `
            <p><strong>${options.coAuthor.firstName} ${
-    options.coAuthor.lastName
-}</strong> has confirmed their involvement in <strong><i>${
-    options.publication.title
-}</i></strong> and has confirmed that the draft is ready to publish.</p>
+            options.coAuthor.lastName
+        }</strong> has confirmed their involvement in <strong><i>${
+            options.publication.title
+        }</i></strong> and has confirmed that the draft is ready to publish.</p>
             <br>
             <p style="text-align: center;"><a style="${styles.button}" href="${
-    options.publication.url
-}" target="_blank" rel="noreferrer noopener">View publication</a></p>
+            options.publication.url
+        }" target="_blank" rel="noreferrer noopener">View publication</a></p>
             <br>
             <p><strong>${options.remainingConfirmationsCount}</strong> co-author${
-    options.remainingConfirmationsCount === 1 ? '' : 's'
-} still need to confirm your draft before this publication can go live.</p> 
+            options.remainingConfirmationsCount === 1 ? '' : 's'
+        } still need to confirm your draft before this publication can go live.</p> 
             <br>
             <p>Note that all co-authors must approve before this publication can go live.</p>
         `;

--- a/api/src/lib/email.ts
+++ b/api/src/lib/email.ts
@@ -275,7 +275,9 @@ type NewRedFlagAuthorNotification = {
     flagReason: string;
 };
 
-export const newRedFlagAuthorNotification = async (options: NewRedFlagAuthorNotification): Promise<SMTPTransport.SentMessageInfo> => {
+export const newRedFlagAuthorNotification = async (
+    options: NewRedFlagAuthorNotification
+): Promise<SMTPTransport.SentMessageInfo> => {
     const html = `
     <p>A potential concern has been flagged with your publication, <strong><i>${options.publicationName}</i></strong>. This will be displayed on the platform until resolved. You can respond to the red flag via the publication page.</p>
     <br>
@@ -311,7 +313,9 @@ type NewRedFlagCreatorNotification = {
     flagId: string;
 };
 
-export const newRedFlagCreatorNotification = async (options: NewRedFlagCreatorNotification): Promise<SMTPTransport.SentMessageInfo> => {
+export const newRedFlagCreatorNotification = async (
+    options: NewRedFlagCreatorNotification
+): Promise<SMTPTransport.SentMessageInfo> => {
     const html = `
     <p>Thank you for flagging a potential concern with <strong><i>${options.publicationName}</i></strong>. The submitting author has been notified, and has the option to respond to your message.</p>
     <br>
@@ -343,7 +347,9 @@ type UpdateRedFlagNotification = {
     submitter: string;
 };
 
-export const updateRedFlagNotification = async (options: UpdateRedFlagNotification): Promise<SMTPTransport.SentMessageInfo> => {
+export const updateRedFlagNotification = async (
+    options: UpdateRedFlagNotification
+): Promise<SMTPTransport.SentMessageInfo> => {
     const html = `
     <p>A new comment has been received against the following red flag.</p>
     <br>
@@ -380,7 +386,9 @@ type ResolveRedFlagAuthorNotification = {
     type: string;
 };
 
-export const resolveRedFlagAuthorNotification = async (options: ResolveRedFlagAuthorNotification): Promise<SMTPTransport.SentMessageInfo> => {
+export const resolveRedFlagAuthorNotification = async (
+    options: ResolveRedFlagAuthorNotification
+): Promise<SMTPTransport.SentMessageInfo> => {
     const html = `
     <p>A red flag for <strong>${options.type}</strong> has been resolved for <strong><i>${options.publicationName}</i></strong>. The red flag 
     warning banner is no longer prominently displayed on the publication page.</p>
@@ -408,7 +416,9 @@ type ResolveRedFlagCreatorNotification = {
     flagId: string;
 };
 
-export const resolveRedFlagCreatorNotification = async (options: ResolveRedFlagCreatorNotification): Promise<SMTPTransport.SentMessageInfo> => {
+export const resolveRedFlagCreatorNotification = async (
+    options: ResolveRedFlagCreatorNotification
+): Promise<SMTPTransport.SentMessageInfo> => {
     const html = `
     <p>Thank you for resolving the red flag you created for <strong><i>${options.publicationName}</i></strong>. The submitting 
     author has been notified, and the warning banner is no longer prominently displayed on the publication page.</p>
@@ -447,18 +457,18 @@ export const notifyCoAuthorConfirmation = async (options: NotifyCoAuthorConfirma
         // one or more confirmations left
         const html = `
            <p><strong>${options.coAuthor.firstName} ${
-    options.coAuthor.lastName
-}</strong> has confirmed their involvement in <strong><i>${
-    options.publication.title
-}</i></strong> and has confirmed that the draft is ready to publish.</p>
+            options.coAuthor.lastName
+        }</strong> has confirmed their involvement in <strong><i>${
+            options.publication.title
+        }</i></strong> and has confirmed that the draft is ready to publish.</p>
             <br>
             <p style="text-align: center;"><a class="button" href="${
-    options.publication.url
-}" target="_blank" rel="noreferrer noopener">View publication</a></p>
+                options.publication.url
+            }" target="_blank" rel="noreferrer noopener">View publication</a></p>
             <br>
             <p><strong>${options.remainingConfirmationsCount}</strong> co-author${
-    options.remainingConfirmationsCount === 1 ? '' : 's'
-} still need to confirm your draft before this publication can go live.</p> 
+            options.remainingConfirmationsCount === 1 ? '' : 's'
+        } still need to confirm your draft before this publication can go live.</p> 
             <br>
             <p>Note that all co-authors must approve before this publication can go live.</p>
         `;
@@ -512,7 +522,7 @@ type NotifyCoAuthorRejection = {
     };
 };
 
-export const notifyCoAuthorRejection = async (options: NotifyCoAuthorRejection):Promise<void> => {
+export const notifyCoAuthorRejection = async (options: NotifyCoAuthorRejection): Promise<void> => {
     const html = `
                 <p>The request that you sent to <strong>${options.coAuthor.email}</strong> to be registered as a co-author of <strong><i>${options.publication.title}</i></strong> has been rejected, and this individual has denied their involvement.</p>
                 <br>

--- a/api/src/lib/email.ts
+++ b/api/src/lib/email.ts
@@ -446,18 +446,18 @@ export const notifyCoAuthorConfirmation = async (options: NotifyCoAuthorConfirma
         // one or more confirmations left
         const html = `
            <p><strong>${options.coAuthor.firstName} ${
-            options.coAuthor.lastName
-        }</strong> has confirmed their involvement in <strong><i>${
-            options.publication.title
-        }</i></strong> and has confirmed that the draft is ready to publish.</p>
+    options.coAuthor.lastName
+}</strong> has confirmed their involvement in <strong><i>${
+    options.publication.title
+}</i></strong> and has confirmed that the draft is ready to publish.</p>
             <br>
             <p style="text-align: center;"><a class="button" href="${
-                options.publication.url
-            }" target="_blank" rel="noreferrer noopener">View publication</a></p>
+    options.publication.url
+}" target="_blank" rel="noreferrer noopener">View publication</a></p>
             <br>
             <p><strong>${options.remainingConfirmationsCount}</strong> co-author${
-            options.remainingConfirmationsCount === 1 ? '' : 's'
-        } still need to confirm your draft before this publication can go live.</p> 
+    options.remainingConfirmationsCount === 1 ? '' : 's'
+} still need to confirm your draft before this publication can go live.</p> 
             <br>
             <p>Note that all co-authors must approve before this publication can go live.</p>
         `;

--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -128,15 +128,15 @@ export const updateDOI = async (doi: string, publication: I.PublicationWithMetad
                 relatedIdentifiers: publication?.linkedTo.map((relatedIdentifier) =>
                     relatedIdentifier.publicationToRef.type === 'PEER_REVIEW'
                         ? {
-                            relatedIdentifier: relatedIdentifier.publicationToRef.doi,
-                            relatedIdentifierType: 'DOI',
-                            relationType: 'Reviews'
-                        }
+                              relatedIdentifier: relatedIdentifier.publicationToRef.doi,
+                              relatedIdentifierType: 'DOI',
+                              relationType: 'Reviews'
+                          }
                         : {
-                            relatedIdentifier: relatedIdentifier.publicationToRef.doi,
-                            relatedIdentifierType: 'DOI',
-                            relationType: 'Continues'
-                        }
+                              relatedIdentifier: relatedIdentifier.publicationToRef.doi,
+                              relatedIdentifierType: 'DOI',
+                              relationType: 'Continues'
+                          }
                 ),
                 fundingReferences: publication?.funders.map((funder) => ({
                     funderName: funder.name,

--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -3,7 +3,7 @@ import * as cheerio from 'cheerio';
 
 import * as I from 'interface';
 
-export const isHTMLSafe = (content: string) => {
+export const isHTMLSafe = (content: string): boolean => {
     const $ = cheerio.load(content);
     let error = false;
 
@@ -21,7 +21,7 @@ export const isHTMLSafe = (content: string) => {
     return !error;
 };
 
-export const getSafeHTML = (content: string) => {
+export const getSafeHTML = (content: string): string => {
     const $ = cheerio.load(content, null, false);
 
     $('*').map((_, element) => {
@@ -51,7 +51,7 @@ export const createEmptyDOI = async (): Promise<I.DOIResponse> => {
     return doi.data;
 };
 
-export const updateDOI = async (doi: string, publication: I.PublicationWithMetadata) => {
+export const updateDOI = async (doi: string, publication: I.PublicationWithMetadata): Promise<I.DOIResponse> => {
     // Get creator
     const creator = {
         name: `${publication?.user.firstName} ${publication?.user.lastName}`,
@@ -151,7 +151,7 @@ export const updateDOI = async (doi: string, publication: I.PublicationWithMetad
     return doiRes.data;
 };
 
-export const OctopusInformation: I.OctopusInformation = {
+export const octopusInformation: I.OctopusInformation = {
     publications: [
         'PROBLEM',
         'HYPOTHESIS',
@@ -350,7 +350,7 @@ export const OctopusInformation: I.OctopusInformation = {
     ]
 };
 
-export const formatFlagType = (flagType: I.FlagCategory) => {
+export const formatFlagType = (flagType: I.FlagCategory): string => {
     const types = {
         PLAGIARISM: 'Plagiarism',
         ETHICAL_ISSUES: 'Ethical issues',
@@ -363,7 +363,7 @@ export const formatFlagType = (flagType: I.FlagCategory) => {
     return types[flagType];
 };
 
-export function sanitizeSearchQuery(searchQuery: string) {
+export function sanitizeSearchQuery(searchQuery: string): string {
     return searchQuery
         .trim()
         .replace(/[^a-z0-9\s]/g, (match) => '\\' + match) // escape all the non-alphanumeric characters which may break the search

--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -128,15 +128,15 @@ export const updateDOI = async (doi: string, publication: I.PublicationWithMetad
                 relatedIdentifiers: publication?.linkedTo.map((relatedIdentifier) =>
                     relatedIdentifier.publicationToRef.type === 'PEER_REVIEW'
                         ? {
-                              relatedIdentifier: relatedIdentifier.publicationToRef.doi,
-                              relatedIdentifierType: 'DOI',
-                              relationType: 'Reviews'
-                          }
+                            relatedIdentifier: relatedIdentifier.publicationToRef.doi,
+                            relatedIdentifierType: 'DOI',
+                            relationType: 'Reviews'
+                        }
                         : {
-                              relatedIdentifier: relatedIdentifier.publicationToRef.doi,
-                              relatedIdentifierType: 'DOI',
-                              relationType: 'Continues'
-                          }
+                            relatedIdentifier: relatedIdentifier.publicationToRef.doi,
+                            relatedIdentifierType: 'DOI',
+                            relationType: 'Continues'
+                        }
                 ),
                 fundingReferences: publication?.funders.map((funder) => ({
                     funderName: funder.name,

--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -13,6 +13,7 @@ export const isHTMLSafe = (content: string) => {
 
         if (classes || style) {
             error = true;
+
             return false;
         }
     });
@@ -121,15 +122,15 @@ export const updateDOI = async (doi: string, publication: I.PublicationWithMetad
                 relatedIdentifiers: publication?.linkedTo.map((relatedIdentifier) =>
                     relatedIdentifier.publicationToRef.type === 'PEER_REVIEW'
                         ? {
-                              relatedIdentifier: relatedIdentifier.publicationToRef.doi,
-                              relatedIdentifierType: 'DOI',
-                              relationType: 'Reviews'
-                          }
+                            relatedIdentifier: relatedIdentifier.publicationToRef.doi,
+                            relatedIdentifierType: 'DOI',
+                            relationType: 'Reviews'
+                        }
                         : {
-                              relatedIdentifier: relatedIdentifier.publicationToRef.doi,
-                              relatedIdentifierType: 'DOI',
-                              relationType: 'Continues'
-                          }
+                            relatedIdentifier: relatedIdentifier.publicationToRef.doi,
+                            relatedIdentifierType: 'DOI',
+                            relationType: 'Continues'
+                        }
                 ),
                 fundingReferences: publication?.funders.map((funder) => ({
                     funderName: funder.name,

--- a/api/src/lib/testUtils.ts
+++ b/api/src/lib/testUtils.ts
@@ -33,7 +33,7 @@ export const testSeed = async (): Promise<void> => {
     });
 };
 
-export const openSearchSeed = async () => {
+export const openSearchSeed = async (): Promise<void> => {
     for (const publication of seeds.publicationsDevSeedData) {
         // only seed in live publications
         if (publication.currentStatus === 'LIVE') {

--- a/api/src/lib/testUtils.ts
+++ b/api/src/lib/testUtils.ts
@@ -80,5 +80,6 @@ export const getEmails = async (query: string): Promise<any> => {
             query
         }
     });
+
     return emails?.data;
 };

--- a/api/src/middleware/authentication.ts
+++ b/api/src/middleware/authentication.ts
@@ -27,9 +27,11 @@ const authentication = (optional = false): middy.MiddlewareObj => {
             Object.assign(request.event, { user });
         } catch (err) {
             console.log(err);
+
             return response.json(401, { message: 'Unknown authentication error, please contact help@jisc.ac.uk.' });
         }
     };
+
     return {
         before
     };

--- a/api/src/middleware/checkOwnership.ts
+++ b/api/src/middleware/checkOwnership.ts
@@ -15,10 +15,12 @@ const checkOwnership = (): middy.MiddlewareObj => {
             if (!user) {
                 return response.json(401, { message: 'Please enter either a valid apiKey or bearer token.' });
             }
+
             const publicationId = request.event.pathParameters?.id;
 
             if (publicationId) {
                 const publication = await publicationService.get(publicationId);
+
                 if (publication && publication.createdBy !== user.id) {
                     return response.json(403, {
                         message: 'User is not the author of this publication.'
@@ -27,9 +29,11 @@ const checkOwnership = (): middy.MiddlewareObj => {
             }
         } catch (err) {
             console.log(err);
+
             return response.json(401, { message: 'Unknown authentication error, please contact help@jisc.ac.uk.' });
         }
     };
+
     return {
         before
     };

--- a/api/src/utilities/testing.ts
+++ b/api/src/utilities/testing.ts
@@ -16,8 +16,8 @@ switch (process.env.STAGE) {
 
 export const agent = supertest.agent(`${host}/${config.versions.v1}`);
 
-export const rollback = () => {};
+export const rollback = (): void => {};
 
-export const migrate = () => {};
+export const migrate = (): void => {};
 
-export const seed = () => {};
+export const seed = (): void => {};

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+    '**/*.(js|ts|tsx)?(x)': (filenames) =>
+      filenames.length > 10 ? 'npm run lint:fix' : `eslint --fix ${filenames.join(' ')}`,
+  }

--- a/ui/.eslintrc.json
+++ b/ui/.eslintrc.json
@@ -1,4 +1,5 @@
 {
+    "root": true,
     "extends": ["next/core-web-vitals", "plugin:jsx-a11y/recommended"],
     "rules": {
         // Disabled due to genuine need of using native <img /> tags over Next/Image


### PR DESCRIPTION
The purpose of this PR was...
Standardise formatting (api) via prettier, disable eslint formatting
Automate prettier --write and eslint --fix on pre-commit hook
Manually fix any outstanding issues from api path

### Acceptance Criteria:
(api path only)
git hook is added on npm install
eslint --fix runs on pre-commit on staged files if < 10 or all api files if > 10 staged when committing branch
any formatting issues are auto fixed
any errors that cannot be auto-fixed are communicated to user
commit fails if errors present
commit succeeds if no errors/only warnings
prettier and eslint are run on entire repo by github action to check nothing has managed to bypass hook

### Tests:

---

### Screenshots:
