### PR TITLE
OCT-560 Invitation emails can be accepted by users who's email doesn't match

### DIFF
--- a/api/prisma/seeds/publications.ts
+++ b/api/prisma/seeds/publications.ts
@@ -217,6 +217,12 @@ const publicationSeeds = [
                     email: 'test-user-7@jisc.ac.uk',
                     code: 'test-code-user-7',
                     confirmedCoAuthor: false
+                },
+                {
+                    id: 'coauthor-test-user-8-problem-draft',
+                    email: 'test-user-8@jisc.ac.uk',
+                    code: 'test-code-user-8',
+                    confirmedCoAuthor: false
                 }
             ]
         },

--- a/api/src/components/coauthor/__tests__/linkCoAuthor.test.ts
+++ b/api/src/components/coauthor/__tests__/linkCoAuthor.test.ts
@@ -95,17 +95,34 @@ describe('Link co-author', () => {
         expect(link.status).toEqual(404);
     });
 
+    // the following test covers an edge case, but still possible
     test('Cannot link co-author with a different email address', async () => {
+        // trying to accept invitation with a user which is not a co-author
         const response = await testUtils.agent
             .patch('/publications/publication-problem-draft/link-coauthor')
-            .query({ apiKey: '000000004' }) // trying to accept the invitation logged in as a different user
+            .query({ apiKey: '000000004' })
             .send({
                 email: 'test-user-7@jisc.ac.uk',
                 code: 'test-code-user-7',
                 approve: true
             });
 
-        expect(response.status).toEqual(403);
+        expect(response.status).toEqual(404);
         expect(response.body.message).toBe('You are not currently listed as an author on this draft');
+
+        // trying to accept invitation with a different co-author account
+        const response2 = await testUtils.agent
+            .patch('/publications/publication-problem-draft/link-coauthor')
+            .query({ apiKey: '000000008' })
+            .send({
+                email: 'test-user-7@jisc.ac.uk',
+                code: 'test-code-user-7',
+                approve: true
+            });
+
+        expect(response2.status).toEqual(403);
+        expect(response2.body.message).toBe(
+            'Your email address does not match the one to which the invitation has been sent.'
+        );
     });
 });

--- a/api/src/components/coauthor/__tests__/linkCoAuthor.test.ts
+++ b/api/src/components/coauthor/__tests__/linkCoAuthor.test.ts
@@ -94,4 +94,18 @@ describe('Link co-author', () => {
 
         expect(link.status).toEqual(404);
     });
+
+    test('Cannot link co-author with a different email address', async () => {
+        const response = await testUtils.agent
+            .patch('/publications/publication-problem-draft/link-coauthor')
+            .query({ apiKey: '000000004' }) // trying to accept the invitation logged in as a different user
+            .send({
+                email: 'test-user-7@jisc.ac.uk',
+                code: 'test-code-user-7',
+                approve: true
+            });
+
+        expect(response.status).toEqual(403);
+        expect(response.body.message).toBe('You are not currently listed as an author on this draft');
+    });
 });

--- a/api/src/components/coauthor/controller.ts
+++ b/api/src/components/coauthor/controller.ts
@@ -248,7 +248,7 @@ export const link = async (
         if (event.user.email !== coAuthorByEmail.email) {
             const isCoAuthor = publication.coAuthors.some((coAuthor) => coAuthor.email === event.user?.email); // check that this user is a coAuthor
 
-            return response.json(403, {
+            return response.json(isCoAuthor ? 403 : 404, {
                 message: isCoAuthor
                     ? 'Your email address does not match the one to which the invitation has been sent.'
                     : 'You are not currently listed as an author on this draft'

--- a/api/src/components/coauthor/controller.ts
+++ b/api/src/components/coauthor/controller.ts
@@ -179,7 +179,7 @@ export const link = async (
         }
 
         if (!event.body.approve) {
-            // email has already been linked
+            // check if user has already been linked
             if (coAuthorByEmail.linkedUser) {
                 return response.json(404, {
                     message:
@@ -242,6 +242,11 @@ export const link = async (
             return response.json(404, {
                 message: 'User has already been linked to this publication.'
             });
+        }
+
+        // check if the user email is the same as the one the invitation has been sent to
+        if (event.user.email !== coAuthorByEmail.email) {
+            return response.json(403, { message: 'You are not currently listed as an author on this draft' });
         }
 
         await coAuthorService.linkUser(event.user.id, event.pathParameters.id, event.body.email, event.body.code);

--- a/api/src/components/coauthor/controller.ts
+++ b/api/src/components/coauthor/controller.ts
@@ -246,7 +246,13 @@ export const link = async (
 
         // check if the user email is the same as the one the invitation has been sent to
         if (event.user.email !== coAuthorByEmail.email) {
-            return response.json(403, { message: 'You are not currently listed as an author on this draft' });
+            const isCoAuthor = publication.coAuthors.some((coAuthor) => coAuthor.email === event.user?.email); // check that this user is a coAuthor
+
+            return response.json(403, {
+                message: isCoAuthor
+                    ? 'Your email address does not match the one to which the invitation has been sent.'
+                    : 'You are not currently listed as an author on this draft'
+            });
         }
 
         await coAuthorService.linkUser(event.user.id, event.pathParameters.id, event.body.email, event.body.code);


### PR DESCRIPTION
The purpose of this PR was to add an extra check on the api in order to prevent coauthors accepting an invitation using a different account

---

### Acceptance Criteria:

---

### Checklist:

- [x] Local manual testing conducted
- [x] API tests added


---

### Tests:

<img width="681" alt="image" src="https://github.com/JiscSD/octopus/assets/48569671/8e521f40-3ac1-4a15-86a0-f65bffd8670c">


---

### Screenshots:
