### PR TITLE
OCT-650 - update opensearch

### DIFF
--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -45,7 +45,7 @@ services:
             - db
 
     opensearch-node1: # This is also the hostname of the container within the Docker network (i.e. https://opensearch-node1/)
-        image: opensearchproject/opensearch:2.3.0 # upgrade from 1.2
+        image: opensearchproject/opensearch:2.7.0
         container_name: api-test-opensearch-node1
         environment:
             - cluster.name=opensearch-cluster # Name the cluster
@@ -72,7 +72,7 @@ services:
             retries: 5
 
     opensearch-dashboards:
-        image: opensearchproject/opensearch-dashboards:2.3.0 # upgrade from 1.2
+        image: opensearchproject/opensearch-dashboards:2.7.0
         container_name: api-test-opensearch-dashboards
         ports:
             - 5601:5601 # Map host port 5601 to container port 5601

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -13,7 +13,7 @@
                 "@middy/do-not-wait-for-empty-event-loop": "^4.5.1",
                 "@middy/http-json-body-parser": "^4.5.1",
                 "@middy/validator": "^4.5.1",
-                "@opensearch-project/opensearch": "^2.1.0",
+                "@opensearch-project/opensearch": "^2.3.0",
                 "@paralleldrive/cuid2": "^2.2.1",
                 "@prisma/client": "^4.14.1",
                 "@serverless/utils": "^6.11.1",
@@ -5788,13 +5788,13 @@
             }
         },
         "node_modules/@opensearch-project/opensearch": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@opensearch-project/opensearch/-/opensearch-2.1.0.tgz",
-            "integrity": "sha512-iM2u63j2IlUOuMSbcw1TZFpRqjK6qMwVhb3jLLa/x4aATxdKOiO1i17mgzfkeepqj85efNzXBZzN+jkq1/EXhQ==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@opensearch-project/opensearch/-/opensearch-2.3.0.tgz",
+            "integrity": "sha512-sqMLZj477aoSEcODcTjJCCzm58cbv6BUionZ2jCcBzfSLgHS9jnmNFdVrUy998QOOkoRHIcZ6DAzjInmI9WQzg==",
             "dependencies": {
                 "aws4": "^1.11.0",
                 "debug": "^4.3.1",
-                "hpagent": "^0.1.1",
+                "hpagent": "^1.2.0",
                 "ms": "^2.1.3",
                 "secure-json-parse": "^2.4.0"
             },
@@ -11495,9 +11495,12 @@
             }
         },
         "node_modules/hpagent": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-0.1.2.tgz",
-            "integrity": "sha512-ePqFXHtSQWAFXYmj+JtOTHr84iNrII4/QRlAAPPE+zqnKy4xJo7Ie1Y4kC7AdB+LxLxSTTzBMASsEcy0q8YyvQ=="
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+            "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+            "engines": {
+                "node": ">=14"
+            }
         },
         "node_modules/html-entities": {
             "version": "2.3.3",

--- a/api/package.json
+++ b/api/package.json
@@ -33,7 +33,7 @@
         "@middy/do-not-wait-for-empty-event-loop": "^4.5.1",
         "@middy/http-json-body-parser": "^4.5.1",
         "@middy/validator": "^4.5.1",
-        "@opensearch-project/opensearch": "^2.1.0",
+        "@opensearch-project/opensearch": "^2.3.0",
         "@paralleldrive/cuid2": "^2.2.1",
         "@prisma/client": "^4.14.1",
         "@serverless/utils": "^6.11.1",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock"
 
   opensearch-node1: # This is also the hostname of the container within the Docker network (i.e. https://opensearch-node1/)
-    image: opensearchproject/opensearch:2.3.0 # upgrade from 1.2
+    image: opensearchproject/opensearch:2.7.0
     container_name: opensearch-node1
     environment:
       - cluster.name=opensearch-cluster # Name the cluster
@@ -70,7 +70,7 @@ services:
       - opensearch-net # All of the containers will join the same Docker bridge network
 
   opensearch-dashboards:
-    image: opensearchproject/opensearch-dashboards:2.3.0 # upgrade from 1.2
+    image: opensearchproject/opensearch-dashboards:2.7.0
     container_name: opensearch-dashboards
     depends_on:
       - opensearch-node1

--- a/infra/modules/elasticsearch/main.tf
+++ b/infra/modules/elasticsearch/main.tf
@@ -33,7 +33,7 @@ resource "aws_security_group" "elasticsearch" {
 
 resource "aws_elasticsearch_domain" "elasticsearch" {
   domain_name           = "${var.environment}-octopus"
-  elasticsearch_version = "OpenSearch_2.3"
+  elasticsearch_version = "OpenSearch_2.7"
 
   encrypt_at_rest {
     enabled = true


### PR DESCRIPTION
The purpose of this PR was to update opensearch to the latest version.

---

### Acceptance Criteria:
- Opensearch is on version 2.7
---

### Checklist:

- [x] Local manual testing conducted
I have confirmed with terraform plan that this would cause the opensearch instance to be changed in-place so it should not affect our search indexes apart from a brief downtime to apply the update.
---
### Screenshots:

<img width="504" alt="Screenshot 2023-07-12 153030" src="https://github.com/JiscSD/octopus/assets/132363734/f1e208aa-9652-4322-a821-a49b99ea36a1">
