### PR TITLE
OCT-581 Author actions bar

### DIFF
--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -669,7 +669,7 @@ const confirmCoAuthorInvitation = async (browser: Browser, user: Helpers.TestUse
 
     await (await page3.waitForSelector('button[title="Yes, this is ready to publish"]')).click();
 
-    await page3.waitForSelector('button:has-text("change your mind")');
+    await page3.waitForSelector('button[title="Cancel your approval"]');
     await context.close();
 };
 
@@ -744,7 +744,7 @@ export const verifyPublicationIsDisplayedAsDraftForCoAuthor = async (
 
     // // Confirm publication is showed as draft
     await page.locator(`a:has-text("${publicationTitle}")`).click();
-    await expect(page.locator('button:has-text("change your mind")')).toBeVisible();
+    await expect(page.locator('button[title="Cancel your approval"]')).toBeVisible();
     await expect(page.locator(`h1:has-text("${publicationTitle}")`)).toHaveText(publicationTitle);
 
     await context.close();
@@ -767,7 +767,7 @@ export const verifyPublicationIsDisplayedAsLiveForCoAuthor = async (
 
     // Confirm publication is showed as live
     await page.locator(`a:has-text("${publicationTitle}")`).click();
-    await expect(page.locator('button:has-text("change your mind")')).not.toBeVisible();
+    await expect(page.locator('button[title="Cancel your approval"]')).not.toBeVisible();
     await expect(page.locator(`h1:has-text("${publicationTitle}")`)).toHaveText(publicationTitle);
 
     await context.close();
@@ -1461,7 +1461,7 @@ test.describe('Publication flow + co-authors', () => {
         await page.waitForNavigation();
 
         // check preview page
-        await expect(page.getByText('This is a draft publication')).toBeVisible();
+        await expect(page.getByText('This publication is locked for approval')).toBeVisible();
         await expect(page.locator('table[data-testid="approval-tracker-table"]')).toBeVisible();
         await expect(page.getByText(`${Helpers.user1.fullName} (You)`)).toBeVisible();
         await expect(page.getByText('2 more author approvals are required before publishing')).toBeVisible();
@@ -1486,7 +1486,7 @@ test.describe('Publication flow + co-authors', () => {
         ]);
 
         // check draft publication controls are not available anymore
-        await expect(page.getByText('This is a draft publication')).not.toBeVisible();
+        await expect(page.getByText('This publication is locked for approval')).not.toBeVisible();
         await expect(page.locator('table[data-testid="approval-tracker-table"]')).not.toBeVisible();
 
         await page.close();
@@ -1531,7 +1531,7 @@ test.describe('Publication flow + co-authors', () => {
         await page.waitForResponse((response) => response.url().includes('/request-approval') && response.ok());
 
         // check preview page
-        await expect(page.getByText('This is a draft publication')).toBeVisible();
+        await expect(page.getByText('This publication is locked for approval')).toBeVisible();
         await expect(page.getByText('Your role on this publication: Corresponding author')).toBeVisible();
         await expect(page.locator('table[data-testid="approval-tracker-table"]')).toBeVisible();
         await expect(page.getByText(`${Helpers.user1.fullName} (You)`)).toBeVisible();
@@ -1597,7 +1597,7 @@ test.describe('Publication flow + co-authors', () => {
         await page.waitForNavigation();
 
         // check preview page
-        await expect(page.getByText('This is a draft publication')).toBeVisible();
+        await expect(page.getByText('This publication is locked for approval')).toBeVisible();
         await expect(page.getByText('Your role on this publication: Corresponding author')).toBeVisible();
         await expect(page.locator('table[data-testid="approval-tracker-table"]')).toBeVisible();
         await expect(page.getByText(`${Helpers.user1.fullName} (You)`)).toBeVisible();

--- a/e2e/tests/PageModel.ts
+++ b/e2e/tests/PageModel.ts
@@ -165,7 +165,7 @@ export const PageModel = {
         replaceButton: 'button:has-text("Replace")',
         importModal: 'div[title="Document Import"]',
         draftEditButton: 'a[role="button"]:has-text("Edit draft publication")',
-        unlockButton: 'a:has-text("Cancel Requests and Unlock for Editing")',
+        unlockButton: 'a:has-text("Cancel all authorship requests and unlock for editing")',
         confirmUnlockButton: 'button:has-text("Unlock")',
         keyInformation: {
             licence: 'select#licence',

--- a/ui/src/components/ApprovalsTracker/index.tsx
+++ b/ui/src/components/ApprovalsTracker/index.tsx
@@ -264,23 +264,12 @@ const ApprovalsTracker: React.FC<Props> = (props): React.ReactElement => {
                                             </h4>
                                         </div>
                                     ) : (
-                                        <div className="flex items-center justify-between gap-4">
-                                            <div className="flex items-center gap-4">
-                                                <OutlineIcons.BadgeCheckIcon className="w-6 text-green-500 duration-500 dark:text-green-300" />
-                                                <h4 className="text-lg dark:text-white-50">
-                                                    All authors have <span className="font-semibold">approved</span>{' '}
-                                                    this publication
-                                                </h4>
-                                            </div>
-                                            <Components.Button
-                                                disabled={props.isPublishing}
-                                                className="inline-flex items-center rounded border-2 border-transparent bg-teal-600 px-2.5 text-white-50 shadow-sm outline-0 focus:overflow-hidden focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 disabled:select-none disabled:opacity-50 disabled:hover:cursor-not-allowed children:border-0 children:text-white-50"
-                                                endIcon={<OutlineIcons.CloudUploadIcon className="w-5 text-white-50" />}
-                                                title="Publish"
-                                                onClick={props.onPublish}
-                                            >
-                                                Publish
-                                            </Components.Button>
+                                        <div className="flex items-center justify-center gap-4">
+                                            <OutlineIcons.BadgeCheckIcon className="w-6 text-green-500 duration-500 dark:text-green-300" />
+                                            <h4 className="text-lg dark:text-white-50">
+                                                All authors have <span className="font-semibold">approved</span> this
+                                                publication
+                                            </h4>
                                         </div>
                                     )}
                                 </td>

--- a/ui/src/components/Publication/ActionBar/index.tsx
+++ b/ui/src/components/Publication/ActionBar/index.tsx
@@ -80,19 +80,17 @@ const ActionBar: React.FC<Props> = (props) => {
                             <OutlineIcons.LockClosedIcon className="mr-2 inline max-w-[20px]" />
                             <div>
                                 <p className="pb-1">This publication is locked for approval.</p>
-                                {user?.id === props.publication.createdBy && (
-                                    <Components.Link
-                                        className="inline w-fit rounded text-teal-600 underline outline-0 focus:ring-2 focus:ring-yellow-400 dark:text-teal-200 dark:decoration-teal-200"
-                                        href={`${Config.urls.viewPublication.path}/${props.publication.id}/edit?step=4`}
-                                        title="Edit publication"
-                                        onClick={async (e) => {
-                                            e.preventDefault();
-                                            await props.onUnlockPublication();
-                                        }}
-                                    >
-                                        Cancel all authorship requests and unlock for editing
-                                    </Components.Link>
-                                )}
+                                <Components.Link
+                                    className="inline w-fit rounded text-teal-600 underline outline-0 focus:ring-2 focus:ring-yellow-400 dark:text-teal-200 dark:decoration-teal-200"
+                                    href={`${Config.urls.viewPublication.path}/${props.publication.id}/edit?step=4`}
+                                    title="Edit publication"
+                                    onClick={async (e) => {
+                                        e.preventDefault();
+                                        await props.onUnlockPublication();
+                                    }}
+                                >
+                                    Cancel all authorship requests and unlock for editing
+                                </Components.Link>
                             </div>
                         </div>
                     )}

--- a/ui/src/components/Publication/ActionBar/index.tsx
+++ b/ui/src/components/Publication/ActionBar/index.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import * as Stores from '@stores';
+import * as Interfaces from '@interfaces';
+import * as Components from '@components';
+import * as Helpers from '@helpers';
+import * as Config from '@config';
+import * as OutlineIcons from '@heroicons/react/outline';
+
+type Props = {
+    publication: Interfaces.Publication;
+    isReadyForPublish: boolean;
+    isCorrespondingUser: boolean;
+    isPublishing: boolean;
+    onUnlockPublication: () => Promise<void>;
+    onApprove: () => Promise<void>;
+    onCancelApproval: () => Promise<void>;
+    onPublish: () => Promise<void>;
+};
+
+const ActionBar: React.FC<Props> = (props) => {
+    const { user } = Stores.useAuthStore();
+    const isApprovedByCoAuthor = React.useMemo(
+        () => props.publication.coAuthors.some((author) => author.linkedUser === user?.id && author.confirmedCoAuthor),
+        [props.publication.coAuthors, user?.id]
+    );
+
+    return (
+        <div className="mb-4 rounded-lg bg-grey-50 p-6 text-grey-900 shadow ring-1 ring-black ring-opacity-5 transition-colors duration-500 dark:bg-grey-700 dark:text-white-50 dark:ring-transparent">
+            {user && (
+                <div className="flex flex-col gap-4 pb-8 lg:flex-row lg:items-center lg:justify-between">
+                    <h4>
+                        <strong>Publication status:</strong>{' '}
+                        {Helpers.getPublicationStatusByAuthor(props.publication, user)}
+                    </h4>
+                    {props.isCorrespondingUser ? (
+                        props.isReadyForPublish ? (
+                            <Components.Button
+                                className="inline-flex max-w-fit items-center rounded border-2 border-transparent bg-teal-600 px-2.5 text-white-50 shadow-sm outline-0 focus:overflow-hidden focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 disabled:select-none disabled:opacity-50 disabled:hover:cursor-not-allowed children:border-0 children:text-white-50"
+                                disabled={props.isPublishing}
+                                endIcon={<OutlineIcons.CloudUploadIcon className="w-5 shrink-0 text-white-50" />}
+                                title="Publish"
+                                onClick={props.onPublish}
+                            >
+                                Publish
+                            </Components.Button>
+                        ) : null
+                    ) : isApprovedByCoAuthor ? (
+                        <Components.Button
+                            className="inline-flex max-w-fit items-center rounded border-2 border-transparent bg-red-600 px-2.5 text-white-50 shadow-sm outline-0 focus:overflow-hidden focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 disabled:select-none disabled:opacity-50 disabled:hover:cursor-not-allowed children:border-0 children:text-white-50"
+                            endIcon={<OutlineIcons.XIcon className="w-5 shrink-0 text-white-50" />}
+                            title="Cancel your approval"
+                            onClick={props.onCancelApproval}
+                        >
+                            Cancel your approval
+                        </Components.Button>
+                    ) : (
+                        <Components.Button
+                            className="inline-flex max-w-fit items-center rounded border-2 border-transparent bg-teal-600 px-2.5 text-white-50 shadow-sm outline-0 focus:overflow-hidden focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 disabled:select-none disabled:opacity-50 disabled:hover:cursor-not-allowed children:border-0 children:text-white-50"
+                            endIcon={<OutlineIcons.CheckIcon className="w-5 shrink-0 text-white-50" />}
+                            title="Approve this publication"
+                            onClick={props.onApprove}
+                        >
+                            Approve this publication
+                        </Components.Button>
+                    )}
+                </div>
+            )}
+
+            <div className="grid gap-6 lg:grid-cols-2">
+                <div>
+                    <div className="flex items-start text-sm">
+                        <OutlineIcons.ExclamationCircleIcon className="mr-2 inline max-w-[20px]" />
+                        <p>
+                            This publication is only visible to authors. All authors must approve this draft before it
+                            can be published.
+                        </p>
+                    </div>
+                    {props.isCorrespondingUser && (
+                        <div className="mt-6 flex items-start text-sm">
+                            <OutlineIcons.LockClosedIcon className="mr-2 inline max-w-[20px]" />
+                            <div>
+                                <p className="pb-1">This publication is locked for approval.</p>
+                                {user?.id === props.publication.createdBy && (
+                                    <Components.Link
+                                        className="inline w-fit rounded text-teal-600 underline outline-0 focus:ring-2 focus:ring-yellow-400 dark:text-teal-200 dark:decoration-teal-200"
+                                        href={`${Config.urls.viewPublication.path}/${props.publication.id}/edit?step=4`}
+                                        title="Edit publication"
+                                        onClick={async (e) => {
+                                            e.preventDefault();
+                                            await props.onUnlockPublication();
+                                        }}
+                                    >
+                                        Cancel all authorship requests and unlock for editing.
+                                    </Components.Link>
+                                )}
+                            </div>
+                        </div>
+                    )}
+                </div>
+                {!props.isCorrespondingUser && (
+                    <div className="flex items-start text-sm">
+                        <OutlineIcons.ExclamationCircleIcon className="mr-2 inline max-w-[20px]" />
+                        <p>
+                            {isApprovedByCoAuthor
+                                ? 'You have already approved this publication.'
+                                : 'If any changes are required, please discuss with the corresponding author.'}
+                        </p>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default ActionBar;

--- a/ui/src/components/Publication/ActionBar/index.tsx
+++ b/ui/src/components/Publication/ActionBar/index.tsx
@@ -90,7 +90,7 @@ const ActionBar: React.FC<Props> = (props) => {
                                             await props.onUnlockPublication();
                                         }}
                                     >
-                                        Cancel all authorship requests and unlock for editing.
+                                        Cancel all authorship requests and unlock for editing
                                     </Components.Link>
                                 )}
                             </div>

--- a/ui/src/components/Publication/SimpleResult/index.tsx
+++ b/ui/src/components/Publication/SimpleResult/index.tsx
@@ -10,30 +10,10 @@ type Props = {
 };
 
 const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
-    const publicationStatus = (publication: Interfaces.UserPublication, user: Interfaces.User) => {
-        if (publication.currentStatus === 'LIVE') return 'Live';
-
-        if (publication.currentStatus === 'DRAFT') {
-            return publication.createdBy === user.id ? 'Draft' : 'Editing in progress';
-        }
-
-        if (publication.coAuthors.length > 1) {
-            if (publication.coAuthors.every((author) => author.confirmedCoAuthor)) {
-                return 'Ready to publish';
-            }
-
-            if (
-                user.id !== publication.createdBy &&
-                publication.coAuthors.find((author) => author.linkedUser === user.id && !author.confirmedCoAuthor)
-            ) {
-                return 'Pending your approval';
-            }
-        }
-
-        return 'Pending author approval';
-    };
-
-    const status = useMemo(() => publicationStatus(props.publication, props.user), [props.publication, props.user]);
+    const status = useMemo(
+        () => Helpers.getPublicationStatusByAuthor(props.publication, props.user),
+        [props.publication, props.user]
+    );
 
     return (
         <div className="w-full rounded border border-transparent bg-white-50 p-3 text-sm shadow transition-colors duration-500 dark:border-teal-500 dark:bg-transparent dark:shadow-none sm:text-base">

--- a/ui/src/components/index.tsx
+++ b/ui/src/components/index.tsx
@@ -89,3 +89,4 @@ export { default as Tooltip } from './Tooltip';
 export { default as AddReferences } from './References/AddReferences';
 export { default as EditReferenceModal } from './References/EditReferenceModal';
 export { default as ApprovalsTracker } from './ApprovalsTracker';
+export { default as ActionBar } from './Publication/ActionBar';


### PR DESCRIPTION
The purpose of this PR was to add an "action bar" on the publication page while the publication it's locked for approvals
The second 'Publish' button was removed from the bottom of the Approvals Tracker table since it's not needed anymore.

---

### Acceptance Criteria:

As per [OCT-581](https://jiscdev.atlassian.net/browse/OCT-581)

---

### Tests:

Updated e2e tests.

---

### Screenshots:

![image](https://user-images.githubusercontent.com/48569671/229818029-e2c25318-1563-4ce0-b2a5-1a105161602b.png)
![image](https://user-images.githubusercontent.com/48569671/229818093-14e568bb-fc5c-44e6-926e-8d608df9a8c7.png)
![image](https://user-images.githubusercontent.com/48569671/229818177-59dc8bdc-01e9-458f-93c7-a934cedaf41d.png)


[OCT-581]: https://jiscdev.atlassian.net/browse/OCT-581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ