### PR TITLE
OCT-730 Add an indication of child research problems on topic pages

### DIFF
--- a/api/src/components/topic/service.ts
+++ b/api/src/components/topic/service.ts
@@ -53,6 +53,15 @@ export const get = async (id: string) => {
                     language: true,
                     translations: true
                 }
+            },
+            publications: {
+                select: {
+                    id: true,
+                    title: true
+                },
+                where: {
+                    currentStatus: 'LIVE'
+                }
             }
         }
     });

--- a/ui/src/lib/interfaces.ts
+++ b/ui/src/lib/interfaces.ts
@@ -457,6 +457,11 @@ export interface MappedOrcidAffiliation {
     url: string | null;
 }
 
+export interface TopicPublication {
+    id: string;
+    title: string;
+}
+
 export interface TopicTranslation {
     id: string;
     topicId: string;
@@ -476,4 +481,5 @@ export interface Topic extends BaseTopic {
     updatedAt: string;
     parents: BaseTopic[];
     children: BaseTopic[];
+    publications: TopicPublication[];
 }

--- a/ui/src/pages/topics/[id]/index.tsx
+++ b/ui/src/pages/topics/[id]/index.tsx
@@ -51,6 +51,8 @@ const Topic: Types.NextPage<Props> = (props): React.ReactElement => {
     const topic = props.topic;
     const showChildren = Boolean(topic.children.length);
     const showParents = Boolean(topic.parents.length);
+    const showPublications = Boolean(topic.publications.length);
+
     return (
         <>
             <Head>
@@ -111,6 +113,7 @@ const Topic: Types.NextPage<Props> = (props): React.ReactElement => {
                         )}
                     </header>
                     <p className="py-10">{Config.values.topicDescription}</p>
+
                     {showChildren && (
                         <div className="border-t border-grey-200">
                             <Components.ContentSection
@@ -132,6 +135,7 @@ const Topic: Types.NextPage<Props> = (props): React.ReactElement => {
                             </Components.ContentSection>
                         </div>
                     )}
+
                     {showParents && (
                         <div className="border-t border-grey-200">
                             <Components.ContentSection id="parents" title="Research topics above this in the hierarchy">
@@ -143,6 +147,25 @@ const Topic: Types.NextPage<Props> = (props): React.ReactElement => {
                                                 className="mb-2 text-teal-600 transition-colors duration-500 hover:underline dark:text-teal-400"
                                             >
                                                 {parent.title}
+                                            </Components.Link>
+                                        </Components.ListItem>
+                                    ))}
+                                </Components.List>
+                            </Components.ContentSection>
+                        </div>
+                    )}
+
+                    {showPublications && (
+                        <div className="border-t border-grey-200">
+                            <Components.ContentSection id="publications" title="Research problems linked to this topic">
+                                <Components.List ordered={false}>
+                                    {topic.publications.map((publication) => (
+                                        <Components.ListItem key={publication.id}>
+                                            <Components.Link
+                                                href={`${Config.urls.viewPublication.path}/${publication.id}`}
+                                                className="mb-2 text-teal-600 transition-colors duration-500 hover:underline dark:text-teal-400"
+                                            >
+                                                {publication.title}
                                             </Components.Link>
                                         </Components.ListItem>
                                     ))}


### PR DESCRIPTION
The purpose of this PR was to add a new section on the topic page called: **Research problems linked to this topic**

On this section, users can see links to all research problems that are linked to that particular topic.

---

### Acceptance Criteria:

As per [OCT-730](https://jiscdev.atlassian.net/browse/OCT-730)

---

### Checklist:

- [x] Local manual testing conducted

---

### Tests:

---

### Screenshots:
![image](https://github.com/JiscSD/octopus/assets/48569671/f52771d4-9a9c-4c15-ac1b-9c724d4c956b)



[OCT-730]: https://jiscdev.atlassian.net/browse/OCT-730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ