### PR TITLE
OCT-615 Publication doesn't go back to draft if all co-authors deny involvement - FIX

### DIFF
--- a/api/src/components/coauthor/controller.ts
+++ b/api/src/components/coauthor/controller.ts
@@ -204,7 +204,7 @@ export const link = async (
             if (publication.coAuthors.length === 2) {
                 // this means only the creator remained and we can safely update publication status back to DRAFT
                 // to avoid publication being LOCKED without co-authors
-                await publicationService.updateStatus(publication.id, 'DRAFT', false);
+                await publicationService.updateStatus(publication.id, 'DRAFT');
             }
 
             return response.json(200, 'Removed co-author from publication');


### PR DESCRIPTION
The original [PR](#373) was branched from an older version of main. Since then, 'updateStatus' service has been updated and no longer needs a 3rd argument. ESLint complains about this when trying to deploy the backend.

---

### Acceptance Criteria:

---

### Tests:

This FIX doesn't affect any existing functionality

---

### Screenshots:
