### PR TITLE
OCT-654 upgrade node to LTS for UI and e2e tests

### DIFF
--- a/e2e/.env.example
+++ b/e2e/.env.example
@@ -19,3 +19,4 @@ ORCID_TEST_FIRST_NAME4=
 ORCID_TEST_LAST_NAME4=
 
 MAIL_HOG=http://localhost:8025/
+UI_BASE=https://localhost:3001

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,7 +1,7 @@
 {
     "name": "e2e",
     "version": "1.0.0",
-    "lockfileVersion": 2,
+    "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
@@ -13,11 +13,11 @@
                 "dotenv": "^16.1.4"
             },
             "devDependencies": {
-                "@playwright/test": "^1.34.3",
-                "@types/node": "^20.2.5"
+                "@playwright/test": "^1.35.1",
+                "@types/node": "^18.16.18"
             },
             "engines": {
-                "node": "16"
+                "node": "18.x"
             }
         },
         "node_modules/@noble/hashes": {
@@ -40,28 +40,28 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.34.3",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.34.3.tgz",
-            "integrity": "sha512-zPLef6w9P6T/iT6XDYG3mvGOqOyb6eHaV9XtkunYs0+OzxBtrPAAaHotc0X+PJ00WPPnLfFBTl7mf45Mn8DBmw==",
+            "version": "1.35.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.35.1.tgz",
+            "integrity": "sha512-b5YoFe6J9exsMYg0pQAobNDR85T1nLumUYgUTtKm4d21iX2L7WqKq9dW8NGJ+2vX0etZd+Y7UeuqsxDXm9+5ZA==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*",
-                "playwright-core": "1.34.3"
+                "playwright-core": "1.35.1"
             },
             "bin": {
                 "playwright": "cli.js"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             },
             "optionalDependencies": {
                 "fsevents": "2.3.2"
             }
         },
         "node_modules/@types/node": {
-            "version": "20.2.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
-            "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==",
+            "version": "18.16.18",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.18.tgz",
+            "integrity": "sha512-/aNaQZD0+iSBAGnvvN2Cx92HqE5sZCPZtx2TsK+4nvV23fFe09jVDvpArXr2j9DnYlzuU9WuoykDDc6wqvpNcw==",
             "dev": true
         },
         "node_modules/dotenv": {
@@ -90,66 +90,16 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.34.3",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.34.3.tgz",
-            "integrity": "sha512-2pWd6G7OHKemc5x1r1rp8aQcpvDh7goMBZlJv6Co5vCNLVcQJdhxRL09SGaY6HcyHH9aT4tiynZabMofVasBYw==",
+            "version": "1.35.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.35.1.tgz",
+            "integrity": "sha512-pNXb6CQ7OqmGDRspEjlxE49w+4YtR6a3X6mT1hZXeJHWmsEz7SunmvZeiG/+y1yyMZdHnnn73WKYdtV1er0Xyg==",
             "dev": true,
             "bin": {
                 "playwright-core": "cli.js"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=16"
             }
-        }
-    },
-    "dependencies": {
-        "@noble/hashes": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
-            "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA=="
-        },
-        "@paralleldrive/cuid2": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.1.tgz",
-            "integrity": "sha512-GJhHYlMhyT2gWemDL7BGMWfTNhspJKkikLKh9wAy3z4GTTINvTYALkUd+eGQK7aLeVkVzPuSA0VCT3H5eEWbbw==",
-            "requires": {
-                "@noble/hashes": "^1.1.5"
-            }
-        },
-        "@playwright/test": {
-            "version": "1.34.3",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.34.3.tgz",
-            "integrity": "sha512-zPLef6w9P6T/iT6XDYG3mvGOqOyb6eHaV9XtkunYs0+OzxBtrPAAaHotc0X+PJ00WPPnLfFBTl7mf45Mn8DBmw==",
-            "dev": true,
-            "requires": {
-                "@types/node": "*",
-                "fsevents": "2.3.2",
-                "playwright-core": "1.34.3"
-            }
-        },
-        "@types/node": {
-            "version": "20.2.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
-            "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==",
-            "dev": true
-        },
-        "dotenv": {
-            "version": "16.1.4",
-            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.1.4.tgz",
-            "integrity": "sha512-m55RtE8AsPeJBpOIFKihEmqUcoVncQIwo7x9U8ZwLEZw9ZpXboz2c+rvog+jUaJvVrZ5kBOeYQBX5+8Aa/OZQw=="
-        },
-        "fsevents": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
-            "optional": true
-        },
-        "playwright-core": {
-            "version": "1.34.3",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.34.3.tgz",
-            "integrity": "sha512-2pWd6G7OHKemc5x1r1rp8aQcpvDh7goMBZlJv6Co5vCNLVcQJdhxRL09SGaY6HcyHH9aT4tiynZabMofVasBYw==",
-            "dev": true
         }
     }
 }

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -4,7 +4,7 @@
     "description": "",
     "main": "index.js",
     "engines": {
-        "node": "16"
+        "node": "18.x"
     },
     "scripts": {
         "test": "npx playwright test",
@@ -14,8 +14,8 @@
     "author": "",
     "license": "ISC",
     "devDependencies": {
-        "@playwright/test": "^1.34.3",
-        "@types/node": "^20.2.5"
+        "@playwright/test": "^1.35.1",
+        "@types/node": "^18.16.18"
     },
     "dependencies": {
         "@paralleldrive/cuid2": "^2.2.1",

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -1,7 +1,7 @@
 import { Browser, expect, Locator, Page } from '@playwright/test';
 import { PageModel } from './PageModel';
 
-export const UI_BASE = process.env.UI_BASE || 'https://localhost:3001';
+export const UI_BASE = process.env.UI_BASE;
 export const MAIL_HOG = process.env.MAIL_HOG;
 
 const requiredEnvVariables = [
@@ -21,7 +21,8 @@ const requiredEnvVariables = [
     'ORCID_TEST_PASS4',
     'ORCID_TEST_FIRST_NAME4',
     'ORCID_TEST_LAST_NAME4',
-    'MAIL_HOG'
+    'MAIL_HOG',
+    'UI_BASE'
 ];
 
 function checkEnvVariable(variableName: string) {

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -55,7 +55,7 @@
                 "@types/js-cookie": "^3.0.1",
                 "@types/jsonwebtoken": "^9.0.2",
                 "@types/luxon": "^3.3.0",
-                "@types/node": "^16.18.36",
+                "@types/node": "^18.16.18",
                 "@types/react": "^18.2.12",
                 "autoprefixer": "^10.4.2",
                 "concurrently": "^8.2.0",
@@ -75,7 +75,7 @@
                 "typescript": "^5.1.3"
             },
             "engines": {
-                "node": "16"
+                "node": "18.x"
             }
         },
         "node_modules/@adobe/css-tools": {
@@ -3052,9 +3052,9 @@
             "dev": true
         },
         "node_modules/@types/node": {
-            "version": "16.18.36",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.36.tgz",
-            "integrity": "sha512-8egDX8dE50XyXWH6C6PRCNkTP106DuUrvdrednFouDSmCi7IOvrqr0frznfZaHifHH/3aq/7a7v9N4wdXMqhBQ==",
+            "version": "18.16.18",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.18.tgz",
+            "integrity": "sha512-/aNaQZD0+iSBAGnvvN2Cx92HqE5sZCPZtx2TsK+4nvV23fFe09jVDvpArXr2j9DnYlzuU9WuoykDDc6wqvpNcw==",
             "dev": true
         },
         "node_modules/@types/object.omit": {
@@ -16458,9 +16458,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "16.18.36",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.36.tgz",
-            "integrity": "sha512-8egDX8dE50XyXWH6C6PRCNkTP106DuUrvdrednFouDSmCi7IOvrqr0frznfZaHifHH/3aq/7a7v9N4wdXMqhBQ==",
+            "version": "18.16.18",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.18.tgz",
+            "integrity": "sha512-/aNaQZD0+iSBAGnvvN2Cx92HqE5sZCPZtx2TsK+4nvV23fFe09jVDvpArXr2j9DnYlzuU9WuoykDDc6wqvpNcw==",
             "dev": true
         },
         "@types/object.omit": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,7 +10,7 @@
         "url": "https://github.com/JiscSD/octopus/tree/main/ui"
     },
     "engines": {
-        "node": "16"
+        "node": "18.x"
     },
     "scripts": {
         "dev": "concurrently \"NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF=local next dev -p 3000\" \"local-ssl-proxy --source 3001 --target 3000\"",
@@ -70,7 +70,7 @@
         "@types/js-cookie": "^3.0.1",
         "@types/jsonwebtoken": "^9.0.2",
         "@types/luxon": "^3.3.0",
-        "@types/node": "^16.18.36",
+        "@types/node": "^18.16.18",
         "@types/react": "^18.2.12",
         "autoprefixer": "^10.4.2",
         "concurrently": "^8.2.0",

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -8,7 +8,7 @@ export let baseURL: string;
 
 switch (process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF) {
     case 'local':
-        baseURL = 'http://localhost:4003/local/v1';
+        baseURL = 'http://127.0.0.1:4003/local/v1'; // https://github.com/node-fetch/node-fetch/issues/1624
         break;
     case 'main':
         baseURL = 'https://api.octopus.ac/v1';


### PR DESCRIPTION
The purpose of this PR was to upgrade UI and e2e node version to 18

---

### Acceptance Criteria:

upgrade to node 18 or whatever latest LTS version there is

need to make sure amplify and API builds support same version)

---

### Checklist:

- [x] Local manual testing conducted

---

### Tests:

---

### Screenshots:
