### PR TITLE
Critical security updates

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1938,6 +1938,14 @@
                 "headers-utils": "^3.0.2",
                 "outvariant": "^1.2.0",
                 "strict-event-emitter": "^0.2.0"
+            },
+            "dependencies": {
+                "@xmldom/xmldom": {
+                    "version": "0.7.10",
+                    "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.10.tgz",
+                    "integrity": "sha512-hb9QhOg5MGmpVkFcoZ9XJMe1em5gd0e2eqqjK87O1dwULedXsnY/Zg/Ju6lcohA+t6jVkmKpe7I1etqhvdRdrQ==",
+                    "dev": true
+                }
             }
         },
         "@nodelib/fs.scandir": {
@@ -2611,10 +2619,9 @@
             }
         },
         "@xmldom/xmldom": {
-            "version": "0.7.5",
-            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz",
-            "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A==",
-            "dev": true
+            "version": "0.8.7",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.7.tgz",
+            "integrity": "sha512-sI1Ly2cODlWStkINzqGrZ8K6n+MTSbAeQnAipGyL+KZCXuHaRlj2gyyy8B/9MvsFFqN7XHryQnB2QwhzvJXovg=="
         },
         "@xtuc/ieee754": {
             "version": "1.2.0",

--- a/api/package.json
+++ b/api/package.json
@@ -41,6 +41,7 @@
         "@types/luxon": "^2.0.9",
         "@types/node": "^17.0.8",
         "@types/nodemailer": "^6.4.4",
+        "@xmldom/xmldom": "^0.8.7",
         "ajv": "^8.8.2",
         "ajv-formats": "^2.1.1",
         "aws-sdk": "^2.1114.0",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10024,10 +10024,9 @@
             }
         },
         "minimist": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-            "dev": true
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
         },
         "mkdirp": {
             "version": "0.5.6",
@@ -10205,6 +10204,12 @@
                     "version": "0.1.1",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
                     "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=",
+                    "dev": true
+                },
+                "underscore": {
+                    "version": "1.6.0",
+                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+                    "integrity": "sha512-z4o1fvKUojIWh9XuaVLUDdf86RQiq13AC1dmHbTpoyuu+bquHms76v16CjycCbec87J7z0k//SiQVk0sMdFmpQ==",
                     "dev": true
                 }
             }
@@ -12655,10 +12660,9 @@
             }
         },
         "underscore": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-            "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-            "dev": true
+            "version": "1.13.6",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+            "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
         },
         "unique-string": {
             "version": "2.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -51,6 +51,7 @@
         "jsonwebtoken": "^8.5.1",
         "luxon": "^2.3.0",
         "mammoth": "^1.4.21",
+        "minimist": "^1.2.8",
         "moment": "^2.29.3",
         "next": "^12.0.10",
         "nextjs-progressbar": "0.0.13",
@@ -66,6 +67,7 @@
         "react-range": "^1.8.12",
         "react-xarrows": "^2.0.2",
         "swr": "^1.1.2",
+        "underscore": "^1.13.6",
         "zustand": "^3.6.9"
     },
     "devDependencies": {
@@ -100,5 +102,6 @@
         "tailwindcss": "^3.0.15",
         "ts-jest": "^27.1.3",
         "typescript": "4.5.4"
-    }
+    },
+    "overrides": {}
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -102,6 +102,5 @@
         "tailwindcss": "^3.0.15",
         "ts-jest": "^27.1.3",
         "typescript": "4.5.4"
-    },
-    "overrides": {}
+    }
 }


### PR DESCRIPTION
The purpose of this PR was to apply some dependency updates to fix critical security vulnerabilities to some subdependencies. I have done this by adding them as ordinary dependencies. In future when we are using node v16+ and npm 8+, this can be done more elegantly by adding an "overrides" section to package.json.

---

### Acceptance Criteria:

Update the following dependencies:

- UI
  - minimist to >= 1.2.6
  - underscore to >= 1.12.1
- API
  - @xmldom/xmldom to >= 0.7.7


---

### Tests:

API:
<img width="253" alt="Screenshot 2023-05-16 135044" src="https://github.com/JiscSD/octopus/assets/132363734/a4fd5df9-01c5-4e28-ad84-b2d64ba548d0">
UI:
<img width="394" alt="Screenshot 2023-05-16 135128" src="https://github.com/JiscSD/octopus/assets/132363734/6e02c8e6-079e-4ada-9313-64dab8a4d439">

---

### Screenshots:
