### PR TITLE
OCT-727: Specify AMI architecture to match instance type (t3.small)

### DIFF
--- a/infra/modules/bastion/main.tf
+++ b/infra/modules/bastion/main.tf
@@ -56,6 +56,11 @@ data "aws_ami" "amazon-linux-2023" {
     name   = "name"
     values = ["al2023-ami-2023*"]
   }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
 }
 
 resource "aws_instance" "bastion" {


### PR DESCRIPTION
The purpose of this PR was to fix a small issue in terraform where it was possible for the bastion EC2 instance to be assigned an amazon machine image that is not compatible with its architecture type (e.g. arm64 vs. x86_64).

---

### Acceptance Criteria:

Bastions are provisioned with an AMI that uses x86_64 architecture to match the t3.small instance type.

---

### Checklist:

- [x] Local manual testing conducted - deployed to int
- [ ] Automated tests added - N/A
- [ ] Documentation updated - N/A