### PR TITLE
Suggestion: Remove z-index for username on desktop nav.

### DIFF
--- a/ui/src/components/Nav/Desktop/index.tsx
+++ b/ui/src/components/Nav/Desktop/index.tsx
@@ -15,7 +15,7 @@ const Desktop: React.FC<Props> = (props): React.ReactElement => (
             {props.items.map((item) => (
                 <li key={item.value} className="first:ml-0 last:mr-0 md:mx-1 lg:mx-2">
                     {item.subItems?.length ? (
-                        <HeadlessUI.Menu as="div" className="relative z-50 inline-block text-left">
+                        <HeadlessUI.Menu as="div" className="relative inline-block text-left">
                             <HeadlessUI.Menu.Button
                                 data-testid="username-button"
                                 className="rounded border-transparent p-2 font-medium text-grey-800 outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400 dark:text-white-50"


### PR DESCRIPTION
On desktop, when opening the command palette, the display of the username shows above the cp overlay. The issue looks to be desktop only.

<img width="1437" alt="Screenshot 2023-04-03 at 20 54 08" src="https://user-images.githubusercontent.com/7602057/229613165-6f5e752d-da90-4bf8-9b7b-8a2132fb93dc.png">
