### PR TITLE
increase bastion instance size

### DIFF
--- a/infra/modules/bastion/main.tf
+++ b/infra/modules/bastion/main.tf
@@ -60,7 +60,7 @@ data "aws_ami" "amazon-linux-2023" {
 
 resource "aws_instance" "bastion" {
   ami                         = "${data.aws_ami.amazon-linux-2023.id}"
-  instance_type               = "t3.nano"
+  instance_type               = "t3.small" # Anything lower and npm install can crash the instance
   subnet_id                   = var.public_subnet
   vpc_security_group_ids      = [aws_security_group.ec2_sg.id]
   associate_public_ip_address = true


### PR DESCRIPTION
The purpose of this PR was to increase the size of our bastion instance because on a nano / micro size, npm install was not completing.

---

### Acceptance Criteria:

The bastion is a t3.small EC2 instance.

---

### Checklist:

None applicable, but tested on int