### PR TITLE
OCT-574 Display GMT on "Reminder sent" text

### DIFF
--- a/ui/src/lib/helpers.tsx
+++ b/ui/src/lib/helpers.tsx
@@ -39,7 +39,8 @@ export const formatDateTime = (value: string, formatType?: 'short' | 'long'): st
         month: formatType || 'long',
         year: 'numeric',
         hour: 'numeric',
-        minute: 'numeric'
+        minute: 'numeric',
+        timeZoneName: 'shortGeneric'
     });
 
     return date === 'Invalid DateTime' ? 'N/A' : date;

--- a/ui/src/lib/helpers.tsx
+++ b/ui/src/lib/helpers.tsx
@@ -39,11 +39,10 @@ export const formatDateTime = (value: string, formatType?: 'short' | 'long'): st
         month: formatType || 'long',
         year: 'numeric',
         hour: 'numeric',
-        minute: 'numeric',
-        timeZoneName: 'shortGeneric'
+        minute: 'numeric'
     });
 
-    return date === 'Invalid DateTime' ? 'N/A' : date;
+    return date === 'Invalid DateTime' ? 'N/A' : `${date} GMT`;
 };
 
 /**


### PR DESCRIPTION
The purpose of this PR was to add timezone name (GMT) on the Approvals Tracker table when sending reminders to co-authors

---

### Acceptance Criteria:

As per [OCT-574](https://jiscdev.atlassian.net/browse/OCT-574)

---

### Tests:

---

### Screenshots:

BEFORE
![image](https://user-images.githubusercontent.com/48569671/230886477-d18cfeb4-fada-403d-a9a6-fe07d16530aa.png)


AFTER
![image](https://user-images.githubusercontent.com/48569671/230886284-64f0c5ce-8065-49ff-bf43-acd571f7985d.png)



[OCT-574]: https://jiscdev.atlassian.net/browse/OCT-574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ