### PR TITLE
OCT-614 - Queued generation of PDFs - Terraform

### DIFF
--- a/infra/create-app/main.tf
+++ b/infra/create-app/main.tf
@@ -74,3 +74,15 @@ module "ses" {
     source = "../modules/ses"
     environment = local.environment
 }
+
+module "sqs" {
+  source = "../modules/sqs"
+  sns_arn = module.sns.arn
+  environment = local.environment
+}
+
+module "sns" {
+  source = "../modules/sns" 
+  environment = local.environment
+}
+

--- a/infra/create-app/main.tf
+++ b/infra/create-app/main.tf
@@ -84,5 +84,6 @@ module "sqs" {
 module "sns" {
   source = "../modules/sns" 
   environment = local.environment
+  slack_channel_email = var.slack_channel_email
 }
 

--- a/infra/create-app/vars.tf
+++ b/infra/create-app/vars.tf
@@ -26,3 +26,8 @@ variable "domain_name" {
 variable "elasticsearch_instance_size" {
   type = string
 }
+
+variable "slack_channel_email" {
+  type = string
+  sensitive = true
+}

--- a/infra/modules/elasticsearch/main.tf
+++ b/infra/modules/elasticsearch/main.tf
@@ -70,6 +70,7 @@ resource "aws_elasticsearch_domain" "elasticsearch" {
 
   advanced_options = {
     "rest.action.multi.allow_explicit_index" = "true"
+    "override_main_response_version"         = "true"
   }
 
   advanced_security_options {
@@ -99,6 +100,7 @@ resource "aws_elasticsearch_domain" "elasticsearch" {
 #   depends_on = [
 #     aws_iam_service_linked_role.elasticsearch
 #   ]
+
 }
 
 // Save password to SSM

--- a/infra/modules/sns/main.tf
+++ b/infra/modules/sns/main.tf
@@ -1,5 +1,5 @@
-resource "aws_sns_topic" "science-octopus-dlq-messages-topic" {
-  name            = "science-octopus-dlq-messages-topic-${var.environment}"
+resource "aws_sns_topic" "pdf-queue-dlq-messages-topic" {
+  name            = "pfd-queue-dlq-messages-topic-${var.environment}"
   delivery_policy = <<EOF
 {
   "http": {

--- a/infra/modules/sns/main.tf
+++ b/infra/modules/sns/main.tf
@@ -23,7 +23,7 @@ EOF
 
 
 resource "aws_sns_topic_subscription" "notify-slack-dlq" {
-  topic_arn = aws_sns_topic.dlq_messages_topic.arn
+  topic_arn = aws_sns_topic.pdf-queue-dlq-messages-topic.arn
   protocol  = "email"
   endpoint  = var.slack_channel_email
 }

--- a/infra/modules/sns/main.tf
+++ b/infra/modules/sns/main.tf
@@ -1,0 +1,29 @@
+resource "aws_sns_topic" "science-octopus-dlq-messages-topic" {
+  name            = "science-octopus-dlq-messages-topic-${var.environment}"
+  delivery_policy = <<EOF
+{
+  "http": {
+    "defaultHealthyRetryPolicy": {
+      "minDelayTarget": 20,
+      "maxDelayTarget": 20,
+      "numRetries": 3,
+      "numMaxDelayRetries": 0,
+      "numNoDelayRetries": 0,
+      "numMinDelayRetries": 0,
+      "backoffFunction": "linear"
+    },
+    "disableSubscriptionOverrides": false,
+    "defaultThrottlePolicy": {
+      "maxReceivesPerSecond": 1
+    }
+  }
+}
+EOF
+}
+
+
+resource "aws_sns_topic_subscription" "notify-slack-dlq" {
+  topic_arn = aws_sns_topic.dlq_messages_topic.arn
+  protocol  = "email"
+  endpoint  = var.environment == "int" ? "" : "octopus-testing-notif-aaaajiuyoqzwooajd4oh7taijy@jiscinnovate.slack.com"
+}

--- a/infra/modules/sns/main.tf
+++ b/infra/modules/sns/main.tf
@@ -25,5 +25,5 @@ EOF
 resource "aws_sns_topic_subscription" "notify-slack-dlq" {
   topic_arn = aws_sns_topic.dlq_messages_topic.arn
   protocol  = "email"
-  endpoint  = var.environment == "int" ? "" : "octopus-testing-notif-aaaajiuyoqzwooajd4oh7taijy@jiscinnovate.slack.com"
+  endpoint  = var.slack_channel_email
 }

--- a/infra/modules/sns/outputs.tf
+++ b/infra/modules/sns/outputs.tf
@@ -1,3 +1,3 @@
 output "arn" {
-    value = aws_sns_topic.science-octopus-dlq-messages-topic.arn
+    value = aws_sns_topic.pdf-queue-dlq-messages-topic.arn
 }

--- a/infra/modules/sns/outputs.tf
+++ b/infra/modules/sns/outputs.tf
@@ -1,0 +1,3 @@
+output "arn" {
+    value = aws_sns_topic.science-octopus-dlq-messages-topic.arn
+}

--- a/infra/modules/sns/vars.tf
+++ b/infra/modules/sns/vars.tf
@@ -1,0 +1,3 @@
+variable "environment" {
+  type = string
+}

--- a/infra/modules/sns/vars.tf
+++ b/infra/modules/sns/vars.tf
@@ -1,3 +1,8 @@
 variable "environment" {
   type = string
 }
+
+variable "slack_channel_email" {
+  type = string
+  sensitive = true
+}

--- a/infra/modules/sqs/main.tf
+++ b/infra/modules/sqs/main.tf
@@ -8,7 +8,7 @@ resource "aws_sqs_queue" "science-octopus-pdf-queue" {
   receive_wait_time_seconds     = 0
   
   redrive_policy = jsonencode({
-    deadLetterTargetArn = aws_sqs_queue.terraform_queue_deadletter.arn
+    deadLetterTargetArn = aws_sqs_queue.science-octopus-pdf-queue-dlq.arn
     maxReceiveCount     = 1
   })
 

--- a/infra/modules/sqs/main.tf
+++ b/infra/modules/sqs/main.tf
@@ -6,6 +6,7 @@ resource "aws_sqs_queue" "science-octopus-pdf-queue" {
   max_message_size              = 2048
   message_retention_seconds     = 86400
   receive_wait_time_seconds     = 0
+  sqs_managed_sse_enabled       = false
   
   redrive_policy = jsonencode({
     deadLetterTargetArn = aws_sqs_queue.science-octopus-pdf-queue-dlq.arn
@@ -16,6 +17,7 @@ resource "aws_sqs_queue" "science-octopus-pdf-queue" {
 
 resource "aws_sqs_queue" "science-octopus-pdf-queue-dlq" {
   name = "science-octopus-pdf-queue-dlq-${var.environment}"
+  sqs_managed_sse_enabled = false
 }
 
 resource "aws_cloudwatch_metric_alarm" "dlq-messages-sent-alarm" {

--- a/infra/modules/sqs/main.tf
+++ b/infra/modules/sqs/main.tf
@@ -1,0 +1,39 @@
+resource "aws_sqs_queue" "science-octopus-pdf-queue" {
+  name                        = "science-octopus-pdf-queue-${var.environment}"
+  
+  visibility_timeout_seconds    = 30
+  delay_seconds                 = 0
+  max_message_size              = 2048
+  message_retention_seconds     = 86400
+  receive_wait_time_seconds     = 0
+  
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.terraform_queue_deadletter.arn
+    maxReceiveCount     = 1
+  })
+
+}
+
+resource "aws_sqs_queue" "science-octopus-pdf-queue-dlq" {
+  name = "science-octopus-pdf-queue-dlq-${var.environment}"
+}
+
+resource "aws_cloudwatch_metric_alarm" "dlq-messages-sent-alarm" {
+  alarm_name                = "science-octopus-pdf-dlq-messages-sent-alarm-${var.environment}"
+  comparison_operator       = "GreaterThanThreshold"
+  evaluation_periods        = 1
+  metric_name               = "ApproximateNumberOfMessagesVisible"
+  namespace                 = "AWS/SQS"
+  period                    = 120
+  statistic                 = "Average"
+  threshold                 = 0
+  alarm_description         = "This metric monitors if any messages enter the DLQ"
+  alarm_actions             = [var.sns_arn]
+
+  dimensions = {
+    QueueName = aws_sqs_queue.science-octopus-pdf-queue.name
+  }
+
+}
+
+

--- a/infra/modules/sqs/vars.tf
+++ b/infra/modules/sqs/vars.tf
@@ -1,0 +1,7 @@
+variable "sns_arn" {
+    type = string
+}
+
+variable "environment" {
+  type = string
+}


### PR DESCRIPTION
This PR created the Terraform for the sqs queue, sns topics, cloud watch alarm. The only thing missing is the link to the sqs queue and the lambda to trigger generation, this can be added either via terraform or manually when this is confirmed tested and working correctly when merging in the second part of this ticket, the code changes [here](https://github.com/JiscSD/octopus/pull/386)

Currently we only have one slack channel, so will need another created to send emails to for testing on int.

We check in our tfvar file, so you will need to add this line to it before running the terraform:
`slack_channel_email = <email_string>`

---

### Acceptance Criteria:

As Per [OCT-614](https://jiscdev.atlassian.net/browse/OCT-614?atlOrigin=eyJpIjoiMTI3YTNlNzg0OWQ3NGU2ZWE5NmE4NzFhYjA4OGY2MjIiLCJwIjoiaiJ9)

[OCT-614]: https://jiscdev.atlassian.net/browse/OCT-614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ