### PR TITLE
Dropdown menu not working except on a full width desktop display

### DIFF
--- a/ui/src/components/Nav/Mobile/index.tsx
+++ b/ui/src/components/Nav/Mobile/index.tsx
@@ -60,10 +60,7 @@ const Mobile: React.FC<Props> = (props): React.ReactElement => {
                                     <li key={item.value} className="my-4">
                                         {item.subItems?.length ? (
                                             <HeadlessUI.Menu as="div" className="relative z-50 inline-block text-left">
-                                                <HeadlessUI.Menu.Button
-                                                    className="rounded border-transparent p-2 font-medium text-grey-800 outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400 dark:text-white-50"
-                                                    onClick={() => setOpen(true)}
-                                                >
+                                                <HeadlessUI.Menu.Button className="rounded border-transparent p-2 font-medium text-grey-800 outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400 dark:text-white-50">
                                                     <span className="flex items-center">
                                                         {item.label}
                                                         <OutlineIcons.ChevronDownIcon className="ml-2 h-4 w-4 text-grey-500 transition-colors duration-500 dark:text-teal-500" />

--- a/ui/src/components/Nav/Mobile/index.tsx
+++ b/ui/src/components/Nav/Mobile/index.tsx
@@ -62,7 +62,7 @@ const Mobile: React.FC<Props> = (props): React.ReactElement => {
                                             <HeadlessUI.Menu as="div" className="relative z-50 inline-block text-left">
                                                 <HeadlessUI.Menu.Button
                                                     className="rounded border-transparent p-2 font-medium text-grey-800 outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400 dark:text-white-50"
-                                                    onClick={handleClose}
+                                                    onClick={() => setOpen(true)}
                                                 >
                                                     <span className="flex items-center">
                                                         {item.label}


### PR DESCRIPTION
The purpose of this PR was to fix the mobile nav bar bug where the subitems menu closes the whole navbar when a user clicks to expand. 

This turned out to be a pretty simple fix and looks like was a bug in our code. I've changed it so the `setOpen` state is set to true when the user clicks it as previously it was being set to false. 

---

### Acceptance Criteria:

As per [OCT-706](https://github.com/JiscSD/octopus/pull/378/files)

---

### Checklist:

- [x] Local manual testing conducted

---

### Screenshots:

https://github.com/JiscSD/octopus/assets/100135505/2f52a86c-b147-43d5-9b21-12372df3d529



[OCT-706]: https://jiscdev.atlassian.net/browse/OCT-706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ