### PR TITLE
OCT-666 😈 Remove source-map-support - Red Dependency 

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -88,7 +88,6 @@
         "serverless-prune-plugin": "^2.0.1",
         "serverless-webpack": "^5.6.0",
         "serverless-webpack-prisma": "^1.1.0",
-        "source-map-support": "^0.5.21",
         "ts-jest": "^27.1.2",
         "ts-loader": "^9.2.6",
         "ts-node": "^10.4.0",


### PR DESCRIPTION
The purpose of this PR was to remove source-map-support from package.json as it's listed as a red dependency and has not received support for 2 years. Also, we don't seem to actually use it. 

---

### Acceptance Criteria:

As per [OCT-666](https://jiscdev.atlassian.net/browse/OCT-666?atlOrigin=eyJpIjoiNDQxZDRmNzdmMmRkNGNhYWE3MzFmZjM1YjRkMDBkMTEiLCJwIjoiaiJ9)

---

### Checklist:

- [x] Local manual testing conducted
- [x] Regression tests performed 


[OCT-666]: https://jiscdev.atlassian.net/browse/OCT-666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ