### PR TITLE
OCT-705 "You do not have permissions to add an affiliation to this publication"

### DIFF
--- a/api/src/components/coauthor/service.ts
+++ b/api/src/components/coauthor/service.ts
@@ -210,3 +210,16 @@ export const updateRequestApprovalStatus = async (publicationId: string, email: 
 
     return coAuthors;
 };
+
+export const createCorrespondingAuthor = (publication: I.PublicationWithMetadata) =>
+    client.prisma.coAuthors.create({
+        data: {
+            email: publication?.user.email || '',
+            publicationId: publication?.id || '',
+            linkedUser: publication?.createdBy,
+            affiliations: [],
+            isIndependent: true,
+            approvalRequested: false,
+            confirmedCoAuthor: true
+        }
+    });

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -373,6 +373,7 @@ export interface CoAuthor {
     publicationId: string;
     createdAt?: string;
     reminderDate?: string | null;
+    isIndependent: boolean;
     affiliations: MappedOrcidAffiliation[];
     user?: {
         firstName: string;

--- a/ui/src/components/Publication/Creation/Affiliations.tsx
+++ b/ui/src/components/Publication/Creation/Affiliations.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React from 'react';
 import useSWR from 'swr';
 import * as Components from '@components';
 import * as Stores from '@stores';

--- a/ui/src/pages/publications/[id]/index.tsx
+++ b/ui/src/pages/publications/[id]/index.tsx
@@ -459,7 +459,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                         </div>
                     )}
 
-                    {author && (
+                    {showApprovalsTracker && author && (
                         <Components.EditAffiliationsModal
                             author={author}
                             autoUpdate={isCorrespondingAuthor || !author.confirmedCoAuthor}


### PR DESCRIPTION
The purpose of this PR was to fix a bug related to old draft publications which didn't have the corresponding author included into the co-author list.

The workaround was to check every time when we fetch co-authors if the corresponding author is included in publication's coAuthor list. If it's not included then we add them automatically before sending the response to the client

---

### Acceptance Criteria:

As per [OCT-705](https://jiscdev.atlassian.net/browse/OCT-705) although the description is not 100% accurate because this issue could only occur for old draft publications. The issue cannot be replicated with a new publication

---

### Checklist:

- [x] Local manual testing conducted

---

### Tests:

---

### Screenshots:
