### PR TITLE
OCT-528 Correct co-author emails

### DIFF
--- a/api/src/components/coauthor/controller.ts
+++ b/api/src/components/coauthor/controller.ts
@@ -44,7 +44,7 @@ export const updateAll = async (
         }
 
         // Check if duplicate coAuthors in array
-        const authorEmails = event.body.map((coAuthor) => coAuthor.email);
+        const authorEmails = event.body.map((coAuthor) => coAuthor.email.toLowerCase());
         const isDuplicate = authorEmails.some((coAuthor, index) => authorEmails.indexOf(coAuthor) != index);
 
         if (isDuplicate) {

--- a/ui/src/components/ApprovalsTracker/index.tsx
+++ b/ui/src/components/ApprovalsTracker/index.tsx
@@ -55,7 +55,7 @@ const ApprovalsTracker: React.FC<Props> = (props): React.ReactElement => {
         setTimeout(async () => {
             // open confirmation modal
             const confirmed = await confirmation(
-                "Are you sure you want to change this co-author's email?",
+                "Are you sure you want to change this author's email?",
                 <p>
                     A new invitation email will be dispatched to <span className="font-semibold">{email}</span>.
                 </p>,
@@ -241,14 +241,14 @@ const ApprovalsTracker: React.FC<Props> = (props): React.ReactElement => {
                     negativeActionCallback={handleCloseModal}
                     positiveButtonText="Change Email"
                     cancelButtonText="Cancel"
-                    title="Change co-author email"
+                    title="Change author's email"
                 >
                     <input
                         autoComplete="off"
                         className="my-4 w-full rounded border border-grey-100 bg-white-50 p-2 text-grey-800 shadow outline-none focus:ring-2 focus:ring-yellow-400"
                         defaultValue={selectedAuthor?.email}
                         name="authorEmail"
-                        placeholder="Email of co-author"
+                        placeholder="Email of author"
                         ref={authorEmailRef}
                     />
                     {authorEmailError && <Components.Alert severity="ERROR" title={authorEmailError} />}

--- a/ui/src/components/ApprovalsTracker/index.tsx
+++ b/ui/src/components/ApprovalsTracker/index.tsx
@@ -1,17 +1,110 @@
 import React, { useMemo } from 'react';
+import cuid from 'cuid';
+
 import * as Interfaces from '@interfaces';
 import * as Stores from '@stores';
 import * as OutlineIcons from '@heroicons/react/outline';
+import * as FaIcons from 'react-icons/fa';
 import * as Components from '@components';
+import * as Contexts from '@contexts';
+import * as Helpers from '@helpers';
+import * as Config from '@config';
+import * as api from '@api';
+
+import { KeyedMutator } from 'swr';
 
 type Props = {
     publication: Interfaces.Publication;
     isPublishing: boolean;
     onPublish: () => void;
+    onError: (message: string) => void;
+    refreshPublicationData: KeyedMutator<Interfaces.Publication>;
 };
 
 const ApprovalsTracker: React.FC<Props> = (props): React.ReactElement => {
     const { user } = Stores.useAuthStore();
+    const [selectedAuthor, setSelectedAuthor] = React.useState<null | Interfaces.CoAuthor>(null);
+    const [authorEmailError, setAuthorEmailError] = React.useState('');
+    const confirmation = Contexts.useConfirmationModal();
+    const authorEmailRef = React.useRef<null | HTMLInputElement>(null);
+
+    const handleCloseModal = React.useCallback(() => {
+        setSelectedAuthor(null);
+        setAuthorEmailError('');
+    }, []);
+
+    const handleAuthorEmailChange = React.useCallback(async () => {
+        if (!selectedAuthor) {
+            return;
+        }
+
+        const email = authorEmailRef.current?.value?.trim().toLowerCase() || '';
+        const isValidEmail = Helpers.validateEmail(email);
+
+        if (!isValidEmail) {
+            return setAuthorEmailError('Please enter a valid email address');
+        }
+
+        if (props.publication.coAuthors.some((author) => author.email.toLowerCase() === email)) {
+            return setAuthorEmailError('Email already added as an author');
+        }
+
+        // close author email edit modal
+        setSelectedAuthor(null);
+
+        setTimeout(async () => {
+            // open confirmation modal
+            const confirmed = await confirmation(
+                "Are you sure you want to change this co-author's email?",
+                <p>
+                    A new invitation email will be dispatched to <span className="font-semibold">{email}</span>.
+                </p>,
+                <FaIcons.FaEdit className="h-8 w-8 text-grey-600" />,
+                'Yes, change email',
+                'Cancel'
+            );
+
+            if (confirmed) {
+                const newAuthor = {
+                    id: cuid(),
+                    email,
+                    publicationId: props.publication.id,
+                    approvalRequested: false,
+                    confirmedCoAuthor: false
+                };
+
+                const newAuthorsArray = props.publication.coAuthors.map((author) => {
+                    return author.email === selectedAuthor.email ? newAuthor : author;
+                });
+
+                try {
+                    // update publication authors
+                    await api.put(
+                        `${Config.endpoints.publications}/${props.publication.id}/coauthor`,
+                        newAuthorsArray,
+                        Helpers.getJWT()
+                    );
+
+                    // request approval again
+                    // this will trigger an invitation email for the new author
+                    await api.put(
+                        `${Config.endpoints.publications}/${props.publication.id}/coauthors/request-approval`,
+                        {},
+                        Helpers.getJWT()
+                    );
+
+                    // get updated publication data
+                    await props.refreshPublicationData();
+
+                    // clear out any errors
+                    setAuthorEmailError('');
+                    props.onError('');
+                } catch (error) {
+                    props.onError((error as Interfaces.JSONResponseError).response?.data?.message);
+                }
+            }
+        }, 300); // wait for the other modal to close
+    }, [confirmation, props, selectedAuthor]);
 
     const remainingApprovalsCount = useMemo(
         () => props.publication.coAuthors.filter((author) => !author.confirmedCoAuthor).length,
@@ -39,6 +132,11 @@ const ApprovalsTracker: React.FC<Props> = (props): React.ReactElement => {
                             <th className="whitespace-pre py-3.5 px-6  text-left text-sm font-semibold text-grey-900 duration-500 dark:text-grey-50 ">
                                 Status
                             </th>
+                            {user?.id === props.publication.createdBy && (
+                                <th className="whitespace-pre py-3.5 px-6  text-left text-sm font-semibold text-grey-900 duration-500 dark:text-grey-50 ">
+                                    Edit
+                                </th>
+                            )}
                         </tr>
                     </thead>
                     <tbody className="divide-y divide-grey-100 bg-white-50 duration-500 dark:divide-teal-300 dark:bg-grey-600">
@@ -73,12 +171,31 @@ const ApprovalsTracker: React.FC<Props> = (props): React.ReactElement => {
                                         <>Unconfirmed</>
                                     )}
                                 </td>
+                                {user?.id === props.publication.createdBy && (
+                                    <td className="whitespace-nowrap py-4 px-6  text-sm text-grey-900 duration-500 dark:text-white-50">
+                                        {!author.linkedUser && (
+                                            <Components.IconButton
+                                                className="p-2"
+                                                title="Edit"
+                                                icon={
+                                                    <FaIcons.FaEdit
+                                                        className="h-4 w-4 text-teal-600 transition-colors duration-500 dark:text-teal-400"
+                                                        aria-hidden="true"
+                                                    />
+                                                }
+                                                onClick={() => setSelectedAuthor(author)}
+                                            />
+                                        )}
+                                    </td>
+                                )}
                             </tr>
                         ))}
-                        {user?.id === props.publication.createdBy && (
-                            <tr className="bg-grey-50 duration-500 dark:bg-grey-700">
+                    </tbody>
+                    {user?.id === props.publication.createdBy && (
+                        <tfoot className="bg-grey-50 duration-500 dark:bg-grey-700">
+                            <tr>
                                 <td
-                                    colSpan={2}
+                                    colSpan={3}
                                     className="whitespace-nowrap py-4 px-6 text-sm text-grey-900 duration-500 dark:text-white-50"
                                 >
                                     {remainingApprovalsCount > 0 ? (
@@ -111,10 +228,32 @@ const ApprovalsTracker: React.FC<Props> = (props): React.ReactElement => {
                                     )}
                                 </td>
                             </tr>
-                        )}
-                    </tbody>
+                        </tfoot>
+                    )}
                 </table>
             </div>
+            {user?.id === props.publication.createdBy && (
+                <Components.Modal
+                    open={Boolean(selectedAuthor)}
+                    icon={<FaIcons.FaEdit className="h-8 w-8 text-grey-600" />}
+                    setOpen={handleCloseModal}
+                    positiveActionCallback={handleAuthorEmailChange}
+                    negativeActionCallback={handleCloseModal}
+                    positiveButtonText="Change Email"
+                    cancelButtonText="Cancel"
+                    title="Change co-author email"
+                >
+                    <input
+                        autoComplete="off"
+                        className="my-4 w-full rounded border border-grey-100 bg-white-50 p-2 text-grey-800 shadow outline-none focus:ring-2 focus:ring-yellow-400"
+                        defaultValue={selectedAuthor?.email}
+                        name="authorEmail"
+                        placeholder="Email of co-author"
+                        ref={authorEmailRef}
+                    />
+                    {authorEmailError && <Components.Alert severity="ERROR" title={authorEmailError} />}
+                </Components.Modal>
+            )}
         </div>
     );
 };

--- a/ui/src/components/Publication/Creation/CoAuthor.tsx
+++ b/ui/src/components/Publication/Creation/CoAuthor.tsx
@@ -94,7 +94,7 @@ const CoAuthor: React.FC = (): React.ReactElement => {
     const handleEmailChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
         setEmailValidated(true);
         SetEmailDuplicated(true);
-        setCoAuthor(event.target.value);
+        setCoAuthor(event.target.value?.trim());
     };
 
     // Validate email for co author regex to use -
@@ -104,7 +104,7 @@ const CoAuthor: React.FC = (): React.ReactElement => {
         const authorsArray = coAuthors || [];
 
         // check to ensure co-author email is not already in the store/database
-        const emailDuplicate = authorsArray.some((author) => author.email === coAuthor);
+        const emailDuplicate = authorsArray.some((author) => author.email.toLowerCase() === coAuthor.toLowerCase());
         if (emailDuplicate) {
             SetEmailDuplicated(false);
             setLoading(false);

--- a/ui/src/components/Publication/Creation/MainText.tsx
+++ b/ui/src/components/Publication/Creation/MainText.tsx
@@ -255,8 +255,8 @@ const MainText: React.FC = (): React.ReactElement | null => {
                                                         }
                                                         onClick={async () => {
                                                             const confirmed = await confirmation(
-                                                                'Adding a reference may affect the accuracy of your reference numbering and in-text references.',
                                                                 'Are you sure you want to add this reference?',
+                                                                'Adding a reference may affect the accuracy of your reference numbering and in-text references.',
                                                                 <FAIcons.FaPlus
                                                                     className="h-8 w-8 text-grey-600"
                                                                     aria-hidden="true"
@@ -306,8 +306,8 @@ const MainText: React.FC = (): React.ReactElement | null => {
                                                         }
                                                         onClick={async () => {
                                                             const confirmed = await confirmation(
-                                                                'Deleting a reference may affect the accuracy of your reference numbering and in-text references. This action cannot be undone. ',
                                                                 'Are you sure you want to delete this reference?',
+                                                                'Deleting a reference may affect the accuracy of your reference numbering and in-text references. This action cannot be undone. ',
                                                                 <OutlineIcons.TrashIcon
                                                                     className="h-10 w-10 text-grey-600"
                                                                     aria-hidden="true"
@@ -330,8 +330,8 @@ const MainText: React.FC = (): React.ReactElement | null => {
                                     title="Delete all references"
                                     onClick={async () => {
                                         const confirmed = await confirmation(
-                                            'This action cannot be undone.',
                                             'Are you sure you want to delete all references from this publication?',
+                                            'This action cannot be undone.',
                                             <OutlineIcons.TrashIcon className="h-6 w-6 text-teal-600 transition-colors duration-500 dark:text-teal-400" />,
                                             'Delete all'
                                         );

--- a/ui/src/contexts/ConfirmationModal.tsx
+++ b/ui/src/contexts/ConfirmationModal.tsx
@@ -2,8 +2,8 @@ import React, { createContext, PropsWithChildren, useCallback, useContext, useSt
 import * as Components from '@components';
 
 type ConfirmationModalContextType = (
-    description: string,
-    title?: string,
+    title: string,
+    description: string | React.ReactNode,
     icon?: React.ReactNode,
     positiveButtonText?: string,
     cancelButtonText?: string
@@ -17,7 +17,7 @@ export const useConfirmationModal = () => useContext(ConfirmationModalContext);
 const ConfirmationModalProvider = ({ children }: PropsWithChildren<{}>) => {
     const [open, setOpen] = useState(false);
     const [title, setTitle] = useState<string>('Are you sure?');
-    const [description, setDescription] = useState<string | null>(null);
+    const [description, setDescription] = useState<string | React.ReactNode>(null);
     const [icon, setIcon] = useState<React.ReactNode>(null);
     const [positiveButtonText, setPositiveButtonText] = useState('Save');
     const [cancelButtonText, setCancelButtonText] = useState('Cancel');
@@ -26,17 +26,11 @@ const ConfirmationModalProvider = ({ children }: PropsWithChildren<{}>) => {
         reject: (reason: boolean) => void;
     } | null>(null);
 
-    const confirmation = useCallback(
-        (
-            description: string,
-            title?: string,
-            icon?: React.ReactNode,
-            positiveButtonText?: string,
-            cancelButtonText?: string
-        ): Promise<boolean> =>
+    const confirmation = useCallback<ConfirmationModalContextType>(
+        (title, description, icon, positiveButtonText, cancelButtonText): Promise<boolean> =>
             new Promise((resolve, reject) => {
                 setDescription(description);
-                setTitle(title ? title : 'Are you sure?');
+                setTitle(title);
                 setIcon(icon ? icon : null);
                 setPositiveButtonText(positiveButtonText ? positiveButtonText : 'Save');
                 setCancelButtonText(cancelButtonText ? cancelButtonText : 'Cancel');
@@ -77,7 +71,7 @@ const ConfirmationModalProvider = ({ children }: PropsWithChildren<{}>) => {
                 positiveActionCallback={handlePositiveAction}
                 negativeActionCallback={handleCancelAction}
             >
-                <p className="text-gray-500 text-sm">{description}</p>
+                <div className="text-sm text-grey-700">{description}</div>
             </Components.Modal>
         </ConfirmationModalContext.Provider>
     );

--- a/ui/src/layouts/BuildPublication.tsx
+++ b/ui/src/layouts/BuildPublication.tsx
@@ -317,7 +317,7 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
                 title="Are you sure you want to save your changes?"
                 icon={<ReactIconsFA.FaRegSave className="h-8 w-8 text-grey-600" aria-hidden="true" />}
             >
-                <p className="text-gray-500 text-sm">
+                <p className="text-sm text-grey-700">
                     Changes to your publication will be saved and it will be stored as a draft.
                 </p>
             </Components.Modal>
@@ -330,7 +330,7 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
                 title="Are you sure you want to publish?"
                 icon={<OutlineIcons.CloudUploadIcon className="h-10 w-10 text-grey-600" aria-hidden="true" />}
             >
-                <p className="text-gray-500 text-sm">It is not possible to make any changes post-publication.</p>
+                <p className="text-sm text-grey-700">It is not possible to make any changes post-publication.</p>
             </Components.Modal>
             <Components.Modal
                 open={requestApprovalModalVisibility}
@@ -350,7 +350,7 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
                 title="Are you sure you want to delete this publication?"
                 icon={<OutlineIcons.TrashIcon className="h-10 w-10 text-grey-600" aria-hidden="true" />}
             >
-                <p className="text-gray-500 text-sm">All content will be deleted and cannot be restored.</p>
+                <p className="text-sm text-grey-700">All content will be deleted and cannot be restored.</p>
             </Components.Modal>
             <Components.Header fixed={false} hasBorder={false} />
             <div className="w-full border-t border-grey-100 dark:border-grey-400"></div>

--- a/ui/src/pages/account.tsx
+++ b/ui/src/pages/account.tsx
@@ -82,8 +82,8 @@ const Account: Types.NextPage<Props> = (props): React.ReactElement => {
 
     const handleRevokeAccess = useCallback(async () => {
         const confirmed = await confirmation(
-            "Revoking access to your ORCID profile will log you out. In order to access Octopus again, you'll need to grant permission to your ORCID profile next time you login.",
             'Are you sure?',
+            "Revoking access to your ORCID profile will log you out. In order to access Octopus again, you'll need to grant permission to your ORCID profile next time you login.",
             <OutlineIcons.UserRemoveIcon className="h-8 w-8 text-teal-600 transition-colors duration-500 dark:text-teal-400" />,
             'Yes',
             'No'


### PR DESCRIPTION
The purpose of this PR was to offer corresponding authors a way to edit unconfirmed authors emails

---

### Acceptance Criteria:

As per [OCT-528](https://jiscdev.atlassian.net/browse/OCT-528)

---

### Tests:

Added e2e test to demo the functionality

---

### Screenshots:
![image](https://user-images.githubusercontent.com/48569671/220571038-53357941-4580-4280-934e-7f9057d0aaa7.png)

![image](https://user-images.githubusercontent.com/48569671/220571109-c209ceff-420f-493d-a5f2-dceb26d1b6c3.png)

![image](https://user-images.githubusercontent.com/48569671/220571293-dd874d79-5454-46c8-83c3-012c111bf0fe.png)

![image](https://user-images.githubusercontent.com/48569671/220571377-911e2944-6c95-437c-a13f-1c7f3bca0a6f.png)



[OCT-528]: https://jiscdev.atlassian.net/browse/OCT-528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ