### PR TITLE
OCT-623 Select/deselect all publication types in search

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -8539,6 +8539,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
             "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+            "dev": true,
             "dependencies": {
                 "mimic-response": "^1.0.0"
             },
@@ -11310,7 +11311,8 @@
         "node_modules/http-cache-semantics": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-            "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
+            "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
+            "dev": true
         },
         "node_modules/http-proxy-agent": {
             "version": "7.0.0",


### PR DESCRIPTION
The purpose of this PR was to add a new _Select/deselect all_ checkbox on the publication search page.

Fixed an existing bug regarding checkboxes selection. For a split second, wrong results were showing up when selecting new publication types, until the api call returned the new data.

---

### Acceptance Criteria:

As per [OCT-623](https://jiscdev.atlassian.net/browse/OCT-623)

---

### Checklist:

- [x] Local manual testing conducted

---

### Tests:

---

### Screenshots:
![image](https://github.com/JiscSD/octopus/assets/48569671/ca0b411d-7209-4fef-91c7-3158897d8861)


[OCT-623]: https://jiscdev.atlassian.net/browse/OCT-623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ