### PR TITLE
OCT-709 Keeping lambdas warm to improve site performance

### DIFF
--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -100,9 +100,10 @@ custom:
         v1: v1
     serverless-offline:
         useChildProcesses: true
-    warmup:
-        default:
-            enabled: true
+    provisionedConcurrencyCount:
+        local: 0
+        int: 1
+        prod: 2
     serverless-offline-ssm:
         stages:
             - local
@@ -152,6 +153,7 @@ functions:
         handler: src/lib/testUtils.openSearchSeed
     # Publications
     getPublications:
+        provisionedConcurrency: ${self:custom.provisionedConcurrencyCount.${self:provider.stage}}
         handler: src/components/publication/routes.getAll
         events:
             - http:
@@ -159,6 +161,7 @@ functions:
                   method: GET
                   cors: true
     getPublication:
+        provisionedConcurrency: ${self:custom.provisionedConcurrencyCount.${self:provider.stage}}
         handler: src/components/publication/routes.get
         events:
             - http:
@@ -201,6 +204,7 @@ functions:
                   method: DELETE
                   cors: true
     getPublicationLinks:
+        provisionedConcurrency: ${self:custom.provisionedConcurrencyCount.${self:provider.stage}}
         handler: src/components/publication/routes.getPublicationLinks
         events:
             - http:
@@ -216,6 +220,7 @@ functions:
                   method: GET
                   cors: true
     getResearchTopics:
+        provisionedConcurrency: ${self:custom.provisionedConcurrencyCount.${self:provider.stage}}
         handler: src/components/publication/routes.getResearchTopics
         events:
             - http:
@@ -224,6 +229,7 @@ functions:
                   cors: true
     # Users
     getUsers:
+        provisionedConcurrency: ${self:custom.provisionedConcurrencyCount.${self:provider.stage}}
         handler: src/components/user/routes.getAll
         events:
             - http:
@@ -254,6 +260,7 @@ functions:
                   cors: true
     # Auth
     authorization:
+        provisionedConcurrency: ${self:custom.provisionedConcurrencyCount.${self:provider.stage}}
         handler: src/components/authorization/routes.authorize
         events:
             - http:
@@ -442,7 +449,6 @@ functions:
     # Verification
     requestVerification:
         handler: src/components/verification/routes.requestCode
-        warmup: true
         events:
             - http:
                   path: ${self:custom.versions.v1}/verification/{id}
@@ -450,7 +456,6 @@ functions:
                   cors: true
     confirmVerification:
         handler: src/components/verification/routes.confirmCode
-        warmup: true
         events:
             - http:
                   path: ${self:custom.versions.v1}/verification/{id}
@@ -472,8 +477,8 @@ functions:
                   cors: true
     # References
     getReferences:
+        provisionedConcurrency: ${self:custom.provisionedConcurrencyCount.${self:provider.stage}}
         handler: src/components/reference/routes.get
-        warmup: true
         events:
             - http:
                   path: ${self:custom.versions.v1}/publications/{id}/reference
@@ -481,7 +486,6 @@ functions:
                   cors: true
     updateAllReference:
         handler: src/components/reference/routes.updateAll
-        warmup: true
         events:
             - http:
                   path: ${self:custom.versions.v1}/publications/{id}/reference
@@ -521,6 +525,7 @@ functions:
                   method: GET
                   cors: true
     getTopics:
+        provisionedConcurrency: ${self:custom.provisionedConcurrencyCount.${self:provider.stage}}
         handler: src/components/topic/routes.getTopics
         events:
             - http:

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -244,6 +244,7 @@ functions:
                   method: GET
                   cors: true
     getUserPublications:
+        provisionedConcurrency: ${self:custom.provisionedConcurrencyCount.${self:provider.stage}}
         handler: src/components/user/routes.getPublications
         events:
             - http:


### PR DESCRIPTION
The purpose of this PR was to use Lambda [Provisioned Concurrency](https://aws.amazon.com/about-aws/whats-new/2019/12/aws-lambda-announces-provisioned-concurrency/) for some of the most used lambdas in order to keep them warm. 

The code has been tested on int and it seems to work fine.

---

### Acceptance Criteria:

As per [OCT-709](https://jiscdev.atlassian.net/browse/OCT-709)

---

### Tests:

---

### Screenshots:
![image](https://github.com/JiscSD/octopus/assets/48569671/6511c24f-b9f2-453d-a948-d0220d6f55bf)


[OCT-709]: https://jiscdev.atlassian.net/browse/OCT-709?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ