### PR TITLE
OCT-595 - Make guidance more obvious

### DIFF
--- a/ui/src/components/Nav/Desktop/index.tsx
+++ b/ui/src/components/Nav/Desktop/index.tsx
@@ -8,7 +8,6 @@ import * as Types from '@types';
 
 type Props = {
     items: Interfaces.NavMenuItem[];
-    user?: Types.UserType | null;
 };
 
 const Desktop: React.FC<Props> = (props): React.ReactElement => (
@@ -19,11 +18,7 @@ const Desktop: React.FC<Props> = (props): React.ReactElement => (
                     {item.subItems?.length ? (
                         <HeadlessUI.Menu as="div" className="relative z-50 inline-block text-left">
                             <HeadlessUI.Menu.Button
-                                data-testid={
-                                    item.label === `${props.user?.firstName} ${props.user?.lastName}`
-                                        ? 'username-button'
-                                        : null
-                                }
+                                data-testid={item.dataTestId}
                                 className="rounded border-transparent p-2 font-medium text-grey-800 outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400 dark:text-white-50"
                             >
                                 <span className="flex items-center">

--- a/ui/src/components/Nav/Desktop/index.tsx
+++ b/ui/src/components/Nav/Desktop/index.tsx
@@ -4,9 +4,11 @@ import * as HeadlessUI from '@headlessui/react';
 
 import * as Components from '@components';
 import * as Interfaces from '@interfaces';
+import * as Types from '@types';
 
 type Props = {
     items: Interfaces.NavMenuItem[];
+    user?: Types.UserType | null;
 };
 
 const Desktop: React.FC<Props> = (props): React.ReactElement => (
@@ -17,7 +19,11 @@ const Desktop: React.FC<Props> = (props): React.ReactElement => (
                     {item.subItems?.length ? (
                         <HeadlessUI.Menu as="div" className="relative z-50 inline-block text-left">
                             <HeadlessUI.Menu.Button
-                                data-testid="username-button"
+                                data-testid={
+                                    item.label === `${props.user?.firstName} ${props.user?.lastName}`
+                                        ? 'username-button'
+                                        : null
+                                }
                                 className="rounded border-transparent p-2 font-medium text-grey-800 outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400 dark:text-white-50"
                             >
                                 <span className="flex items-center">

--- a/ui/src/components/Nav/index.tsx
+++ b/ui/src/components/Nav/index.tsx
@@ -18,6 +18,24 @@ const Nav: React.FC = (): React.ReactElement => {
                 value: Config.urls.browsePublications.path
             },
             {
+                label: 'How To',
+                value: '',
+                subItems: [
+                    {
+                        label: 'FAQ',
+                        value: Config.urls.faq.path
+                    },
+                    {
+                        label: 'Author Guide',
+                        value: Config.urls.authorGuide.path
+                    },
+                    {
+                        label: 'Our Aims',
+                        value: Config.urls.octopusAims.path
+                    }
+                ]
+            },
+            {
                 label: 'Publish',
                 value: Config.urls.createPublication.path
             }
@@ -44,7 +62,7 @@ const Nav: React.FC = (): React.ReactElement => {
         return menuItems;
     }, [user]);
 
-    return isDesktop ? <Components.NavDesktop items={items} /> : <Components.NavMobile items={items} />;
+    return isDesktop ? <Components.NavDesktop user={user} items={items} /> : <Components.NavMobile items={items} />;
 };
 
 export default Nav;

--- a/ui/src/components/Nav/index.tsx
+++ b/ui/src/components/Nav/index.tsx
@@ -45,6 +45,7 @@ const Nav: React.FC = (): React.ReactElement => {
             menuItems.push({
                 label: `${user?.firstName} ${user?.lastName}`,
                 value: `${Config.urls.viewUser.path}/${user.id}`,
+                dataTestId: 'username-button',
                 subItems: [
                     {
                         label: 'My Profile',
@@ -62,7 +63,7 @@ const Nav: React.FC = (): React.ReactElement => {
         return menuItems;
     }, [user]);
 
-    return isDesktop ? <Components.NavDesktop user={user} items={items} /> : <Components.NavMobile items={items} />;
+    return isDesktop ? <Components.NavDesktop items={items} /> : <Components.NavMobile items={items} />;
 };
 
 export default Nav;

--- a/ui/src/lib/interfaces.ts
+++ b/ui/src/lib/interfaces.ts
@@ -11,6 +11,7 @@ export interface JSONResponseError extends Axios.AxiosError {}
 export interface NavMenuItem {
     label: string;
     value: string;
+    dataTestId?: string;
     subItems?: NavMenuItem[] | React.ReactNode[] | any[];
 }
 

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -69,10 +69,10 @@ const Home: Types.NextPage<Props> = (props): React.ReactElement => {
                             upon the latest work.
                         </p>
 
-                        <div className="mx-auto flex w-fit space-x-6">
+                        <div className="mx-auto flex w-fit flex-wrap justify-around gap-y-5 space-x-6">
                             <Components.Link
                                 href={Config.urls.about.path}
-                                className="flex items-center rounded-lg bg-grey-700 px-4 font-medium text-white-50 transition-colors duration-500 hover:bg-grey-600 dark:bg-teal-600 dark:hover:bg-teal-600"
+                                className="flex items-center rounded-lg bg-grey-700 p-4 font-medium text-white-50 transition-colors duration-500 hover:bg-grey-600 dark:bg-teal-600 dark:hover:bg-teal-600 sm:px-4"
                             >
                                 <span className="text-center font-montserrat text-sm leading-none tracking-wide">
                                     Learn more
@@ -80,7 +80,7 @@ const Home: Types.NextPage<Props> = (props): React.ReactElement => {
                             </Components.Link>
                             <Components.Link
                                 href={Config.urls.authorGuide.path}
-                                className="flex items-center rounded-lg bg-grey-700 px-4 font-medium text-white-50 transition-colors duration-500 hover:bg-grey-600 dark:bg-teal-600 dark:hover:bg-teal-600"
+                                className="flex items-center rounded-lg bg-grey-700 p-4 font-medium text-white-50 transition-colors duration-500 hover:bg-grey-600 dark:bg-teal-600 dark:hover:bg-teal-600 sm:px-4"
                             >
                                 <span className="text-center font-montserrat text-sm leading-none tracking-wide">
                                     Author Guide

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -68,31 +68,30 @@ const Home: Types.NextPage<Props> = (props): React.ReactElement => {
                             enabling peer review and quality assessment and allowing the academic community to build
                             upon the latest work.
                         </p>
-
-                        <div className="mx-auto flex w-fit flex-wrap justify-between gap-y-5 lg:justify-evenly lg:space-x-6">
+                        <div className="mx-auto flex w-full flex-wrap gap-6 sm:w-fit sm:justify-between">
                             <Components.Link
                                 href={Config.urls.about.path}
-                                className="flex w-2/5 items-center rounded-lg bg-grey-700 p-4 font-medium text-white-50 transition-colors duration-500 hover:bg-grey-600 dark:bg-teal-600 dark:hover:bg-teal-600 sm:px-4 lg:w-auto"
+                                className="flex flex-1 items-center rounded-lg bg-grey-700 p-4 font-medium text-white-50 transition-colors duration-500 hover:bg-grey-600 dark:bg-teal-600 dark:hover:bg-teal-600 sm:w-fit sm:flex-auto sm:px-4"
                             >
-                                <span className="mx-auto text-center font-montserrat text-sm leading-none tracking-wide">
+                                <span className="w-full text-center font-montserrat text-sm leading-none tracking-wide">
                                     Learn more
                                 </span>
                             </Components.Link>
                             <Components.Link
                                 href={Config.urls.authorGuide.path}
-                                className="flex w-2/5 items-center space-x-4 rounded-lg bg-grey-700 p-4 font-medium text-white-50 transition-colors duration-500 hover:bg-grey-600 dark:bg-teal-600 dark:hover:bg-teal-600 sm:px-4 lg:w-auto"
+                                className="flex flex-1 items-center space-x-4 rounded-lg bg-grey-700 p-4 font-medium text-white-50 transition-colors duration-500 hover:bg-grey-600 dark:bg-teal-600 dark:hover:bg-teal-600 sm:w-fit sm:flex-auto sm:px-4"
                             >
-                                <span className="mx-auto text-center font-montserrat text-sm leading-none tracking-wide">
+                                <span className="w-full text-center font-montserrat text-sm leading-none tracking-wide">
                                     Author Guide
                                 </span>
                             </Components.Link>
                             <button
                                 aria-label="Open search"
-                                className="flex w-full items-center justify-between rounded-lg bg-teal-600 p-3 text-center outline-0 transition-colors duration-300 hover:bg-teal-700 focus:ring-2 focus:ring-yellow-400 dark:bg-grey-700 dark:hover:bg-grey-600 lg:w-52"
+                                className="flex w-full items-center justify-between rounded-lg bg-teal-600 p-3 text-center outline-0 transition-colors duration-300 hover:bg-teal-700 focus:ring-2 focus:ring-yellow-400 dark:bg-grey-700 dark:hover:bg-grey-600 sm:w-52"
                                 onClick={(e) => toggleCmdPalette()}
                             >
-                                <OutlineIcons.SearchIcon className="h-6 w-6 text-white-50 transition-colors duration-500 dark:text-teal-500" />
-                                <span className="mx-auto font-montserrat text-sm text-white-50 transition-colors duration-500 dark:text-grey-50">
+                                <OutlineIcons.SearchIcon className="h-6 w-6 flex-shrink-0 text-white-50 transition-colors duration-500 dark:text-teal-500" />
+                                <span className="w-full text-center font-montserrat text-sm text-white-50 transition-colors duration-500 dark:text-grey-50">
                                     Quick search...
                                 </span>
                             </button>

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -69,26 +69,26 @@ const Home: Types.NextPage<Props> = (props): React.ReactElement => {
                             upon the latest work.
                         </p>
 
-                        <div className="mx-auto flex w-fit flex-wrap justify-around gap-y-5 space-x-6">
+                        <div className="mx-auto flex w-fit flex-wrap justify-between gap-y-5 lg:justify-evenly lg:space-x-6">
                             <Components.Link
                                 href={Config.urls.about.path}
-                                className="flex items-center rounded-lg bg-grey-700 p-4 font-medium text-white-50 transition-colors duration-500 hover:bg-grey-600 dark:bg-teal-600 dark:hover:bg-teal-600 sm:px-4"
+                                className="flex w-2/5 items-center rounded-lg bg-grey-700 p-4 font-medium text-white-50 transition-colors duration-500 hover:bg-grey-600 dark:bg-teal-600 dark:hover:bg-teal-600 sm:px-4 lg:w-auto"
                             >
-                                <span className="text-center font-montserrat text-sm leading-none tracking-wide">
+                                <span className="mx-auto text-center font-montserrat text-sm leading-none tracking-wide">
                                     Learn more
                                 </span>
                             </Components.Link>
                             <Components.Link
                                 href={Config.urls.authorGuide.path}
-                                className="flex items-center rounded-lg bg-grey-700 p-4 font-medium text-white-50 transition-colors duration-500 hover:bg-grey-600 dark:bg-teal-600 dark:hover:bg-teal-600 sm:px-4"
+                                className="flex w-2/5 items-center space-x-4 rounded-lg bg-grey-700 p-4 font-medium text-white-50 transition-colors duration-500 hover:bg-grey-600 dark:bg-teal-600 dark:hover:bg-teal-600 sm:px-4 lg:w-auto"
                             >
-                                <span className="text-center font-montserrat text-sm leading-none tracking-wide">
+                                <span className="mx-auto text-center font-montserrat text-sm leading-none tracking-wide">
                                     Author Guide
                                 </span>
                             </Components.Link>
                             <button
                                 aria-label="Open search"
-                                className="flex w-52 items-center justify-between rounded-lg bg-teal-600 p-3 text-center outline-0 transition-colors duration-300 hover:bg-teal-700 focus:ring-2 focus:ring-yellow-400 dark:bg-grey-700 dark:hover:bg-grey-600"
+                                className="flex w-full items-center justify-between rounded-lg bg-teal-600 p-3 text-center outline-0 transition-colors duration-300 hover:bg-teal-700 focus:ring-2 focus:ring-yellow-400 dark:bg-grey-700 dark:hover:bg-grey-600 lg:w-52"
                                 onClick={(e) => toggleCmdPalette()}
                             >
                                 <OutlineIcons.SearchIcon className="h-6 w-6 text-white-50 transition-colors duration-500 dark:text-teal-500" />

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -78,6 +78,14 @@ const Home: Types.NextPage<Props> = (props): React.ReactElement => {
                                     Learn more
                                 </span>
                             </Components.Link>
+                            <Components.Link
+                                href={Config.urls.authorGuide.path}
+                                className="flex items-center rounded-lg bg-grey-700 px-4 font-medium text-white-50 transition-colors duration-500 hover:bg-grey-600 dark:bg-teal-600 dark:hover:bg-teal-600"
+                            >
+                                <span className="text-center font-montserrat text-sm leading-none tracking-wide">
+                                    Author Guide
+                                </span>
+                            </Components.Link>
                             <button
                                 aria-label="Open search"
                                 className="flex w-52 items-center justify-between rounded-lg bg-teal-600 p-3 text-center outline-0 transition-colors duration-300 hover:bg-teal-700 focus:ring-2 focus:ring-yellow-400 dark:bg-grey-700 dark:hover:bg-grey-600"


### PR DESCRIPTION
The purpose of this PR was to make the guidance more obvious.

---

### Acceptance Criteria:

As per [OCT-595](https://jiscdev.atlassian.net/browse/OCT-595?atlOrigin=eyJpIjoiNjM0ODE3N2VmMjk4NGVkYzk5YmZkNTViM2NmMzk3MmQiLCJwIjoiaiJ9)

Comment on ticket:

> I have spoken to Tim about the positioning of the “Author Guide” button - This will no longer be to the right to the search, instead the order will be: Learn More - Author Guide - Search




[OCT-595]: https://jiscdev.atlassian.net/browse/OCT-595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ