### PR TITLE
Sending referenced works to datacite

### DIFF
--- a/api/src/components/publication/controller.ts
+++ b/api/src/components/publication/controller.ts
@@ -5,6 +5,7 @@ import * as I from 'interface';
 import * as helpers from 'lib/helpers';
 import * as response from 'lib/response';
 import * as publicationService from 'publication/service';
+import * as referenceService from 'reference/service';
 import * as coAuthorService from 'coauthor/service';
 
 export const getAll = async (
@@ -334,8 +335,10 @@ export const updateStatus = async (
             cleanContent: htmlToText.convert(updatedPublication.content)
         });
 
+        const references = await referenceService.getAllByPublication(publicationId);
+
         // Publication is live, so update the DOI
-        await helpers.updateDOI(publication.doi, publication);
+        await helpers.updateDOI(publication.doi, publication, references);
 
         return response.json(200, { message: 'Publication is now LIVE.' });
     } catch (err) {

--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -73,18 +73,6 @@ export const getFullDOIsStrings = (text: string): [] | RegExpMatchArray =>
         /(\s+)?(\(|\(\s+)?(?:DOI((\s+)?([:-])?(\s+)?))?(10\.[0-9a-zA-Z]+\/(?:(?!["&\'])\S)+)\b(\)|\s+\))?(\.)?/gi //eslint-disable-line
     ) || [];
 
-const createDoiReferenceObject = (references: I.Reference[]): I.DataCiteDoiReferences[] => {
-    const dataCiteDoiReferences = references.map((reference) => {
-        return {
-            relatedIdentifier: getFullDOIsStrings(reference.location!),
-            relatedIdentifierType: 'DOI',
-            relationType: 'References'
-        };
-    });
-
-    return dataCiteDoiReferences;
-};
-
 export const updateDOI = async (
     doi: string,
     publication: I.PublicationWithMetadata,
@@ -98,10 +86,43 @@ export const updateDOI = async (
         if (coAuthor.user !== null) return createCreatorObject(coAuthor.user);
     });
 
-    const doiReferences = createDoiReferenceObject(references.filter((reference) => reference.type === 'DOI'));
+    const linkedPublications = publication?.linkedTo.map((relatedIdentifier) =>
+        relatedIdentifier.publicationToRef.type === 'PEER_REVIEW'
+            ? {
+                  relatedIdentifier: relatedIdentifier.publicationToRef.doi,
+                  relatedIdentifierType: 'DOI',
+                  relationType: 'Reviews'
+              }
+            : {
+                  relatedIdentifier: relatedIdentifier.publicationToRef.doi,
+                  relatedIdentifierType: 'DOI',
+                  relationType: 'Continues'
+              }
+    );
 
-    console.log(doiReferences);
-    // const nonDoiReferences = references.filter((reference) => reference.type !== 'DOI');
+    const doiReferences = references.map((reference) => {
+        if (reference.type !== 'DOI' || !reference.location) return;
+
+        const doi: any = getFullDOIsStrings(reference.location);
+
+        return {
+            relatedIdentifier: doi,
+            relatedIdentifierType: 'DOI',
+            relationType: 'References'
+        };
+    });
+
+    const allReferencesWithDOI = doiReferences.concat(linkedPublications);
+
+    const otherReferences = references.map((reference) => {
+        if (reference.type === 'DOI') return;
+
+        return {
+            relatedItem: reference.location!,
+            referenceText: reference.text,
+            relationType: 'References'
+        };
+    });
 
     // check if the creator of the publication is not listed as an author
     if (!publication.coAuthors.find((author) => author.linkedUser === publication.createdBy)) {
@@ -153,19 +174,8 @@ export const updateDOI = async (
                     resourceTypeGeneral: 'Other',
                     resourceType: publication?.type
                 },
-                relatedIdentifiers: publication?.linkedTo.map((relatedIdentifier) =>
-                    relatedIdentifier.publicationToRef.type === 'PEER_REVIEW'
-                        ? {
-                              relatedIdentifier: relatedIdentifier.publicationToRef.doi,
-                              relatedIdentifierType: 'DOI',
-                              relationType: 'Reviews'
-                          }
-                        : {
-                              relatedIdentifier: relatedIdentifier.publicationToRef.doi,
-                              relatedIdentifierType: 'DOI',
-                              relationType: 'Continues'
-                          }
-                ),
+                relatedIdentifiers: allReferencesWithDOI,
+                relatedItems: otherReferences,
                 fundingReferences: publication?.funders.map((funder) => ({
                     funderName: funder.name,
                     funderReference: funder.ror || funder.link,

--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -68,7 +68,28 @@ const createCreatorObject = (user: I.DataCiteUser): I.DataCiteCreator => {
     };
 };
 
-export const updateDOI = async (doi: string, publication: I.PublicationWithMetadata): Promise<I.DOIResponse> => {
+export const getFullDOIsStrings = (text: string): [] | RegExpMatchArray =>
+    text.match(
+        /(\s+)?(\(|\(\s+)?(?:DOI((\s+)?([:-])?(\s+)?))?(10\.[0-9a-zA-Z]+\/(?:(?!["&\'])\S)+)\b(\)|\s+\))?(\.)?/gi //eslint-disable-line
+    ) || [];
+
+const createDoiReferenceObject = (references: I.Reference[]): I.DataCiteDoiReferences[] => {
+    const dataCiteDoiReferences = references.map((reference) => {
+        return {
+            relatedIdentifier: getFullDOIsStrings(reference.location!),
+            relatedIdentifierType: 'DOI',
+            relationType: 'References'
+        };
+    });
+
+    return dataCiteDoiReferences;
+};
+
+export const updateDOI = async (
+    doi: string,
+    publication: I.PublicationWithMetadata,
+    references: I.Reference[]
+): Promise<I.DOIResponse> => {
     if (!publication) {
         throw Error('Publication not found');
     }
@@ -76,6 +97,11 @@ export const updateDOI = async (doi: string, publication: I.PublicationWithMetad
     const authors = publication.coAuthors.map((coAuthor) => {
         if (coAuthor.user !== null) return createCreatorObject(coAuthor.user);
     });
+
+    const doiReferences = createDoiReferenceObject(references.filter((reference) => reference.type === 'DOI'));
+
+    console.log(doiReferences);
+    // const nonDoiReferences = references.filter((reference) => reference.type !== 'DOI');
 
     // check if the creator of the publication is not listed as an author
     if (!publication.coAuthors.find((author) => author.linkedUser === publication.createdBy)) {
@@ -148,6 +174,8 @@ export const updateDOI = async (doi: string, publication: I.PublicationWithMetad
             }
         }
     };
+
+    console.log(payload.data.attributes.relatedIdentifiers);
 
     const doiRes = await axios.put<I.DOIResponse>(`${process.env.DATACITE_ENDPOINT as string}/${doi}`, payload, {
         auth: {

--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -106,7 +106,7 @@ export const updateDOI = async (
         const doi: any = getFullDOIsStrings(reference.location);
 
         return {
-            relatedIdentifier: doi,
+            relatedIdentifier: doi[0],
             relatedIdentifierType: 'DOI',
             relationType: 'References'
         };
@@ -117,14 +117,25 @@ export const updateDOI = async (
     const otherReferences = references.map((reference) => {
         if (reference.type === 'DOI') return;
 
-        return {
+        const mutatedReference = {
+            titles: [
+                {
+                    title: reference.text.replace(/(<([^>]+)>)/gi, '')
+                }
+            ],
             relationType: 'References',
-            relatedItemIdentifier: reference.location,
-            relatedItemIdentifierType: "URL",
-            titles: {
-                title: reference.text
-            },
+            relatedItemType: 'Other'
         };
+
+        return reference.location
+            ? {
+                  ...mutatedReference,
+                  relatedItemIdentifier: {
+                      relatedItemIdentifier: reference.location,
+                      relatedItemIdentifierType: 'URL'
+                  }
+              }
+            : mutatedReference;
     });
 
     // check if the creator of the publication is not listed as an author
@@ -178,7 +189,7 @@ export const updateDOI = async (
                     resourceType: publication?.type
                 },
                 relatedIdentifiers: allReferencesWithDOI,
-                relatedItem: otherReferences,
+                relatedItems: otherReferences,
                 fundingReferences: publication?.funders.map((funder) => ({
                     funderName: funder.name,
                     funderReference: funder.ror || funder.link,

--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -118,9 +118,12 @@ export const updateDOI = async (
         if (reference.type === 'DOI') return;
 
         return {
-            relatedItem: reference.location!,
-            referenceText: reference.text,
-            relationType: 'References'
+            relationType: 'References',
+            relatedItemIdentifier: reference.location,
+            relatedItemIdentifierType: "URL",
+            titles: {
+                title: reference.text
+            },
         };
     });
 
@@ -175,7 +178,7 @@ export const updateDOI = async (
                     resourceType: publication?.type
                 },
                 relatedIdentifiers: allReferencesWithDOI,
-                relatedItems: otherReferences,
+                relatedItem: otherReferences,
                 fundingReferences: publication?.funders.map((funder) => ({
                     funderName: funder.name,
                     funderReference: funder.ror || funder.link,
@@ -184,8 +187,6 @@ export const updateDOI = async (
             }
         }
     };
-
-    console.log(payload.data.attributes.relatedIdentifiers);
 
     const doiRes = await axios.put<I.DOIResponse>(`${process.env.DATACITE_ENDPOINT as string}/${doi}`, payload, {
         auth: {

--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -86,24 +86,16 @@ export const updateDOI = async (
         if (coAuthor.user !== null) return createCreatorObject(coAuthor.user);
     });
 
-    const linkedPublications = publication?.linkedTo.map((relatedIdentifier) =>
-        relatedIdentifier.publicationToRef.type === 'PEER_REVIEW'
-            ? {
-                  relatedIdentifier: relatedIdentifier.publicationToRef.doi,
-                  relatedIdentifierType: 'DOI',
-                  relationType: 'Reviews'
-              }
-            : {
-                  relatedIdentifier: relatedIdentifier.publicationToRef.doi,
-                  relatedIdentifierType: 'DOI',
-                  relationType: 'Continues'
-              }
-    );
+    const linkedPublications = publication?.linkedTo.map((relatedIdentifier) => ({
+        relatedIdentifier: relatedIdentifier.publicationToRef.doi,
+        relatedIdentifierType: 'DOI',
+        relationType: relatedIdentifier.publicationToRef.type === 'PEER_REVIEW' ? 'Reviews' : 'Continues'
+    }));
 
     const doiReferences = references.map((reference) => {
         if (reference.type !== 'DOI' || !reference.location) return;
 
-        const doi: any = getFullDOIsStrings(reference.location);
+        const doi = getFullDOIsStrings(reference.location);
 
         return {
             relatedIdentifier: doi[0],

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -571,12 +571,6 @@ export interface DataCiteCreator {
     nameIdentifiers: DataCiteCreatorNameIdentifiers[];
 }
 
-export interface DataCiteDoiReferences {
-    relatedIdentifier: [] | RegExpMatchArray;
-    relatedIdentifierType: string;
-    relationType: string;
-}
-
 export interface DataCiteCreatorNameIdentifiers {
     nameIdentifier: string;
     nameIdentifierScheme: string;

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -571,6 +571,12 @@ export interface DataCiteCreator {
     nameIdentifiers: DataCiteCreatorNameIdentifiers[];
 }
 
+export interface DataCiteDoiReferences {
+    relatedIdentifier: [] | RegExpMatchArray;
+    relatedIdentifierType: string;
+    relationType: string;
+}
+
 export interface DataCiteCreatorNameIdentifiers {
     nameIdentifier: string;
     nameIdentifierScheme: string;

--- a/api/src/scripts/updateDoi.ts
+++ b/api/src/scripts/updateDoi.ts
@@ -1,7 +1,7 @@
 import * as client from '../lib/client';
 import * as helpers from '../lib/helpers';
 
-const updateDoiNames = async (): Promise<void> => {
+const updateDoi = async (): Promise<void> => {
     const publications = await client.prisma.publication.findMany({
         where: {
             currentStatus: 'LIVE'
@@ -70,7 +70,7 @@ const updateDoiNames = async (): Promise<void> => {
             },
             References: {
                 select: {
-                    id: true, 
+                    id: true,
                     type: true,
                     text: true,
                     location: true,
@@ -171,4 +171,4 @@ const updateDoiNames = async (): Promise<void> => {
     }
 };
 
-updateDoiNames().catch((err) => console.log(err));
+updateDoi().catch((err) => console.log(err));

--- a/api/src/scripts/updateDoi.ts
+++ b/api/src/scripts/updateDoi.ts
@@ -68,6 +68,15 @@ const updateDoiNames = async (): Promise<void> => {
                     ror: true
                 }
             },
+            References: {
+                select: {
+                    id: true, 
+                    type: true,
+                    text: true,
+                    location: true,
+                    publicationId: true
+                }
+            },
             coAuthors: {
                 select: {
                     id: true,
@@ -156,7 +165,7 @@ const updateDoiNames = async (): Promise<void> => {
     let index = 1;
 
     for (const publication of publications) {
-        await helpers.updateDOI(publication.doi, publication).catch((err) => console.log(err));
+        await helpers.updateDOI(publication.doi, publication, publication.References).catch((err) => console.log(err));
         console.log(`No: ${index}. ${publication.title} doi updated (${publication.doi})`);
         index++;
     }


### PR DESCRIPTION
The purpose of this PR is to send the references to datacite so they are retained on the DOI's data. This PR contains the following changes: 
- The references are passed into the `updateDOI` helper function in the api 
- The references with DOIs are combined with the linked publications and are sent as `relatedIdentifiers`. Any references without DOIs are sent as `relatedItems` 
- The `updateDOINames` script's name has been changed to `updateDoi` and the references are being pulled and passed through the `updateDOI` script

---

### Acceptance Criteria:

As Per [OCT-611](https://jiscdev.atlassian.net/browse/OCT-611?atlOrigin=eyJpIjoiZjIwODQ3MjhiN2E5NDUxYzk3ZTI2NmJmZWE5OWY1YzUiLCJwIjoiaiJ9)

---

### How to test this PR:
- Create a publication with several references (both with and without DOIs) 
- Publish 
- Login to [our test repository](https://doi.test.datacite.org/sign-in) and search for the relevant DOI
- Check that this data has been retained in the JSON object under  `relatedIdentifiers` and `relatedItems` 

---

### Screenshots

https://user-images.githubusercontent.com/100135505/235718524-456f545a-3005-441a-a754-51fdc1672fe3.mov



[OCT-611]: https://jiscdev.atlassian.net/browse/OCT-611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ