### PR TITLE
Author search dropdown not changing properly - UI 

### DIFF
--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -92,7 +92,7 @@ export const search = async <T extends Types.SearchParameter>(
     offset: number | null = null,
     publicationType?: string | null
 ): Promise<Interfaces.SearchResults<T>> => {
-    let endpoint: string = searchType === 'users' ? Config.endpoints.users : Config.endpoints.publications;
+    let endpoint: string = searchType === 'authors' ? Config.endpoints.users : Config.endpoints.publications;
     let params: string = '';
 
     // Global search params

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -95,7 +95,7 @@ export type PublicationCreationStoreType = {
 
 export type JSONValue = unknown;
 
-export type SearchType = 'publications' | 'authors';
+export type SearchType = 'publications' | 'authors' | 'users';
 
 export type SearchParameter = Interfaces.Publication | Interfaces.User;
 

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -95,7 +95,7 @@ export type PublicationCreationStoreType = {
 
 export type JSONValue = unknown;
 
-export type SearchType = 'publications' | 'users';
+export type SearchType = 'publications' | 'authors';
 
 export type SearchParameter = Interfaces.Publication | Interfaces.User;
 

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -95,7 +95,7 @@ export type PublicationCreationStoreType = {
 
 export type JSONValue = unknown;
 
-export type SearchType = 'publications' | 'authors' | 'users';
+export type SearchType = 'publications' | 'authors';
 
 export type SearchParameter = Interfaces.Publication | Interfaces.User;
 

--- a/ui/src/pages/search/authors/index.tsx
+++ b/ui/src/pages/search/authors/index.tsx
@@ -20,7 +20,7 @@ import * as api from '@api';
 
 export const getServerSideProps: Types.GetServerSideProps = async (context) => {
     // defaults to possible query params
-    let searchType: Types.SearchType = 'users';
+    let searchType: Types.SearchType = 'authors';
     let query: string | string[] | null = null;
     let limit: number | string | string[] | null = null;
     let offset: number | string | string[] | null = null;
@@ -89,7 +89,7 @@ const Search: Types.NextPage<Props> = (props): React.ReactElement => {
     const router = Router.useRouter();
     const searchInputRef = React.useRef<HTMLInputElement>(null);
     // params
-    const [searchType] = React.useState(props.searchType);
+    const [searchType, setSearchType] = React.useState(props.searchType);
     const [query, setQuery] = React.useState(props.query ? props.query : '');
     // param for pagination
     const [limit, setLimit] = React.useState(props.limit ? parseInt(props.limit, 10) : 10);
@@ -138,7 +138,11 @@ const Search: Types.NextPage<Props> = (props): React.ReactElement => {
                             <select
                                 name="search-type"
                                 id="search-type"
-                                onChange={(e) => router.push(`/search/${e.target.value}`)}
+                                onChange={(e) => {
+                                    const value: Types.SearchType = e.target.value as Types.SearchType;
+                                    setSearchType(value);
+                                    router.push(`/search/${value}`);
+                                }}
                                 value={searchType}
                                 className="col-span-3 !mt-0 block w-full rounded-md border border-grey-200 outline-none focus:ring-2 focus:ring-yellow-500"
                                 disabled={isValidating}


### PR DESCRIPTION
The purpose of this PR was to fix a bug where if the user switches to the author search on the search page, the dropdown for search type stays on “Publication”. This prevents users from switching back to the publications search except by navigating away and back to the search page.

The reason for this bug is that the state wasn't being updated when the user changes their selection. 

---

### Acceptance Criteria:
See [OCT-721](https://jiscdev.atlassian.net/jira/software/projects/OCT/boards/836?selectedIssue=OCT-721)

---

### Checklist:

- [X] Local manual testing conducted

---

### Screenshots:

https://github.com/JiscSD/octopus/assets/100135505/6588ebbb-31a9-4431-bfe5-d9aa7e0e9c15



[OCT-721]: https://jiscdev.atlassian.net/browse/OCT-721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ