### PR TITLE
OCT-473: stop options from being obscured

### DIFF
--- a/ui/src/components/Publication/Creation/LinkedPublications.tsx
+++ b/ui/src/components/Publication/Creation/LinkedPublications.tsx
@@ -165,7 +165,7 @@ const LinkedPublications: React.FC = (): React.ReactElement => {
                         leaveTo="opacity-0"
                         afterLeave={() => setSearch('')}
                     >
-                        <HeadlessUI.Combobox.Options className="absolute mt-2 max-h-96 w-2/3 overflow-scroll rounded bg-white-50 shadow-xl">
+                        <HeadlessUI.Combobox.Options className="absolute z-10 mt-2 max-h-96 w-2/3 overflow-scroll rounded bg-white-50 shadow-xl">
                             {!isValidating &&
                                 results.data.map((publication: Interfaces.Publication, index: number) => (
                                     <HeadlessUI.Combobox.Option


### PR DESCRIPTION
The purpose of this PR was to stop options in the publication link combobox being unreachable because the end of the scroll bar is obscured.

---

### Acceptance Criteria:

The scrollbar can be scrolled from top to bottom and all options are fully shown.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added - N/A
- [ ] Documentation updated - N/A

---

### Tests:
<img width="528" alt="Screenshot 2023-08-01 130051" src="https://github.com/JiscSD/octopus/assets/132363734/9815c417-7249-4879-be31-c9b67656f88f">

---

### Screenshots:

Note the options list now extends past the bottom of the section tag containing the form. Previously the overflow was hidden behind the footer.

<img width="1133" alt="Screenshot 2023-08-01 130339" src="https://github.com/JiscSD/octopus/assets/132363734/77f71626-2cda-4736-9e3c-13ec8d708f8d">
