### PR TITLE
OCT-521 - Reminder fix

### DIFF
--- a/api/src/components/coauthor/controller.ts
+++ b/api/src/components/coauthor/controller.ts
@@ -373,9 +373,10 @@ export const sendApprovalReminder = async (
         });
     }
 
-    if (publication.currentStatus !== 'DRAFT') {
+    // Can only send reminder on publications that have been locked for review
+    if (publication.currentStatus !== 'LOCKED') {
         return response.json(403, {
-            message: 'This publication cannot be edited.'
+            message: 'A reminder is not able to be sent unless approval is being requested'
         });
     }
 


### PR DESCRIPTION
The purpose of this PR was to fix a bug where the reminders were not able to be sent due the publication status being in 'LOCKED' rather than 'DRAFT' when initially created. 


