### PR TITLE
OCT-588 API Request approval not checking completion

### DIFF
--- a/api/prisma/seeds/publications.ts
+++ b/api/prisma/seeds/publications.ts
@@ -94,6 +94,47 @@ const publicationSeeds = [
         }
     },
     {
+        id: 'locked-publication-problem-confirmed-co-authors',
+        title: 'LOCKED Publication PROBLEM confirmed co-authors',
+        type: 'PROBLEM',
+        licence: 'CC_BY',
+        content: 'LOCKED Publication PROBLEM confirmed co-authors',
+        conflictOfInterestStatus: false,
+        currentStatus: 'LOCKED',
+        doi: '10.82259/cty5-2g03',
+        user: {
+            connect: {
+                id: 'test-user-1'
+            }
+        },
+        coAuthors: {
+            create: {
+                id: 'test-user-2',
+                email: 'test-user-2@jisc.ac.uk',
+                code: 'test-user-2',
+                confirmedCoAuthor: true,
+                linkedUser: 'test-user-2'
+            }
+        },
+        publicationStatus: {
+            create: [
+                {
+                    status: 'DRAFT',
+                    createdAt: '2022-01-20T15:51:42.523Z'
+                },
+                {
+                    status: 'LOCKED',
+                    createdAt: '2022-01-22T15:51:42.523Z'
+                }
+            ]
+        },
+        linkedTo: {
+            create: {
+                publicationTo: 'publication-problem-live'
+            }
+        }
+    },
+    {
         id: 'publication-problem-draft',
         title: 'Publication PROBLEM-DRAFT',
         type: 'PROBLEM',

--- a/api/src/components/coauthor/__tests__/requestApproval.test.ts
+++ b/api/src/components/coauthor/__tests__/requestApproval.test.ts
@@ -1,0 +1,46 @@
+import * as testUtils from 'lib/testUtils';
+
+describe('Request co-authors approvals', () => {
+    beforeEach(async () => {
+        await testUtils.clearDB();
+        await testUtils.testSeed();
+    });
+
+    test('Can request approvals only if the publication is DRAFT or LOCKED', async () => {
+        const draftPublicationResponse = await testUtils.agent
+            .put('/publications/publication-problem-draft/coauthors/request-approval')
+            .query({ apiKey: '000000005' });
+
+        expect(draftPublicationResponse.status).toEqual(200);
+
+        const lockedPublicationResponse = await testUtils.agent
+            .put('/publications/publication-problem-locked/coauthors/request-approval')
+            .query({ apiKey: '000000005' });
+
+        expect(lockedPublicationResponse.status).toEqual(200);
+    });
+
+    test('Cannot request approvals for a LIVE publication', async () => {
+        const livePublicationResponse = await testUtils.agent
+            .put('/publications/publication-problem-live/coauthors/request-approval')
+            .query({ apiKey: '123456789' });
+
+        expect(livePublicationResponse.status).toEqual(403);
+    });
+
+    test('Cannot request approvals if user is not the creator', async () => {
+        const draftPublicationResponse = await testUtils.agent
+            .put('/publications/publication-problem-draft/coauthors/request-approval')
+            .query({ apiKey: '000000006' });
+
+        expect(draftPublicationResponse.status).toEqual(403);
+    });
+
+    test('Cannot request approvals if publication has no-coauthors', async () => {
+        const draftPublicationResponse = await testUtils.agent
+            .put('/publications/publication-2/coauthors/request-approval')
+            .query({ apiKey: '987654321' });
+
+        expect(draftPublicationResponse.status).toEqual(403);
+    });
+});

--- a/api/src/components/coauthor/__tests__/sendApprovalReminder.test.ts
+++ b/api/src/components/coauthor/__tests__/sendApprovalReminder.test.ts
@@ -1,0 +1,86 @@
+import * as testUtils from 'lib/testUtils';
+
+describe('Request co-authors approvals', () => {
+    beforeEach(async () => {
+        await testUtils.clearDB();
+        await testUtils.testSeed();
+    });
+
+    test('Can send approval reminder only if publication status is LOCKED', async () => {
+        // test LIVE
+        const livePublicationResponse = await testUtils.agent
+            .post(
+                '/publications/publication-problem-live/coauthors/coauthor-test-user-6-problem-live/approval-reminder'
+            )
+            .query({ apiKey: '123456789' });
+
+        expect(livePublicationResponse.status).toEqual(403);
+        expect(livePublicationResponse.body.message).toEqual(
+            'A reminder is not able to be sent unless approval is being requested'
+        );
+
+        // test DRAFT
+        const draftPublicationResponse = await testUtils.agent
+            .post(
+                '/publications/publication-problem-draft/coauthors/coauthor-test-user-7-problem-draft/approval-reminder'
+            )
+            .query({ apiKey: '000000005' });
+
+        expect(draftPublicationResponse.status).toEqual(403);
+        expect(draftPublicationResponse.body.message).toEqual(
+            'A reminder is not able to be sent unless approval is being requested'
+        );
+
+        // test LOCKED
+        const lockedPublicationResponse = await testUtils.agent
+            .post(
+                '/publications/publication-problem-locked/coauthors/coauthor-test-user-7-problem-locked/approval-reminder'
+            )
+            .query({ apiKey: '000000005' });
+
+        expect(lockedPublicationResponse.status).toEqual(200);
+        expect(lockedPublicationResponse.body.message).toEqual('Reminder sent to test-user-7@jisc.ac.uk');
+    });
+
+    test('Cannot send approval reminder if a co-author already approved', async () => {
+        const response = await testUtils.agent
+            .post(
+                '/publications/locked-publication-problem-confirmed-co-authors/coauthors/test-user-2/approval-reminder'
+            )
+            .query({ apiKey: '123456789' });
+
+        expect(response.status).toEqual(400);
+        expect(response.body.message).toEqual('This author has already approved this publication');
+    });
+
+    test('Cannot send approval reminder to a user which is not a co-author', async () => {
+        const response = await testUtils.agent
+            .post(
+                '/publications/locked-publication-problem-confirmed-co-authors/coauthors/test-user-22/approval-reminder'
+            )
+            .query({ apiKey: '123456789' });
+
+        expect(response.status).toEqual(404);
+        expect(response.body.message).toEqual('This author does not exist on this publication');
+    });
+
+    test('Cannot send approval reminder to the same co-author twice', async () => {
+        const response1 = await testUtils.agent
+            .post(
+                '/publications/publication-problem-locked/coauthors/coauthor-test-user-7-problem-locked/approval-reminder'
+            )
+            .query({ apiKey: '000000005' });
+
+        expect(response1.status).toEqual(200);
+        expect(response1.body.message).toEqual('Reminder sent to test-user-7@jisc.ac.uk');
+
+        const response2 = await testUtils.agent
+            .post(
+                '/publications/publication-problem-locked/coauthors/coauthor-test-user-7-problem-locked/approval-reminder'
+            )
+            .query({ apiKey: '000000005' });
+
+        expect(response2.status).toEqual(400);
+        expect(response2.body.message).toEqual('You have already sent a reminder to this author');
+    });
+});

--- a/api/src/components/coauthor/controller.ts
+++ b/api/src/components/coauthor/controller.ts
@@ -341,18 +341,11 @@ export const requestApproval = async (
         }
 
         // check if publication actually has co-authors
-        if (publication.coAuthors.length === 1) {
+        if (publication.coAuthors.length < 2) {
             return response.json(403, { message: 'There is no co-author to request approval from.' });
         }
 
         if (publication.currentStatus === 'DRAFT') {
-            // check if publication is ready to be LOCKED
-            if (!publicationService.isReadyToLock(publication)) {
-                return response.json(403, {
-                    message: 'Please make sure all required fields are filled in before requesting approval.'
-                });
-            }
-
             // check if publication was LOCKED before
             if (publication.publicationStatus.some(({ status }) => status === 'LOCKED')) {
                 // notify linked co-authors about changes
@@ -370,9 +363,6 @@ export const requestApproval = async (
                     });
                 }
             }
-
-            // Lock publication from editing
-            await publicationService.updateStatus(publication.id, 'LOCKED');
         }
 
         // get all pending co authors

--- a/api/src/components/coauthor/controller.ts
+++ b/api/src/components/coauthor/controller.ts
@@ -349,7 +349,7 @@ export const requestApproval = async (
             // check if publication is ready to be LOCKED
             if (!publicationService.isReadyToLock(publication)) {
                 return response.json(403, {
-                    message: 'Publication is not ready to be LOCKED. Make sure all fields are filled in.'
+                    message: 'Please make sure all required fields are filled in before requesting approval.'
                 });
             }
 

--- a/api/src/components/coauthor/controller.ts
+++ b/api/src/components/coauthor/controller.ts
@@ -329,34 +329,51 @@ export const requestApproval = async (
             return response.json(404, { message: 'Publication not found' });
         }
 
-        if (
-            publication.currentStatus === 'DRAFT' &&
-            publication.publicationStatus.some(({ status }) => status === 'LOCKED')
-        ) {
-            // notify linked co-authors about changes
-            const linkedCoAuthors = publication.coAuthors.filter(
-                (author) => author.linkedUser && author.linkedUser !== publication.createdBy
-            );
-
-            for (const linkedCoAuthor of linkedCoAuthors) {
-                await email.notifyCoAuthorsAboutChanges({
-                    coAuthor: { email: linkedCoAuthor.email },
-                    publication: {
-                        title: publication.title || '',
-                        url: `${process.env.BASE_URL}/publications/${publication.id}`
-                    }
-                });
-            }
+        if (publication.currentStatus === 'LIVE') {
+            return response.json(403, { message: 'Cannot request approvals for a LIVE publication.' });
         }
 
-        /**
-         * @TODO
-         * - fix bug - publication going into LOCKED mode without title, linked publications, main text, etc...
-         * - find a better way to handle publication transition from one state to another
-         */
+        // check if user is not the corresponding author
+        if (event.user.id !== publication.createdBy) {
+            return response.json(403, {
+                message: 'You are not allowed to request approvals for this publication.'
+            });
+        }
 
-        // Lock publication from editing
-        await publicationService.updateStatus(publication.id, 'LOCKED', false);
+        // check if publication actually has co-authors
+        if (publication.coAuthors.length === 1) {
+            return response.json(403, { message: 'There is no co-author to request approval from.' });
+        }
+
+        if (publication.currentStatus === 'DRAFT') {
+            // check if publication is ready to be LOCKED
+            if (!publicationService.isReadyToLock(publication)) {
+                return response.json(403, {
+                    message: 'Publication is not ready to be LOCKED. Make sure all fields are filled in.'
+                });
+            }
+
+            // check if publication was LOCKED before
+            if (publication.publicationStatus.some(({ status }) => status === 'LOCKED')) {
+                // notify linked co-authors about changes
+                const linkedCoAuthors = publication.coAuthors.filter(
+                    (author) => author.linkedUser && author.linkedUser !== publication.createdBy
+                );
+
+                for (const linkedCoAuthor of linkedCoAuthors) {
+                    await email.notifyCoAuthorsAboutChanges({
+                        coAuthor: { email: linkedCoAuthor.email },
+                        publication: {
+                            title: publication.title || '',
+                            url: `${process.env.BASE_URL}/publications/${publication.id}`
+                        }
+                    });
+                }
+            }
+
+            // Lock publication from editing
+            await publicationService.updateStatus(publication.id, 'LOCKED');
+        }
 
         // get all pending co authors
         const pendingCoAuthors = await coAuthorService.getPendingApprovalForPublication(publicationId);

--- a/api/src/components/coauthor/service.ts
+++ b/api/src/components/coauthor/service.ts
@@ -1,6 +1,6 @@
 import * as client from 'lib/client';
+import * as I from 'lib/interface';
 import cuid from 'cuid';
-import { CoAuthor } from 'lib/interface';
 import { Prisma } from '@prisma/client';
 
 export const get = (id: string) =>
@@ -73,7 +73,7 @@ export const update = (id: string, data: Prisma.CoAuthorsUpdateInput) =>
  * onCreate - don't take user input for fields like: confirmedCoAuthor, approvalRequested or linkedUser
  *
  */
-export const updateAll = (publicationId: string, authors: CoAuthor[]) =>
+export const updateAll = (publicationId: string, authors: I.CoAuthor[]) =>
     client.prisma.$transaction(
         authors.map((author, index) =>
             client.prisma.coAuthors.upsert({

--- a/api/src/components/publication/__tests__/updateStatus.test.ts
+++ b/api/src/components/publication/__tests__/updateStatus.test.ts
@@ -156,7 +156,7 @@ describe('Update publication status', () => {
                 apiKey: '000000005'
             });
 
-        expect(updatePublication.status).toEqual(404);
+        expect(updatePublication.status).toEqual(403);
         expect(updatePublication.body.message).toEqual(
             'Publication is not ready to be made LIVE. Make sure all fields are filled in.'
         );

--- a/api/src/components/publication/__tests__/updateStatus.test.ts
+++ b/api/src/components/publication/__tests__/updateStatus.test.ts
@@ -13,7 +13,7 @@ describe('Update publication status', () => {
                 apiKey: '123456789'
             });
 
-        expect(updatePublicationAttemptOne.status).toEqual(404);
+        expect(updatePublicationAttemptOne.status).toEqual(403);
 
         // add a valid link
         await testUtils.agent
@@ -72,7 +72,7 @@ describe('Update publication status', () => {
                 apiKey: '123456789'
             });
 
-        expect(updatedPublication.status).toEqual(404);
+        expect(updatedPublication.status).toEqual(403);
     });
 
     test('User with permissions cannot update their publication to LIVE from DRAFT if there is no licence.', async () => {
@@ -82,7 +82,7 @@ describe('Update publication status', () => {
                 apiKey: '000000005'
             });
 
-        expect(updatedPublication.status).toEqual(404);
+        expect(updatedPublication.status).toEqual(403);
     });
 
     test('User with permissions can update their publication to LIVE from DRAFT and a publishedDate is created', async () => {
@@ -93,7 +93,7 @@ describe('Update publication status', () => {
             });
 
         expect(updatedPublication.status).toEqual(200);
-        expect(updatedPublication.body.publishedDate).toBeTruthy();
+        expect(updatedPublication.body.message).toEqual('Publication is now LIVE.');
     });
 
     // COI tests
@@ -104,7 +104,7 @@ describe('Update publication status', () => {
                 apiKey: '123456789'
             });
 
-        expect(updatedPublication.status).toEqual(404);
+        expect(updatedPublication.status).toEqual(403);
     });
 
     test('User with permissions can update their publication to LIVE with a conflict of interest, if they have provided text', async () => {
@@ -146,7 +146,7 @@ describe('Update publication status', () => {
 
         expect(updatePublication.status).toEqual(200);
 
-        expect(updatePublication.body.currentStatus).toEqual('LIVE');
+        expect(updatePublication.body.message).toEqual('Publication is now LIVE.');
     });
 
     test('Publication owner cannot publish if not all co-authors are confirmed', async () => {

--- a/api/src/components/publication/controller.ts
+++ b/api/src/components/publication/controller.ts
@@ -236,24 +236,30 @@ export const updateStatus = async (
     event: I.AuthenticatedAPIRequest<undefined, undefined, I.UpdateStatusPathParams>
 ): Promise<I.JSONResponse> => {
     try {
-        const publication = await publicationService.get(event.pathParameters.id);
+        const publicationId = event.pathParameters?.id;
+        const publication = await publicationService.get(publicationId);
+        const newStatus = event.pathParameters?.status;
+        const currentStatus = publication?.currentStatus;
 
-        if (publication?.user.id !== event.user.id) {
+        if (publication?.createdBy !== event.user.id) {
             return response.json(403, {
                 message: 'You do not have permission to modify the status of this publication.'
             });
         }
 
-        // TODO, eventually a service in LIVE can be HIDDEN and a service HIDDEN can become LIVE
-        if (publication?.currentStatus === 'LIVE') {
+        if (currentStatus === 'LIVE') {
             return response.json(403, {
                 message: 'A status of a publication that is not in DRAFT or LOCKED cannot be changed.'
             });
         }
 
-        if (publication?.currentStatus === 'LOCKED' && event.pathParameters.status !== 'LIVE') {
+        if (currentStatus === newStatus) {
+            return response.json(403, { message: `Publication status is already ${newStatus}.` });
+        }
+
+        if (newStatus === 'DRAFT') {
             // Update status to 'DRAFT'
-            await publicationService.updateStatus(event.pathParameters.id, event.pathParameters.status, false);
+            await publicationService.updateStatus(publicationId, newStatus);
 
             // Cancel co author approvals
             await coAuthorService.resetCoAuthors(publication?.id);
@@ -263,22 +269,15 @@ export const updateStatus = async (
             });
         }
 
-        const isReadyToPublish = publicationService.isPublicationReadyToPublish(
-            publication,
-            event.pathParameters.status
-        );
+        const isReadyToPublish = publicationService.isReadyToPublish(publication);
 
         if (!isReadyToPublish) {
-            return response.json(404, {
+            return response.json(403, {
                 message: 'Publication is not ready to be made LIVE. Make sure all fields are filled in.'
             });
         }
 
-        const updatedPublication = await publicationService.updateStatus(
-            event.pathParameters.id,
-            event.pathParameters.status,
-            isReadyToPublish
-        );
+        const updatedPublication = await publicationService.updateStatus(publicationId, newStatus);
 
         // now that the publication is LIVE, we store in opensearch
         await publicationService.createOpenSearchRecord({
@@ -294,11 +293,9 @@ export const updateStatus = async (
         });
 
         // Publication is live, so update the DOI
-        const res = await helpers.updateDOI(publication.doi, publication);
-        console.log(res);
-        // TODO:  Do we want to do anything with this response?
+        await helpers.updateDOI(publication.doi, publication);
 
-        return response.json(200, updatedPublication);
+        return response.json(200, { message: 'Publication is now LIVE.' });
     } catch (err) {
         console.log(err);
 

--- a/api/src/components/publication/schema/updateStatus.ts
+++ b/api/src/components/publication/schema/updateStatus.ts
@@ -5,7 +5,7 @@ const updatedPublicationSchema: I.Schema = {
     properties: {
         status: {
             type: 'string',
-            enum: <I.PublicationStatusEnum[]>['LIVE', 'DRAFT']
+            enum: <I.PublicationStatusEnum[]>['LIVE', 'DRAFT', 'LOCKED']
         },
         id: {
             type: 'string'

--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -416,7 +416,7 @@ export const create = async (e: I.CreatePublicationRequestBody, user: I.User, do
     return publication;
 };
 
-export const updateStatus = async (id: string, status: I.PublicationStatusEnum, isReadyToPublish: boolean) => {
+export const updateStatus = async (id: string, status: I.PublicationStatusEnum) => {
     const query = {
         where: {
             id
@@ -450,7 +450,7 @@ export const updateStatus = async (id: string, status: I.PublicationStatusEnum, 
         }
     };
 
-    if (isReadyToPublish) {
+    if (status === 'LIVE') {
         // @ts-ignore
         query.data.publishedDate = new Date().toISOString();
     }
@@ -482,16 +482,14 @@ export const doesDuplicateFlagExist = async (publication, category, user) => {
     return flag;
 };
 
-export const isPublicationReadyToPublish = (publication: I.PublicationWithMetadata, status: string) => {
+export const isReadyToPublish = (publication: I.PublicationWithMetadata): boolean => {
     if (!publication) {
         return false;
     }
 
-    let isReady = false;
-
-    // @ts-ignore This needs looking at, type mismatch between inferred type from get method to what Prisma has
     const hasAtLeastOneLinkTo = publication.linkedTo.length !== 0;
-    const hasAllFields = ['title', 'content', 'licence'].every((field) => publication[field]);
+    const hasFilledRequiredFields =
+        ['title', 'licence'].every((field) => publication[field]) && !Helpers.isEmptyContent(publication.content || '');
     const conflictOfInterest = validateConflictOfInterest(publication);
     const hasPublishDate = Boolean(publication.publishedDate);
     const isDataAndHasEthicalStatement = publication.type === 'DATA' ? publication.ethicalStatement !== null : true;
@@ -499,23 +497,39 @@ export const isPublicationReadyToPublish = (publication: I.PublicationWithMetada
         publication.type === 'DATA' ? publication.dataPermissionsStatement !== null : true;
     const coAuthorsAreVerified = publication.coAuthors.every((coAuthor) => coAuthor.confirmedCoAuthor);
 
-    const isAttemptToLive = status === 'LIVE';
-
-    // More external checks can be chained here for the future
-    if (
+    return (
         hasAtLeastOneLinkTo &&
-        hasAllFields &&
+        hasFilledRequiredFields &&
         conflictOfInterest &&
         !hasPublishDate &&
         isDataAndHasEthicalStatement &&
         isDataAndHasPermissionsStatement &&
-        coAuthorsAreVerified &&
-        isAttemptToLive
-    ) {
-        isReady = true;
+        coAuthorsAreVerified
+    );
+};
+
+export const isReadyToLock = (publication: I.PublicationWithMetadata) => {
+    if (!publication || publication.currentStatus !== 'DRAFT') {
+        return false;
     }
 
-    return isReady;
+    const hasAtLeastOneLinkTo = publication.linkedTo.length > 0;
+    const hasFilledRequiredFields =
+        ['title', 'licence'].every((field) => publication[field]) && !Helpers.isEmptyContent(publication.content || '');
+    const conflictOfInterest = validateConflictOfInterest(publication);
+    const isDataAndHasEthicalStatement = publication.type === 'DATA' ? publication.ethicalStatement !== null : true;
+    const isDataAndHasPermissionsStatement =
+        publication.type === 'DATA' ? publication.dataPermissionsStatement !== null : true;
+    const hasCoAuthors = publication.coAuthors.length > 1;
+
+    return (
+        hasAtLeastOneLinkTo &&
+        hasFilledRequiredFields &&
+        conflictOfInterest &&
+        isDataAndHasEthicalStatement &&
+        isDataAndHasPermissionsStatement &&
+        hasCoAuthors
+    );
 };
 
 export const getLinksForPublication = async (id: string) => {

--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -520,7 +520,7 @@ export const isReadyToLock = (publication: I.PublicationWithMetadata) => {
     const isDataAndHasEthicalStatement = publication.type === 'DATA' ? publication.ethicalStatement !== null : true;
     const isDataAndHasPermissionsStatement =
         publication.type === 'DATA' ? publication.dataPermissionsStatement !== null : true;
-    const hasCoAuthors = publication.coAuthors.length > 1;
+    const hasRequestedApprovals = publication.coAuthors.some((author) => author.approvalRequested);
 
     return (
         hasAtLeastOneLinkTo &&
@@ -528,7 +528,7 @@ export const isReadyToLock = (publication: I.PublicationWithMetadata) => {
         conflictOfInterest &&
         isDataAndHasEthicalStatement &&
         isDataAndHasPermissionsStatement &&
-        hasCoAuthors
+        hasRequestedApprovals
     );
 };
 

--- a/api/src/components/user/__tests__/getUserPublications.test.ts
+++ b/api/src/components/user/__tests__/getUserPublications.test.ts
@@ -12,7 +12,7 @@ describe('Get a given users publications', () => {
             .query({ apiKey: 123456789, offset: 0, limit: 100 });
 
         expect(publications.status).toEqual(200);
-        expect(publications.body.results.length).toEqual(19);
+        expect(publications.body.results.length).toEqual(20);
     });
 
     test('Unauthenticated user can only view live publications', async () => {

--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -912,3 +912,5 @@ export const createPublicationFooterTemplate = (publication: I.Publication): str
         </div>
     </div>`;
 };
+
+export const isEmptyContent = (content: string): boolean => (content ? /^(<p>\s*<\/p>)+$/.test(content) : true);

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -111,7 +111,7 @@ export interface UpdatePublicationPathParams {
 
 export interface UpdateStatusPathParams {
     id: string;
-    status: 'LIVE';
+    status: 'LIVE' | 'DRAFT';
 }
 
 export interface UpdatePublicationRequestBody {

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -111,7 +111,7 @@ export interface UpdatePublicationPathParams {
 
 export interface UpdateStatusPathParams {
     id: string;
-    status: 'LIVE' | 'DRAFT';
+    status: 'LIVE' | 'DRAFT' | 'LOCKED';
 }
 
 export interface UpdatePublicationRequestBody {

--- a/ui/src/layouts/BuildPublication.tsx
+++ b/ui/src/layouts/BuildPublication.tsx
@@ -213,14 +213,20 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
 
     const requestApproval = useCallback(async () => {
         try {
+            // save publication
             await saveCurrent();
-            const response = await api.put(
+
+            // request co-authors approvals
+            await api.put(
                 `${Config.endpoints.publications}/${props.publication.id}/coauthors/request-approval`,
                 {},
                 props.token
             );
-            updateCoAuthors(response.data);
 
+            // update publication status to LOCKED
+            await api.put(`${Config.endpoints.publications}/${props.publication.id}/status/LOCKED`, {}, props.token);
+
+            // redirect to publication page
             router.push(`${Config.urls.viewPublication.path}/${props.publication.id}`);
         } catch (err) {
             const { message } = err as Interfaces.JSONResponseError;
@@ -386,7 +392,7 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
                             >
                                 <Components.IconButton
                                     title="Toggle side bar"
-                                    className="absolute -right-8 top-[50vh] rounded-br rounded-tr border-t border-r border-b border-grey-400 bg-teal-700"
+                                    className="absolute -right-8 top-[50vh] rounded-br rounded-tr border-b border-r border-t border-grey-400 bg-teal-700"
                                     icon={
                                         showSideBar ? (
                                             <OutlineIcons.ArrowLeftIcon className="h-6 w-6 text-white-50" />


### PR DESCRIPTION
The purpose of this PR was to prevent publications from being LOCKED without filling out the required fields like title, main text, co-authors list and so on...

---

### Acceptance Criteria:

As per [OCT-588](https://jiscdev.atlassian.net/browse/OCT-588)

---

### Tests:

---

### Screenshots:


[OCT-588]: https://jiscdev.atlassian.net/browse/OCT-588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ