### PR TITLE
Break up sentence on home page blurb

### DIFF
--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -62,7 +62,7 @@ const Home: Types.NextPage<Props> = (props): React.ReactElement => {
                             in full detail
                         </h1>
                         <p className="mx-auto mb-10 block text-center font-montserrat text-base font-medium leading-relaxed text-grey-700 transition-colors duration-500 dark:text-grey-100 lg:w-8/12 lg:text-lg">
-                            Octopus is a new publishing platform for scholarly research funded by UKRI – the UK
+                            Octopus is a new publishing platform for scholarly research. Funded by UKRI – the UK
                             government research funder.
                         </p>
                         <p className="mx-auto mb-10 block text-center font-montserrat text-base font-medium leading-relaxed text-grey-700 transition-colors duration-500 dark:text-grey-100 lg:w-8/12 lg:text-lg">


### PR DESCRIPTION
The purpose of this PR was to change the copy on the homepage so it reads: 

> Octopus is a new publishing platform for scholarly research. Funded by UKRI – the UK government research funder.

---

### Acceptance Criteria:
 As per [OCT-704](https://jiscdev.atlassian.net/jira/software/projects/OCT/boards/836?selectedIssue=OCT-704)

---

### Checklist:

- [X] Local manual testing conducted

---

### Screenshots:

![Screenshot 2023-07-07 at 10 11 18](https://github.com/JiscSD/octopus/assets/100135505/8b3c6d4a-127f-416e-bda8-5f18a8d6bfcd)



[OCT-704]: https://jiscdev.atlassian.net/browse/OCT-704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ