### PR TITLE
OCT-289 Inconsistent email formatting - OLD OUTLOOK IMAGE SIZE FIX

### DIFF
--- a/api/src/lib/email.ts
+++ b/api/src/lib/email.ts
@@ -137,6 +137,7 @@ export const standardHTMLEmailTemplate = (subject: string, html: string) => {
                         <img
                             src="https://science-octopus-publishing-images-prod.s3.eu-west-1.amazonaws.com/OCTOPUS_LOGO_ILLUSTRATION_WHITE_500PX.png"
                             style="${styles.headerImg}"
+                            width="40"
                         />
                         <h3 style="${styles.headerH3}">Octopus</h3>
                     </div>
@@ -148,12 +149,14 @@ export const standardHTMLEmailTemplate = (subject: string, html: string) => {
                                     <img
                                     src="https://science-octopus-publishing-images-prod.s3.eu-west-1.amazonaws.com/OCTOPUS_LOGO_ILLUSTRATION_WHITE_500PX.png"
                                     style="${styles.footerImg}"
+                                    width="45"
                                     />
                                 </a>
                                 <a href="https://www.jisc.ac.uk/" style="${styles.footerImgLink}">
                                     <img
                                     src="https://www.jisc.ac.uk/sites/all/themes/jisc_clean/img/jisc-logo.svg"
                                     style="${styles.footerImg}"
+                                    width="45"
                                     />
                                 </a>
                             </p>


### PR DESCRIPTION
The purpose of this PR was to fix image size on old outlook email clients.

All the other styles issues in the old outlook client will be ignore because they require much more time and effort to fix and there's no guaranteed result

---

### Acceptance Criteria:

---

### Tests:

---

### Screenshots:
BEFORE
<img width="1398" alt="image" src="https://user-images.githubusercontent.com/48569671/218467067-f9382973-301d-4d5a-9f01-717cbafcf4c1.png">

AFTER
<img width="617" alt="image" src="https://user-images.githubusercontent.com/48569671/218467143-fb400820-81c5-444e-8fe0-56f895897751.png">

