### PR TITLE
update button text from coauthor invitation email

### DIFF
--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -572,10 +572,10 @@ const confirmCoAuthorInvitation = async (browser: Browser, user: Helpers.TestUse
         .first()
         .click();
 
-    // clicking 'I am an author' link is blocked by cors
+    // clicking 'Confirm & Review Publication' link is blocked by cors
     const invitationLink = await page2
         .frameLocator('iframe')
-        .locator("a:has-text('I am an author')")
+        .locator("a:has-text('Confirm & Review Publication')")
         .getAttribute('href');
 
     // navigate to that link instead


### PR DESCRIPTION
The purpose of this PR was to make a small correction our e2e tests so that they don't fail to locate the accept button in our coauthor invitation emails.