### PR TITLE
Remove underscore

### DIFF
--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,56 +1,155 @@
 {
-  "name": "e2e",
-  "version": "1.0.0",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "@noble/hashes": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
-      "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA=="
+    "name": "e2e",
+    "version": "1.0.0",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "e2e",
+            "version": "1.0.0",
+            "license": "ISC",
+            "dependencies": {
+                "@paralleldrive/cuid2": "^2.2.1",
+                "dotenv": "^16.1.4"
+            },
+            "devDependencies": {
+                "@playwright/test": "^1.34.3",
+                "@types/node": "^20.2.5"
+            },
+            "engines": {
+                "node": "16"
+            }
+        },
+        "node_modules/@noble/hashes": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
+            "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==",
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/@paralleldrive/cuid2": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.1.tgz",
+            "integrity": "sha512-GJhHYlMhyT2gWemDL7BGMWfTNhspJKkikLKh9wAy3z4GTTINvTYALkUd+eGQK7aLeVkVzPuSA0VCT3H5eEWbbw==",
+            "dependencies": {
+                "@noble/hashes": "^1.1.5"
+            }
+        },
+        "node_modules/@playwright/test": {
+            "version": "1.34.3",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.34.3.tgz",
+            "integrity": "sha512-zPLef6w9P6T/iT6XDYG3mvGOqOyb6eHaV9XtkunYs0+OzxBtrPAAaHotc0X+PJ00WPPnLfFBTl7mf45Mn8DBmw==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*",
+                "playwright-core": "1.34.3"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/@types/node": {
+            "version": "20.2.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
+            "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==",
+            "dev": true
+        },
+        "node_modules/dotenv": {
+            "version": "16.1.4",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.1.4.tgz",
+            "integrity": "sha512-m55RtE8AsPeJBpOIFKihEmqUcoVncQIwo7x9U8ZwLEZw9ZpXboz2c+rvog+jUaJvVrZ5kBOeYQBX5+8Aa/OZQw==",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/motdotla/dotenv?sponsor=1"
+            }
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.34.3",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.34.3.tgz",
+            "integrity": "sha512-2pWd6G7OHKemc5x1r1rp8aQcpvDh7goMBZlJv6Co5vCNLVcQJdhxRL09SGaY6HcyHH9aT4tiynZabMofVasBYw==",
+            "dev": true,
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        }
     },
-    "@paralleldrive/cuid2": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.1.tgz",
-      "integrity": "sha512-GJhHYlMhyT2gWemDL7BGMWfTNhspJKkikLKh9wAy3z4GTTINvTYALkUd+eGQK7aLeVkVzPuSA0VCT3H5eEWbbw==",
-      "requires": {
-        "@noble/hashes": "^1.1.5"
-      }
-    },
-    "@playwright/test": {
-      "version": "1.34.3",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.34.3.tgz",
-      "integrity": "sha512-zPLef6w9P6T/iT6XDYG3mvGOqOyb6eHaV9XtkunYs0+OzxBtrPAAaHotc0X+PJ00WPPnLfFBTl7mf45Mn8DBmw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "fsevents": "2.3.2",
-        "playwright-core": "1.34.3"
-      }
-    },
-    "@types/node": {
-      "version": "20.2.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
-      "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==",
-      "dev": true
-    },
-    "dotenv": {
-      "version": "16.1.4",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.1.4.tgz",
-      "integrity": "sha512-m55RtE8AsPeJBpOIFKihEmqUcoVncQIwo7x9U8ZwLEZw9ZpXboz2c+rvog+jUaJvVrZ5kBOeYQBX5+8Aa/OZQw=="
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true
-    },
-    "playwright-core": {
-      "version": "1.34.3",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.34.3.tgz",
-      "integrity": "sha512-2pWd6G7OHKemc5x1r1rp8aQcpvDh7goMBZlJv6Co5vCNLVcQJdhxRL09SGaY6HcyHH9aT4tiynZabMofVasBYw==",
-      "dev": true
+    "dependencies": {
+        "@noble/hashes": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
+            "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA=="
+        },
+        "@paralleldrive/cuid2": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.1.tgz",
+            "integrity": "sha512-GJhHYlMhyT2gWemDL7BGMWfTNhspJKkikLKh9wAy3z4GTTINvTYALkUd+eGQK7aLeVkVzPuSA0VCT3H5eEWbbw==",
+            "requires": {
+                "@noble/hashes": "^1.1.5"
+            }
+        },
+        "@playwright/test": {
+            "version": "1.34.3",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.34.3.tgz",
+            "integrity": "sha512-zPLef6w9P6T/iT6XDYG3mvGOqOyb6eHaV9XtkunYs0+OzxBtrPAAaHotc0X+PJ00WPPnLfFBTl7mf45Mn8DBmw==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*",
+                "fsevents": "2.3.2",
+                "playwright-core": "1.34.3"
+            }
+        },
+        "@types/node": {
+            "version": "20.2.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
+            "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==",
+            "dev": true
+        },
+        "dotenv": {
+            "version": "16.1.4",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.1.4.tgz",
+            "integrity": "sha512-m55RtE8AsPeJBpOIFKihEmqUcoVncQIwo7x9U8ZwLEZw9ZpXboz2c+rvog+jUaJvVrZ5kBOeYQBX5+8Aa/OZQw=="
+        },
+        "fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "optional": true
+        },
+        "playwright-core": {
+            "version": "1.34.3",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.34.3.tgz",
+            "integrity": "sha512-2pWd6G7OHKemc5x1r1rp8aQcpvDh7goMBZlJv6Co5vCNLVcQJdhxRL09SGaY6HcyHH9aT4tiynZabMofVasBYw==",
+            "dev": true
+        }
     }
-  }
 }

--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -135,6 +135,8 @@ export const publicationFlowConflictOfInterest = async (
     conflictOfInterest: boolean,
     conflictOfInterestText?: string
 ) => {
+    await page.click("aside button:has-text('Conflict of interest')");
+
     // COI
     if (conflictOfInterest) {
         await page.locator(PageModel.publish.coi.true).click();
@@ -551,6 +553,7 @@ const addCoAuthor = async (page: Page, user: Helpers.TestUser) => {
 };
 
 const removeCoAuthor = async (page: Page, user: Helpers.TestUser) => {
+    await page.waitForResponse((res) => res.url().includes('/coauthors') && res.ok());
     const row = page.locator('tr', { hasText: user.email });
     await row.locator('button[title="Delete"]').click();
 };
@@ -632,7 +635,7 @@ const rejectCoAuthorInvitation = async (
     // navigating to 'I am not an author link' will remove this co-author from the publication
     const page3 = await context.newPage();
     await page3.goto(invitationLink);
-    await page3.waitForLoadState('load');
+    await page3.waitForLoadState('networkidle');
 
     if (checkErrorMessage) {
         await expect(page3.locator(`h2.error-message-e2e`)).toHaveText(errorMessage);
@@ -830,6 +833,9 @@ test.describe('Publication flow + co-authors', () => {
         await page.locator(PageModel.publish.text.editor).click();
         await page.keyboard.type(publicationWithCoAuthors.content);
 
+        // confirm conflict of interest
+        await publicationFlowConflictOfInterest(page, true, 'Some conflict of interest text');
+
         // add one co-author
         await page.locator('aside button:has-text("Co-authors")').click();
         await addCoAuthor(page, Helpers.user2);
@@ -873,6 +879,9 @@ test.describe('Publication flow + co-authors', () => {
         await (await page.waitForSelector("aside button:has-text('Main text')")).click();
         await page.locator(PageModel.publish.text.editor).click();
         await page.keyboard.type(publicationWithCoAuthors.content);
+
+        // confirm conflict of interest
+        await publicationFlowConflictOfInterest(page, true, 'Some conflict of interest text');
 
         // add co-author
         await page.locator('aside button:has-text("Co-authors")').click();
@@ -937,6 +946,9 @@ test.describe('Publication flow + co-authors', () => {
         await page.locator(PageModel.publish.text.editor).click();
         await page.keyboard.type(publicationWithCoAuthors.content);
 
+        // confirm conflict of interest
+        await publicationFlowConflictOfInterest(page, true, 'Some conflict of interest text');
+
         // add co-authors
         await page.locator('aside button:has-text("Co-authors")').click();
         await addCoAuthor(page, Helpers.user2);
@@ -948,8 +960,11 @@ test.describe('Publication flow + co-authors', () => {
         // change the order of authors using the keyboard
         await page.locator('span[title="Drag to reorder authors"]').first().focus();
         await page.keyboard.press('Space'); // select first row
+        await page.waitForTimeout(100);
         await page.keyboard.press('ArrowDown'); // move it down
+        await page.waitForTimeout(100);
         await page.keyboard.press('Space'); // confirm position
+        await page.waitForTimeout(100);
 
         // verify authors order again
         await expect(page.locator('table > tbody > tr').first()).toContainText(Helpers.user2.email);
@@ -1011,6 +1026,9 @@ test.describe('Publication flow + co-authors', () => {
         await (await page.waitForSelector("aside button:has-text('Main text')")).click();
         await page.locator(PageModel.publish.text.editor).click();
         await page.keyboard.type(publicationWithCoAuthors.content);
+
+        // confirm conflict of interest
+        await publicationFlowConflictOfInterest(page, true, 'Some conflict of interest text');
 
         // add co-author
         await page.locator('aside button:has-text("Co-authors")').click();
@@ -1081,6 +1099,9 @@ test.describe('Publication flow + co-authors', () => {
         await page.locator(PageModel.publish.text.editor).click();
         await page.keyboard.type(publicationWithCoAuthors.content);
 
+        // confirm conflict of interest
+        await publicationFlowConflictOfInterest(page, true, 'Some conflict of interest text');
+
         // add co-author
         await page.locator('aside button:has-text("Co-authors")').click();
         await addCoAuthor(page, Helpers.user2);
@@ -1143,6 +1164,9 @@ test.describe('Publication flow + co-authors', () => {
         await (await page.waitForSelector("aside button:has-text('Main text')")).click();
         await page.locator(PageModel.publish.text.editor).click();
         await page.keyboard.type(publicationWithCoAuthors.content);
+
+        // confirm conflict of interest
+        await publicationFlowConflictOfInterest(page, true, 'Some conflict of interest text');
 
         // add co-author
         await page.locator('aside button:has-text("Co-authors")').click();
@@ -1214,6 +1238,9 @@ test.describe('Publication flow + co-authors', () => {
         await page.locator(PageModel.publish.text.editor).click();
         await page.keyboard.type(publicationWithCoAuthors.content);
 
+        // confirm conflict of interest
+        await publicationFlowConflictOfInterest(page, false);
+
         // add co-author
         await page.locator('aside button:has-text("Co-authors")').click();
         await addCoAuthor(page, Helpers.user2);
@@ -1269,6 +1296,9 @@ test.describe('Publication flow + co-authors', () => {
         await (await page.waitForSelector("aside button:has-text('Main text')")).click();
         await page.locator(PageModel.publish.text.editor).click();
         await page.keyboard.type(publicationWithCoAuthors.content);
+
+        // confirm conflict of interest
+        await publicationFlowConflictOfInterest(page, false);
 
         // add co-author
         await page.locator('aside button:has-text("Co-authors")').click();
@@ -1338,6 +1368,9 @@ test.describe('Publication flow + co-authors', () => {
         await page.locator(PageModel.publish.text.editor).click();
         await page.keyboard.type(publicationWithCoAuthors.content);
 
+        // confirm conflict of interest
+        await publicationFlowConflictOfInterest(page, false);
+
         // add co-author
         await page.locator('aside button:has-text("Co-authors")').click();
         await addCoAuthor(page, Helpers.user2);
@@ -1400,6 +1433,9 @@ test.describe('Publication flow + co-authors', () => {
         await (await page.waitForSelector("aside button:has-text('Main text')")).click();
         await page.locator(PageModel.publish.text.editor).click();
         await page.keyboard.type(publicationWithCoAuthors.content);
+
+        // confirm conflict of interest
+        await publicationFlowConflictOfInterest(page, false);
 
         // add co-author
         await page.locator('aside button:has-text("Co-authors")').click();
@@ -1484,6 +1520,9 @@ test.describe('Publication flow + co-authors', () => {
         await page.locator(PageModel.publish.text.editor).click();
         await page.keyboard.type(publicationWithCoAuthors.content);
 
+        // confirm conflict of interest
+        await publicationFlowConflictOfInterest(page, false);
+
         // add co-author
         await page.locator('aside button:has-text("Co-authors")').click();
         await addCoAuthor(page, Helpers.user2);
@@ -1548,6 +1587,9 @@ test.describe('Publication flow + co-authors', () => {
         await (await page.waitForSelector("aside button:has-text('Main text')")).click();
         await page.locator(PageModel.publish.text.editor).click();
         await page.keyboard.type(publicationWithCoAuthors.content);
+
+        // confirm conflict of interest
+        await publicationFlowConflictOfInterest(page, false);
 
         // add co-author
         await page.locator('aside button:has-text("Co-authors")').click();
@@ -1627,6 +1669,9 @@ test.describe('Publication flow + co-authors', () => {
         await page.locator(PageModel.publish.text.editor).click();
         await page.keyboard.type(publicationWithCoAuthors.content);
 
+        // confirm conflict of interest
+        await publicationFlowConflictOfInterest(page, false);
+
         // add co-author
         await page.locator('aside button:has-text("Co-authors")').click();
         await addCoAuthor(page, Helpers.user2);
@@ -1685,6 +1730,9 @@ test.describe('Publication flow + co-authors', () => {
         await page.locator(PageModel.publish.text.editor).click();
         await page.keyboard.type(publicationWithCoAuthors.content);
 
+        // confirm conflict of interest
+        await publicationFlowConflictOfInterest(page, false);
+
         // add co-author
         await page.locator('aside button:has-text("Co-authors")').click();
         await addCoAuthor(page, Helpers.user2);
@@ -1740,6 +1788,9 @@ test.describe('Publication flow + co-authors', () => {
         await (await page.waitForSelector("aside button:has-text('Main text')")).click();
         await page.locator(PageModel.publish.text.editor).click();
         await page.keyboard.type(publicationWithCoAuthors.content);
+
+        // confirm conflict of interest
+        await publicationFlowConflictOfInterest(page, false);
 
         // add co-author
         await page.locator('aside button:has-text("Co-authors")').click();

--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -553,7 +553,9 @@ const addCoAuthor = async (page: Page, user: Helpers.TestUser) => {
 };
 
 const removeCoAuthor = async (page: Page, user: Helpers.TestUser) => {
-    await page.waitForResponse((res) => res.url().includes('/coauthors') && res.ok());
+    const responsePromise = page.waitForResponse((res) => res.url().includes('/coauthors') && res.ok());
+    await page.locator('aside button:has-text("Co-authors")').click();
+    await responsePromise;
     const row = page.locator('tr', { hasText: user.email });
     await row.locator('button[title="Delete"]').click();
 };
@@ -801,9 +803,9 @@ test.describe('Publication flow + co-authors', () => {
 
         // check publication title and authors
         await expect(page.locator(`h1:has-text("${publicationWithCoAuthors.title}")`)).toBeVisible();
-        await expect(page.getByText(Helpers.user1.shortName)).toBeVisible();
-        await expect(page.getByText(Helpers.user2.shortName)).toBeVisible();
-        await expect(page.getByText(Helpers.user3.shortName)).toBeVisible();
+        await expect(page.locator(`span.author-name:has-text("${Helpers.user1.shortName}")`)).toBeVisible();
+        await expect(page.locator(`span.author-name:has-text("${Helpers.user2.shortName}")`)).toBeVisible();
+        await expect(page.locator(`span.author-name:has-text("${Helpers.user3.shortName}")`)).toBeVisible();
         await page.close();
     });
 
@@ -901,7 +903,6 @@ test.describe('Publication flow + co-authors', () => {
 
         // Unlock publication
         await unlockPublication(page);
-        await page.locator('aside button:has-text("Co-authors")').click();
 
         // remove co-author from the publication
         await removeCoAuthor(page, Helpers.user3);
@@ -989,8 +990,8 @@ test.describe('Publication flow + co-authors', () => {
 
         // check publication title and authors
         await expect(page.locator(`h1:has-text("${publicationWithCoAuthors.title}")`)).toBeVisible();
-        await expect(page.getByText(Helpers.user1.shortName)).toBeVisible();
-        await expect(page.getByText(Helpers.user2.shortName)).toBeVisible();
+        await expect(page.locator(`span.author-name:has-text("${Helpers.user1.shortName}")`)).toBeVisible();
+        await expect(page.locator(`span.author-name:has-text("${Helpers.user2.shortName}")`)).toBeVisible();
 
         // check authors order on the publication page
         await expect(page.locator('.author-name').first()).toContainText(Helpers.user2.shortName);
@@ -1048,7 +1049,6 @@ test.describe('Publication flow + co-authors', () => {
 
         // Unlock publication
         await unlockPublication(page);
-        await page.locator('aside button:has-text("Co-authors")').click();
 
         // remove co-author from the publication
         await removeCoAuthor(page, Helpers.user2);
@@ -1120,7 +1120,6 @@ test.describe('Publication flow + co-authors', () => {
 
         // Unlock publication
         await unlockPublication(page);
-        await page.locator('aside button:has-text("Co-authors")').click();
 
         // remove co-author from the publication
         await removeCoAuthor(page, Helpers.user2);
@@ -1186,7 +1185,6 @@ test.describe('Publication flow + co-authors', () => {
 
         // Unlock publication
         await unlockPublication(page);
-        await page.locator('aside button:has-text("Co-authors")').click();
 
         // remove co-author from the publication
         await removeCoAuthor(page, Helpers.user2);
@@ -1457,9 +1455,6 @@ test.describe('Publication flow + co-authors', () => {
         await page.locator(PageModel.publish.confirmRequestApproval).click();
         await page.waitForResponse((response) => response.url().includes('/request-approval') && response.ok());
 
-        // preview publication
-        await Promise.all([page.waitForNavigation(), page.locator(PageModel.publish.previewButton).click()]);
-
         // check preview page
         await expect(page.getByText('This publication is locked for approval')).toBeVisible();
         await expect(page.locator('table[data-testid="approval-tracker-table"]')).toBeVisible();
@@ -1603,9 +1598,6 @@ test.describe('Publication flow + co-authors', () => {
         await page.locator(PageModel.publish.requestApprovalButton).click();
         await page.locator(PageModel.publish.confirmRequestApproval).click();
         await page.waitForResponse((response) => response.url().includes('/request-approval') && response.ok());
-
-        // preview publication
-        await Promise.all([page.waitForNavigation(), page.locator(PageModel.publish.previewButton).click()]);
 
         // check preview page
         await expect(page.getByText('This publication is locked for approval')).toBeVisible();

--- a/e2e/tests/LoggedOut/profile.e2e.spec.ts
+++ b/e2e/tests/LoggedOut/profile.e2e.spec.ts
@@ -1,83 +1,66 @@
-import * as Helpers from "../helpers";
-import { expect, Page, test } from "@playwright/test";
-import { PageModel } from "../PageModel";
+import * as Helpers from '../helpers';
+import { expect, Page, test } from '@playwright/test';
+import { PageModel } from '../PageModel';
 
-test.describe("Science Octopus profile", () => {
-  let page: Page;
+test.describe('Science Octopus profile', () => {
+    let page: Page;
 
-  test.beforeAll(async ({ browser }) => {
-    page = await browser.newPage();
-    // navigate to Science Octopus profile page
-    await page.goto(`${Helpers.UI_BASE}/authors/octopus`, {
-      waitUntil: "domcontentloaded",
+    test.beforeAll(async ({ browser }) => {
+        page = await browser.newPage();
+        // navigate to Science Octopus profile page
+        await page.goto(`${Helpers.UI_BASE}/authors/octopus`, {
+            waitUntil: 'domcontentloaded'
+        });
+        await expect(page).toHaveTitle('Author: XXXX-XXXX-XXXX-XXXX - Octopus | Built for Researchers');
     });
-    await expect(page).toHaveTitle(
-      "Author: XXXX-XXXX-XXXX-XXXX - Octopus | Built for Researchers"
-    );
-  });
 
-  test.afterAll(async () => {
-    await page.close();
-  });
+    test.afterAll(async () => {
+        await page.close();
+    });
 
-  test("Octopus publications pagination", async () => {
-    // check user full name
-    await expect(page.locator("h1")).toHaveText("Science Octopus");
+    test('Octopus publications pagination', async () => {
+        // check user full name
+        await expect(page.locator('h1')).toHaveText('Science Octopus');
 
-    // check Octopus publications section
-    const octopusPublicationsHeader = page.locator(
-      PageModel.profilePage.octopusPublications
-    );
+        // check Octopus publications section
+        const octopusPublicationsHeader = page.locator(PageModel.profilePage.octopusPublications);
 
-    await expect(octopusPublicationsHeader).toBeVisible();
+        await expect(octopusPublicationsHeader).toBeVisible();
 
-    const octopusPublicationsSection =
-      octopusPublicationsHeader.locator("xpath=..");
+        await page.waitForLoadState('networkidle');
 
-    // initially, only 10 publications should be visible
-    expect(
-      await octopusPublicationsSection.locator("a[role=button]").count()
-    ).toEqual(10);
+        const octopusPublicationsSection = octopusPublicationsHeader.locator('xpath=..');
 
-    // press "Show More" button to see more publications
-    await expect(page.locator("'Show More'")).toBeVisible();
-    await Promise.all([
-      page.waitForResponse(
-        (response) =>
-          response
-            .url()
-            .includes("/users/octopus/publications?offset=10&limit=10") &&
-          response.ok()
-      ),
-      page.click("'Show More'"),
-    ]);
+        // initially, only 10 publications should be visible
+        expect(await octopusPublicationsSection.locator('a[role=button]').count()).toEqual(10);
 
-    // wait for publications to be rendered - 50ms per each
-    await page.waitForTimeout(500);
+        // press "Show More" button to see more publications
+        await expect(page.locator("'Show More'")).toBeVisible();
+        await Promise.all([
+            page.waitForResponse(
+                (response) => response.url().includes('/users/octopus/publications?offset=10&limit=10') && response.ok()
+            ),
+            page.click("'Show More'")
+        ]);
 
-    // the next 10 pubs should be loaded
-    expect(
-      await octopusPublicationsSection.locator("a[role=button]").count()
-    ).toEqual(20);
+        // wait for publications to be rendered - 50ms per each
+        await page.waitForTimeout(500);
 
-    // press "Show More" button again
-    await Promise.all([
-      page.waitForResponse(
-        (response) =>
-          response
-            .url()
-            .includes("/users/octopus/publications?offset=20&limit=10") &&
-          response.ok()
-      ),
-      page.click("'Show More'"),
-    ]);
+        // the next 10 pubs should be loaded
+        expect(await octopusPublicationsSection.locator('a[role=button]').count()).toEqual(20);
 
-    // wait for publications to be rendered - 50ms per each
-    await page.waitForTimeout(500);
+        // press "Show More" button again
+        await Promise.all([
+            page.waitForResponse(
+                (response) => response.url().includes('/users/octopus/publications?offset=20&limit=10') && response.ok()
+            ),
+            page.click("'Show More'")
+        ]);
 
-    // 30 publications should now be visible in the UI
-    expect(
-      await octopusPublicationsSection.locator("a[role=button]").count()
-    ).toEqual(30);
-  });
+        // wait for publications to be rendered - 50ms per each
+        await page.waitForTimeout(500);
+
+        // 30 publications should now be visible in the UI
+        expect(await octopusPublicationsSection.locator('a[role=button]').count()).toEqual(30);
+    });
 });

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -44,7 +44,6 @@
                 "react-icons": "^4.3.1",
                 "react-xarrows": "^2.0.2",
                 "swr": "^2.1.5",
-                "underscore": "^1.13.6",
                 "zustand": "^4.3.8"
             },
             "devDependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -59,7 +59,6 @@
         "react-icons": "^4.3.1",
         "react-xarrows": "^2.0.2",
         "swr": "^2.1.5",
-        "underscore": "^1.13.6",
         "zustand": "^4.3.8"
     },
     "devDependencies": {


### PR DESCRIPTION
The purpose of this PR was to remove underscore, because it is an unused dependency that has security advisories against it.

I have also cherry picked [this commit](https://github.com/JiscSD/octopus/pull/423/commits/5ba4eaca71d8f70a0f66285c7f523ad7e7de75d2) made by Florin so that I could run end to end tests. I had to make a few more changes to them as well to detect author names more specifically and to stop trying to manually preview the publication after requesting approval (which happens automatically).

The e2e package-lock change seems to just be the new lockfile version as a result of installing dependencies using node 16 (as directed in package.json) so I have included it.

---

### Acceptance Criteria:

Underscore is no longer a UI dependency.

---

### Checklist:

- [x] Local manual testing conducted

---