### PR TITLE
OCT-455 - Upgrade Prisma

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1990,22 +1990,22 @@
             }
         },
         "@prisma/client": {
-            "version": "3.13.0",
-            "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.13.0.tgz",
-            "integrity": "sha512-lnEA2tTyVbO5mS1ehmHJQKBDiKB8shaR6s3azwj3Azfi5XHIfnqmkolLCvUeFYnkDCNVzGXJpUgKwQt/UOOYVQ==",
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.14.1.tgz",
+            "integrity": "sha512-TZIswkeX1ccsHG/eN2kICzg/csXll0osK3EHu1QKd8VJ3XLcXozbNELKkCNfsCUvKJAwPdDtFCzF+O+raIVldw==",
             "requires": {
-                "@prisma/engines-version": "3.13.0-17.efdf9b1183dddfd4258cd181a72125755215ab7b"
+                "@prisma/engines-version": "4.14.0-67.d9a4c5988f480fa576d43970d5a23641aa77bc9c"
             }
         },
         "@prisma/engines": {
-            "version": "3.14.0-36.2b0c12756921c891fec4f68d9444e18c7d5d4a6a",
-            "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-3.14.0-36.2b0c12756921c891fec4f68d9444e18c7d5d4a6a.tgz",
-            "integrity": "sha512-LwZvI3FY6f43xFjQNRuE10JM5R8vJzFTSmbV9X0Wuhv9kscLkjRlZt0BEoiHmO+2HA3B3xxbMfB5du7ZoSFXGg=="
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.14.1.tgz",
+            "integrity": "sha512-APqFddPVHYmWNKqc+5J5SqrLFfOghKOLZxobmguDUacxOwdEutLsbXPVhNnpFDmuQWQFbXmrTTPoRrrF6B1MWA=="
         },
         "@prisma/engines-version": {
-            "version": "3.13.0-17.efdf9b1183dddfd4258cd181a72125755215ab7b",
-            "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.13.0-17.efdf9b1183dddfd4258cd181a72125755215ab7b.tgz",
-            "integrity": "sha512-TGp9rvgJIKo8NgvAHSwOosbut9mTA7VC6/rpQI9gh+ySSRjdQFhbGyNUiOcQrlI9Ob2DWeO7y4HEnhdKxYiECg=="
+            "version": "4.14.0-67.d9a4c5988f480fa576d43970d5a23641aa77bc9c",
+            "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.14.0-67.d9a4c5988f480fa576d43970d5a23641aa77bc9c.tgz",
+            "integrity": "sha512-3jum8/YSudeSN0zGW5qkpz+wAN2V/NYCQ+BPjvHYDfWatLWlQkqy99toX0GysDeaUoBIJg1vaz2yKqiA3CFcQw=="
         },
         "@selderee/plugin-htmlparser2": {
             "version": "0.6.0",
@@ -7957,11 +7957,11 @@
             "dev": true
         },
         "prisma": {
-            "version": "3.14.0",
-            "resolved": "https://registry.npmjs.org/prisma/-/prisma-3.14.0.tgz",
-            "integrity": "sha512-l9MOgNCn/paDE+i1K2fp9NZ+Du4trzPTJsGkaQHVBufTGqzoYHuNk8JfzXuIn0Gte6/ZjyKj652Jq/Lc1tp2yw==",
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.14.1.tgz",
+            "integrity": "sha512-z6hxzTMYqT9SIKlzD08dhzsLUpxjFKKsLpp5/kBDnSqiOjtUyyl/dC5tzxLcOa3jkEHQ8+RpB/fE3w8bgNP51g==",
             "requires": {
-                "@prisma/engines": "3.14.0-36.2b0c12756921c891fec4f68d9444e18c7d5d4a6a"
+                "@prisma/engines": "4.14.1"
             }
         },
         "process-nextick-args": {

--- a/api/package.json
+++ b/api/package.json
@@ -34,7 +34,7 @@
         "@middy/http-json-body-parser": "^2.5.4",
         "@middy/validator": "^2.5.4",
         "@opensearch-project/opensearch": "^2.1.0",
-        "@prisma/client": "^3.13.0",
+        "@prisma/client": "^4.14.1",
         "@types/cheerio": "^0.22.30",
         "@types/jest": "^27.4.0",
         "@types/jsonwebtoken": "^8.5.7",
@@ -56,7 +56,7 @@
         "luxon": "^2.3.0",
         "middy": "^0.36.0",
         "nodemailer": "^6.7.2",
-        "prisma": "^3.14.0",
+        "prisma": "^4.14.1",
         "puppeteer-core": "10.1.0",
         "string-strip-html": "^9.1.6",
         "supertest": "^6.2.3"

--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -621,7 +621,7 @@ export const getLinksForPublication = async (id: string) => {
         
         SELECT * FROM to_left
         WHERE "type" != "childPublicationType"
-            AND "type" != ${publication?.type}
+            AND CAST("type" AS text) != ${publication?.type}
             AND "currentStatus" = 'LIVE';
     `;
 


### PR DESCRIPTION
The purpose of this PR was to upgrade Prisma from major version 3 to 4. 

---

### Acceptance Criteria:

As Per [OCT-455](https://jiscdev.atlassian.net/browse/OCT-455?atlOrigin=eyJpIjoiNzgxMzdlNzM4ODU1NGQxNjhmMTkxZDA4NGQ2NmM4MmQiLCJwIjoiaiJ9)

This is also a part of the work to update the dependencies as part of CE: 
As Per [OCT-648](https://jiscdev.atlassian.net/browse/OCT-648?atlOrigin=eyJpIjoiOTM3M2YxZmM2MmNiNGU5OGExZTEwYTkzOWU0MTE4MTEiLCJwIjoiaiJ9)


