### PR TITLE
OCT-734 Creation of an overall blog page

### DIFF
--- a/.github/workflows/ui-tasks.yml
+++ b/.github/workflows/ui-tasks.yml
@@ -7,6 +7,8 @@ env:
   NEXT_PUBLIC_MEDIA_BUCKET: https://science-octopus-publishing-images-int.s3.eu-west-1.amazonaws.com
   NEXT_PUBLIC_ORCID_APP_ID: APP-GXJE14DWV9NGHP5T
   NEXT_PUBLIC_ORCID_AUTH_URL: https://sandbox.orcid.org/oauth
+  NEXT_PUBLIC_CONTENTFUL_SPACE_ID: ${{secrets.NEXT_PUBLIC_CONTENTFUL_SPACE_ID}}
+  NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN: ${{secrets.NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN}}
 
 jobs:
   prettier:

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -15673,15 +15673,9 @@
             }
         },
         "node_modules/node-fetch": {
-<<<<<<< HEAD
-            "version": "2.6.13",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
-            "integrity": "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==",
-=======
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
             "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
->>>>>>> 8b30c2a2 (fixed package-lock)
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -15673,9 +15673,15 @@
             }
         },
         "node_modules/node-fetch": {
+<<<<<<< HEAD
             "version": "2.6.13",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
             "integrity": "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==",
+=======
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+>>>>>>> 8b30c2a2 (fixed package-lock)
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },

--- a/e2e/mocks/contentful_blog_posts.json
+++ b/e2e/mocks/contentful_blog_posts.json
@@ -1,0 +1,672 @@
+[
+    {
+        "sys": {
+            "id": "1bX9uHns0Nd7var3qb36eK",
+            "createdAt": "2023-08-25T06:10:10.140Z"
+        },
+        "fields": {
+            "title": "Blog 20",
+            "content": {
+                "nodeType": "document",
+                "data": {},
+                "content": [
+                    {
+                        "nodeType": "paragraph",
+                        "data": {},
+                        "content": [
+                            { "nodeType": "text", "value": "Lorem Ipsum", "marks": [{ "type": "bold" }], "data": {} },
+                            {
+                                "nodeType": "text",
+                                "value": " is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s.",
+                                "marks": [],
+                                "data": {}
+                            }
+                        ]
+                    }
+                ]
+            },
+            "author": "Florin H"
+        }
+    },
+    {
+        "sys": {
+            "id": "3JtCNSLX3FvWsvg4n94LF8",
+            "createdAt": "2023-08-25T06:09:38.809Z"
+        },
+        "fields": {
+            "title": "Blog 19",
+            "content": {
+                "data": {},
+                "content": [
+                    {
+                        "data": {},
+                        "content": [
+                            { "data": {}, "marks": [{ "type": "bold" }], "value": "Lorem Ipsum", "nodeType": "text" },
+                            {
+                                "data": {},
+                                "marks": [],
+                                "value": " is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+                                "nodeType": "text"
+                            }
+                        ],
+                        "nodeType": "paragraph"
+                    }
+                ],
+                "nodeType": "document"
+            },
+            "author": "Florin H"
+        }
+    },
+    {
+        "sys": {
+            "id": "sw2LKIqLoc5u0PcbH9XY0",
+            "createdAt": "2023-08-25T06:08:49.952Z"
+        },
+        "fields": {
+            "title": "Blog 18",
+            "content": {
+                "data": {},
+                "content": [
+                    {
+                        "data": {},
+                        "content": [
+                            { "data": {}, "marks": [{ "type": "bold" }], "value": "Lorem Ipsum", "nodeType": "text" },
+                            {
+                                "data": {},
+                                "marks": [],
+                                "value": " is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+                                "nodeType": "text"
+                            }
+                        ],
+                        "nodeType": "paragraph"
+                    }
+                ],
+                "nodeType": "document"
+            },
+            "author": "Florin H"
+        }
+    },
+    {
+        "sys": {
+            "id": "1KdaLFBJAruRyfY56uQH7O",
+            "createdAt": "2023-08-25T06:08:32.757Z"
+        },
+        "fields": {
+            "title": "Blog 17",
+            "content": {
+                "nodeType": "document",
+                "data": {},
+                "content": [
+                    {
+                        "nodeType": "paragraph",
+                        "data": {},
+                        "content": [
+                            { "nodeType": "text", "value": "Lorem Ipsum", "marks": [{ "type": "bold" }], "data": {} },
+                            {
+                                "nodeType": "text",
+                                "value": " is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+                                "marks": [],
+                                "data": {}
+                            }
+                        ]
+                    }
+                ]
+            },
+            "author": "Florin H"
+        }
+    },
+    {
+        "sys": {
+            "id": "4a0to1iziNDhDmLixhE04V",
+            "createdAt": "2023-08-25T06:08:17.597Z"
+        },
+        "fields": {
+            "title": "Blog 16",
+            "content": {
+                "data": {},
+                "content": [
+                    {
+                        "data": {},
+                        "content": [
+                            { "data": {}, "marks": [{ "type": "bold" }], "value": "Lorem Ipsum", "nodeType": "text" },
+                            {
+                                "data": {},
+                                "marks": [],
+                                "value": " is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+                                "nodeType": "text"
+                            }
+                        ],
+                        "nodeType": "paragraph"
+                    }
+                ],
+                "nodeType": "document"
+            },
+            "author": "Florin H"
+        }
+    },
+    {
+        "sys": {
+            "id": "73pzpPnU66XssWbeT7xBum",
+            "createdAt": "2023-08-25T06:08:02.985Z"
+        },
+        "fields": {
+            "title": "Blog 15",
+            "content": {
+                "data": {},
+                "content": [
+                    {
+                        "data": {},
+                        "content": [
+                            { "data": {}, "marks": [{ "type": "bold" }], "value": "Lorem Ipsum", "nodeType": "text" },
+                            {
+                                "data": {},
+                                "marks": [],
+                                "value": " is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+                                "nodeType": "text"
+                            }
+                        ],
+                        "nodeType": "paragraph"
+                    }
+                ],
+                "nodeType": "document"
+            },
+            "author": "Florin H"
+        }
+    },
+    {
+        "sys": {
+            "id": "1i7IesCEAzQmS9VzxFuaTY",
+            "createdAt": "2023-08-25T06:07:48.136Z"
+        },
+        "fields": {
+            "title": "Blog 14",
+            "content": {
+                "data": {},
+                "content": [
+                    {
+                        "data": {},
+                        "content": [
+                            { "data": {}, "marks": [{ "type": "bold" }], "value": "Lorem Ipsum", "nodeType": "text" },
+                            {
+                                "data": {},
+                                "marks": [],
+                                "value": " is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+                                "nodeType": "text"
+                            }
+                        ],
+                        "nodeType": "paragraph"
+                    }
+                ],
+                "nodeType": "document"
+            },
+            "author": "Florin H"
+        }
+    },
+    {
+        "sys": {
+            "id": "6hMaPxUNKY1I3KmNdy4Ddc",
+            "createdAt": "2023-08-25T06:07:33.241Z"
+        },
+        "fields": {
+            "title": "Blog 13",
+            "content": {
+                "data": {},
+                "content": [
+                    {
+                        "data": {},
+                        "content": [
+                            { "data": {}, "marks": [{ "type": "bold" }], "value": "Lorem Ipsum", "nodeType": "text" },
+                            {
+                                "data": {},
+                                "marks": [],
+                                "value": " is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+                                "nodeType": "text"
+                            }
+                        ],
+                        "nodeType": "paragraph"
+                    }
+                ],
+                "nodeType": "document"
+            },
+            "author": "Florin H"
+        }
+    },
+    {
+        "sys": {
+            "id": "5dBcw1ifqT35qwgH7DRx5z",
+            "createdAt": "2023-08-25T06:07:20.221Z"
+        },
+        "fields": {
+            "title": "Blog 12",
+            "content": {
+                "data": {},
+                "content": [
+                    {
+                        "data": {},
+                        "content": [
+                            { "data": {}, "marks": [{ "type": "bold" }], "value": "Lorem Ipsum", "nodeType": "text" },
+                            {
+                                "data": {},
+                                "marks": [],
+                                "value": " is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+                                "nodeType": "text"
+                            }
+                        ],
+                        "nodeType": "paragraph"
+                    }
+                ],
+                "nodeType": "document"
+            },
+            "author": "Florin H"
+        }
+    },
+    {
+        "sys": {
+            "id": "4yzxLXnXGcbgQu7HcGUyy0",
+            "createdAt": "2023-08-25T06:07:07.267Z"
+        },
+        "fields": {
+            "title": "Blog 11",
+            "content": {
+                "nodeType": "document",
+                "data": {},
+                "content": [
+                    {
+                        "nodeType": "paragraph",
+                        "data": {},
+                        "content": [
+                            { "nodeType": "text", "value": "Lorem Ipsum", "marks": [{ "type": "bold" }], "data": {} },
+                            {
+                                "nodeType": "text",
+                                "value": " is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+                                "marks": [],
+                                "data": {}
+                            }
+                        ]
+                    }
+                ]
+            },
+            "author": "Florin H"
+        }
+    },
+    {
+        "sys": {
+            "id": "6w11qfusJTxtoLKZr60B03",
+            "createdAt": "2023-08-25T06:06:51.447Z"
+        },
+        "fields": {
+            "title": "Blog 10",
+            "content": {
+                "data": {},
+                "content": [
+                    {
+                        "data": {},
+                        "content": [
+                            { "data": {}, "marks": [{ "type": "bold" }], "value": "Lorem Ipsum", "nodeType": "text" },
+                            {
+                                "data": {},
+                                "marks": [],
+                                "value": " is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+                                "nodeType": "text"
+                            }
+                        ],
+                        "nodeType": "paragraph"
+                    }
+                ],
+                "nodeType": "document"
+            },
+            "author": "Florin H"
+        }
+    },
+    {
+        "sys": {
+            "id": "dFYH7tCfCcBG5o9HxJ4Le",
+            "createdAt": "2023-08-25T06:06:31.552Z"
+        },
+        "fields": {
+            "title": "Blog 9",
+            "content": {
+                "data": {},
+                "content": [
+                    {
+                        "data": {},
+                        "content": [
+                            { "data": {}, "marks": [{ "type": "bold" }], "value": "Lorem Ipsum", "nodeType": "text" },
+                            {
+                                "data": {},
+                                "marks": [],
+                                "value": " is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+                                "nodeType": "text"
+                            }
+                        ],
+                        "nodeType": "paragraph"
+                    }
+                ],
+                "nodeType": "document"
+            },
+            "author": "Florin H"
+        }
+    },
+    {
+        "sys": {
+            "id": "3jU4kaNrMeAHsFbUmXFQWL",
+            "createdAt": "2023-08-25T06:06:09.763Z"
+        },
+        "fields": {
+            "title": "Blog 8",
+            "content": {
+                "data": {},
+                "content": [
+                    {
+                        "data": {},
+                        "content": [
+                            { "data": {}, "marks": [{ "type": "bold" }], "value": "Lorem Ipsum", "nodeType": "text" },
+                            {
+                                "data": {},
+                                "marks": [],
+                                "value": " is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+                                "nodeType": "text"
+                            }
+                        ],
+                        "nodeType": "paragraph"
+                    }
+                ],
+                "nodeType": "document"
+            },
+            "author": "Florin H"
+        }
+    },
+    {
+        "sys": {
+            "id": "55un06psQw9iDWmqoZtPnn",
+            "createdAt": "2023-08-25T06:05:54.734Z"
+        },
+        "fields": {
+            "title": "Blog 7",
+            "content": {
+                "data": {},
+                "content": [
+                    {
+                        "data": {},
+                        "content": [
+                            { "data": {}, "marks": [{ "type": "bold" }], "value": "Lorem Ipsum", "nodeType": "text" },
+                            {
+                                "data": {},
+                                "marks": [],
+                                "value": " is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+                                "nodeType": "text"
+                            }
+                        ],
+                        "nodeType": "paragraph"
+                    }
+                ],
+                "nodeType": "document"
+            },
+            "author": "Florin H"
+        }
+    },
+    {
+        "sys": {
+            "id": "3f6BEIA6yrMSBO2jPJkcLm",
+            "createdAt": "2023-08-25T06:05:18.909Z"
+        },
+        "fields": {
+            "title": "Blog 6",
+            "content": {
+                "nodeType": "document",
+                "data": {},
+                "content": [
+                    {
+                        "nodeType": "heading-2",
+                        "data": {},
+                        "content": [{ "nodeType": "text", "value": "Why do we use it?", "marks": [], "data": {} }]
+                    },
+                    {
+                        "nodeType": "paragraph",
+                        "data": {},
+                        "content": [
+                            {
+                                "nodeType": "text",
+                                "value": "It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).",
+                                "marks": [],
+                                "data": {}
+                            }
+                        ]
+                    }
+                ]
+            },
+            "author": "Florin H"
+        }
+    },
+    {
+        "sys": {
+            "id": "3RL1Q52wi1IGRBqrjyjxsD",
+            "createdAt": "2023-08-25T06:05:00.814Z"
+        },
+        "fields": {
+            "title": "Blog 5",
+            "content": {
+                "nodeType": "document",
+                "data": {},
+                "content": [
+                    {
+                        "nodeType": "heading-2",
+                        "data": {},
+                        "content": [{ "nodeType": "text", "value": "Why do we use it?", "marks": [], "data": {} }]
+                    },
+                    {
+                        "nodeType": "paragraph",
+                        "data": {},
+                        "content": [
+                            {
+                                "nodeType": "text",
+                                "value": "It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).",
+                                "marks": [],
+                                "data": {}
+                            }
+                        ]
+                    }
+                ]
+            },
+            "author": "Florin H"
+        }
+    },
+    {
+        "sys": {
+            "id": "5OXI1JAgybvsKwHa35yAr0",
+            "createdAt": "2023-08-25T06:04:42.557Z"
+        },
+        "fields": {
+            "title": "Blog 4",
+            "content": {
+                "data": {},
+                "content": [
+                    {
+                        "data": {},
+                        "content": [{ "data": {}, "marks": [], "value": "Why do we use it?", "nodeType": "text" }],
+                        "nodeType": "heading-2"
+                    },
+                    {
+                        "data": {},
+                        "content": [
+                            {
+                                "data": {},
+                                "marks": [],
+                                "value": "It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).",
+                                "nodeType": "text"
+                            }
+                        ],
+                        "nodeType": "paragraph"
+                    }
+                ],
+                "nodeType": "document"
+            },
+            "author": "Florin H"
+        }
+    },
+    {
+        "sys": {
+            "id": "77tCPYZZ7wnPpngFlGt04n",
+            "createdAt": "2023-08-25T06:04:24.484Z"
+        },
+        "fields": {
+            "title": "Octopus Blog 3",
+            "content": {
+                "nodeType": "document",
+                "data": {},
+                "content": [
+                    {
+                        "nodeType": "heading-2",
+                        "data": {},
+                        "content": [{ "nodeType": "text", "value": "Why do we use it?", "marks": [], "data": {} }]
+                    },
+                    {
+                        "nodeType": "paragraph",
+                        "data": {},
+                        "content": [
+                            {
+                                "nodeType": "text",
+                                "value": "It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).",
+                                "marks": [],
+                                "data": {}
+                            }
+                        ]
+                    }
+                ]
+            },
+            "author": "Florin H"
+        }
+    },
+
+    {
+        "sys": {
+            "id": "4s7J5kSognnNuoRvN6msO7",
+            "createdAt": "2023-08-24T16:06:48.378Z"
+        },
+        "fields": {
+            "title": "Octopus Blog 2",
+            "content": {
+                "nodeType": "document",
+                "data": {},
+                "content": [
+                    {
+                        "nodeType": "paragraph",
+                        "data": {},
+                        "content": [
+                            { "nodeType": "text", "value": "Lorem Ipsum", "marks": [{ "type": "bold" }], "data": {} },
+                            {
+                                "nodeType": "text",
+                                "value": " is simply dummy text of the printing and typesetting industry. Lorem Ipsum",
+                                "marks": [],
+                                "data": {}
+                            }
+                        ]
+                    },
+                    {
+                        "nodeType": "paragraph",
+                        "data": {},
+                        "content": [
+                            {
+                                "nodeType": "text",
+                                "value": "has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+                                "marks": [],
+                                "data": {}
+                            }
+                        ]
+                    },
+                    {
+                        "nodeType": "paragraph",
+                        "data": {},
+                        "content": [{ "nodeType": "text", "value": "", "marks": [], "data": {} }]
+                    },
+                    {
+                        "nodeType": "paragraph",
+                        "data": {},
+                        "content": [{ "nodeType": "text", "value": "some updates...", "marks": [], "data": {} }]
+                    }
+                ]
+            },
+            "author": "Florin H"
+        }
+    },
+    {
+        "sys": {
+            "id": "1ge4ri1lBkrLA20hNrLyAE",
+            "createdAt": "2023-08-18T12:43:00.757Z"
+        },
+        "fields": {
+            "title": "My first Octopus blog",
+            "content": {
+                "nodeType": "document",
+                "data": {},
+                "content": [
+                    {
+                        "nodeType": "heading-2",
+                        "data": {},
+                        "content": [{ "nodeType": "text", "value": "What is Lorem Ipsum?", "marks": [], "data": {} }]
+                    },
+                    {
+                        "nodeType": "paragraph",
+                        "data": {},
+                        "content": [
+                            { "nodeType": "text", "value": "Lorem Ipsum", "marks": [{ "type": "bold" }], "data": {} },
+                            {
+                                "nodeType": "text",
+                                "value": " is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the ",
+                                "marks": [],
+                                "data": {}
+                            },
+                            { "nodeType": "text", "value": "1960s", "marks": [{ "type": "code" }], "data": {} },
+                            {
+                                "nodeType": "text",
+                                "value": " with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
+                                "marks": [],
+                                "data": {}
+                            }
+                        ]
+                    },
+                    {
+                        "nodeType": "embedded-asset-block",
+                        "data": {
+                            "target": { "sys": { "id": "5RF8igo5rylOq5n9afilFc", "type": "Link", "linkType": "Asset" } }
+                        },
+                        "content": []
+                    },
+                    {
+                        "nodeType": "heading-2",
+                        "data": {},
+                        "content": [{ "nodeType": "text", "value": "Where can I get some?", "marks": [], "data": {} }]
+                    },
+                    {
+                        "nodeType": "paragraph",
+                        "data": {},
+                        "content": [
+                            {
+                                "nodeType": "text",
+                                "value": "There are many variations of passages of Lorem Ipsum available, but the majority have suffered alteration in some form, by injected humour, or randomised words which don't look even slightly believable. If you are going to use a passage of Lorem Ipsum, you need to be sure there isn't anything embarrassing hidden in the middle of text. All the Lorem Ipsum generators on the Internet tend to repeat predefined chunks as necessary, making this the first true generator on the Internet. It uses a dictionary of over 200 Latin words, combined with a handful of model sentence structures, to generate Lorem Ipsum which looks reasonable. The generated Lorem Ipsum is therefore always free from repetition, injected humour, or non-characteristic words etc. ",
+                                "marks": [],
+                                "data": {}
+                            }
+                        ]
+                    },
+                    {
+                        "nodeType": "paragraph",
+                        "data": {},
+                        "content": [{ "nodeType": "text", "value": "", "marks": [], "data": {} }]
+                    },
+                    {
+                        "nodeType": "paragraph",
+                        "data": {},
+                        "content": [{ "nodeType": "text", "value": "small update", "marks": [], "data": {} }]
+                    },
+                    {
+                        "nodeType": "paragraph",
+                        "data": {},
+                        "content": [{ "nodeType": "text", "value": "", "marks": [], "data": {} }]
+                    }
+                ]
+            },
+            "author": "Florin H"
+        }
+    }
+]

--- a/e2e/tests/LoggedOut/blog.e2e.spec.ts
+++ b/e2e/tests/LoggedOut/blog.e2e.spec.ts
@@ -1,0 +1,73 @@
+import { Page, expect, test } from '@playwright/test';
+import { PageModel } from '../PageModel';
+import * as Helpers from '../helpers';
+import contentfulBlogPosts from '../../mocks/contentful_blog_posts.json';
+
+test.describe('Blog', () => {
+    let page: Page = null;
+    let skip = 0;
+    let limit = 0;
+
+    test.beforeAll(async ({ browser }) => {
+        const context = await browser.newContext();
+        page = await context.newPage();
+
+        await page.route('https://cdn.contentful.com/spaces/*/*/*/entries?*', async (route) => {
+            const reqUrl = new URL(route.request().url());
+            const searchParams = reqUrl.searchParams;
+            skip = Number(searchParams.get('skip'));
+            limit = Number(searchParams.get('limit'));
+
+            const json = {
+                items: contentfulBlogPosts.slice(skip, skip + limit),
+                limit,
+                skip,
+                sys: { type: 'Array' },
+                total: contentfulBlogPosts.length
+            };
+            await route.fulfill({ json });
+        });
+    });
+
+    test('Blogs are paginated', async () => {
+        // Navigate to blog page
+        await page.goto(`${Helpers.UI_BASE}/blog`);
+
+        // check page title and description
+        await expect(page.locator(PageModel.blog.pageTitle)).toBeVisible();
+        await expect(page.locator(PageModel.blog.pageDescription)).toBeVisible();
+        await expect(page.locator(PageModel.blog.followOnTwitter)).toBeVisible();
+
+        // check that blog cards are visible
+        await expect(page.locator(PageModel.blog.blogCard).first()).toBeVisible();
+
+        // check the number of blog cards displayed per page equals "limit" query param used for the api call
+        expect(await page.locator(PageModel.blog.blogCard).count()).toEqual(limit);
+
+        // check pagination info shows correct details
+        expect(await page.locator(PageModel.blog.paginationInfo).textContent()).toEqual(
+            `Showing 1 - ${limit} of ${contentfulBlogPosts.length}`
+        );
+
+        // check next/prev buttons
+        await expect(page.locator(PageModel.blog.prevButton)).toBeDisabled();
+        await expect(page.locator(PageModel.blog.nextButton)).toBeEnabled();
+
+        // clicking the Next button goes to second page
+        await page.click(PageModel.blog.nextButton);
+
+        // check the rest of blog posts are displayed
+        expect(await page.locator(PageModel.blog.blogCard).count()).toEqual(contentfulBlogPosts.length - skip);
+
+        // check pagination info shows correct details for the second page
+        expect(await page.locator(PageModel.blog.paginationInfo).textContent()).toEqual(
+            `Showing ${skip + 1} - ${
+                skip + limit > contentfulBlogPosts.length ? contentfulBlogPosts.length : skip + limit
+            } of ${contentfulBlogPosts.length}`
+        );
+
+        // check next/prev buttons
+        await expect(page.locator(PageModel.blog.prevButton)).toBeEnabled();
+        await expect(page.locator(PageModel.blog.nextButton)).toBeDisabled();
+    });
+});

--- a/e2e/tests/PageModel.ts
+++ b/e2e/tests/PageModel.ts
@@ -220,6 +220,18 @@ export const PageModel = {
     topic: {
         createProblemLink: 'a:has-text("Write a linked Research Problem")',
         addBookmark: '[title="Bookmark this topic"]',
-        removeBookmark: '[title="Remove bookmark"]',
+        removeBookmark: '[title="Remove bookmark"]'
+    },
+    blog: {
+        pageTitle: 'h1:has-text("The Octopus Blog")',
+        pageDescription: 'h2:has-text("Stay up to date with the latest from the Octopus team")',
+        followOnTwitter: 'h4:has-text("Follow Octopus on Twitter")',
+        paginationInfo: '#pagination-info',
+        nextButton: 'button:has-text("Next")',
+        prevButton: 'button:has-text("Previous")',
+        blogCard: '.blog-card',
+        blogCardTitle: '.blog-card-title',
+        blogCardText: '.blog-card-text',
+        blogCardFooter: '.blog-card-footer'
     }
 };

--- a/e2e/tests/PageModel.ts
+++ b/e2e/tests/PageModel.ts
@@ -225,7 +225,7 @@ export const PageModel = {
     blog: {
         pageTitle: 'h1:has-text("The Octopus Blog")',
         pageDescription: 'h2:has-text("Stay up to date with the latest from the Octopus team")',
-        followOnTwitter: 'h4:has-text("Follow Octopus on Twitter")',
+        followOnTwitter: 'p:has-text("Follow Octopus on Twitter")',
         paginationInfo: '#pagination-info',
         nextButton: 'button:has-text("Next")',
         prevButton: 'button:has-text("Previous")',

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "types": ["node"],
-        "esModuleInterop": true
+        "esModuleInterop": true,
+        "resolveJsonModule": true
     }
 }

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -4,3 +4,5 @@ NEXT_PUBLIC_ORCID_AUTH_URL=https://sandbox.orcid.org/oauth
 NEXT_PUBLIC_BASE_URL=https://localhost:3001
 NEXT_PUBLIC_MEDIA_BUCKET=http://localhost:4566/science-octopus-publishing-images-local
 NEXT_PUBLIC_STAGE=local
+NEXT_PUBLIC_CONTENTFUL_SPACE_ID=contentful-space-id
+NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN=contentful-access-token

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9,6 +9,8 @@
             "version": "1.0.0",
             "license": "GPL-3.0-only",
             "dependencies": {
+                "@contentful/rich-text-plain-text-renderer": "^16.0.6",
+                "@contentful/rich-text-react-renderer": "^15.17.1",
                 "@headlessui/react": "^1.7.15",
                 "@heroicons/react": "^2.0.18",
                 "@paralleldrive/cuid2": "^2.2.1",
@@ -27,6 +29,7 @@
                 "@tiptap/starter-kit": "^2.0.4",
                 "@types/react-beautiful-dnd": "^13.1.4",
                 "axios": "^1.4.0",
+                "contentful": "^10.5.0",
                 "framer-motion": "^10.13.2",
                 "html-react-parser": "^4.2.0",
                 "js-cookie": "^3.0.5",
@@ -46,6 +49,7 @@
                 "zustand": "^4.3.9"
             },
             "devDependencies": {
+                "@contentful/rich-text-types": "^16.2.1",
                 "@lhci/cli": "^0.12.0",
                 "@tailwindcss/line-clamp": "^0.4.4",
                 "@tailwindcss/typography": "^0.5.9",
@@ -671,6 +675,40 @@
             "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
+        },
+        "node_modules/@contentful/rich-text-plain-text-renderer": {
+            "version": "16.0.6",
+            "resolved": "https://registry.npmjs.org/@contentful/rich-text-plain-text-renderer/-/rich-text-plain-text-renderer-16.0.6.tgz",
+            "integrity": "sha512-CvsU5T8zqwHh2bgzmHKnxKjcxpCMeTkHAklzblUTLPCkHVyJnbBqAZ6h9tpGbyFY3+WIDI6co22+oJIaHUDxuA==",
+            "dependencies": {
+                "@contentful/rich-text-types": "^16.2.1"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@contentful/rich-text-react-renderer": {
+            "version": "15.17.1",
+            "resolved": "https://registry.npmjs.org/@contentful/rich-text-react-renderer/-/rich-text-react-renderer-15.17.1.tgz",
+            "integrity": "sha512-LSsYBYYAzkSCWmAbbVCzxZhcrUNBWdgOo9YY1WgvANmzF9zEUODxml3lCLN7PQ08nGMAjzhJBV5wpyp5YReRjg==",
+            "dependencies": {
+                "@contentful/rich-text-types": "^16.2.1"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.6 || ^17.0.0 || ^18.0.0",
+                "react-dom": "^16.8.6 || ^17.0.0 || ^18.0.0"
+            }
+        },
+        "node_modules/@contentful/rich-text-types": {
+            "version": "16.2.1",
+            "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.2.1.tgz",
+            "integrity": "sha512-fBxqYcyG3Nw33DhifuE7Ndw3xlrWlOMjwsOvhLmVP4LO475Qyy9ioRChtEt6DPUdH2SFpobvM0qqC/fVe0MNDA==",
+            "engines": {
+                "node": ">=6.0.0"
+            }
         },
         "node_modules/@emotion/is-prop-valid": {
             "version": "0.8.8",
@@ -4812,6 +4850,58 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/contentful": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/contentful/-/contentful-10.5.0.tgz",
+            "integrity": "sha512-aCXGmUSR8Qn/tz49Eztk9mUPJ6xe1osZfqgMSYzEM2dm1WT+gQbqnxOiBBHOdCckXNAk9OnA535IjihW6yMysw==",
+            "dependencies": {
+                "@contentful/rich-text-types": "^16.0.2",
+                "axios": "^1.4.0",
+                "contentful-resolve-response": "^1.8.1",
+                "contentful-sdk-core": "^8.1.0",
+                "json-stringify-safe": "^5.0.1",
+                "type-fest": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/contentful-resolve-response": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.8.1.tgz",
+            "integrity": "sha512-VXGK2c8dBIGcRCknqudKmkDr2PzsUYfjLN6hhx71T09UzoXOdA/c0kfDhsf/BBCBWPWcLaUgaJEFU0lCo45TSg==",
+            "dependencies": {
+                "fast-copy": "^2.1.7"
+            },
+            "engines": {
+                "node": ">=4.7.2"
+            }
+        },
+        "node_modules/contentful-sdk-core": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-8.1.0.tgz",
+            "integrity": "sha512-ZXTtrkrx4OlRcVY0WLihrskF+BSuHe7QZuWA8DNEeTlHmkPXAVch9Og5TJDoyGeqNrArR3Ovd7yfaG+1QYo+ag==",
+            "dependencies": {
+                "fast-copy": "^2.1.7",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
+                "p-throttle": "^4.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/contentful/node_modules/type-fest": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.2.0.tgz",
+            "integrity": "sha512-5zknd7Dss75pMSED270A1RQS3KloqRJA9XbXLe0eCxyw7xXFb3rd+9B0UQ/0E+LQT6lnrLviEolYORlRWamn4w==",
+            "engines": {
+                "node": ">=16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/convert-source-map": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -6654,6 +6744,11 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/fast-copy": {
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
+            "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA=="
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -9935,6 +10030,11 @@
             "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
             "dev": true
         },
+        "node_modules/json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+        },
         "node_modules/json5": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -10320,8 +10420,12 @@
         "node_modules/lodash.isplainobject": {
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-            "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-            "dev": true
+            "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+        },
+        "node_modules/lodash.isstring": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
         },
         "node_modules/lodash.memoize": {
             "version": "4.1.2",
@@ -11173,6 +11277,17 @@
             },
             "engines": {
                 "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-throttle": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-4.1.1.tgz",
+            "integrity": "sha512-TuU8Ato+pRTPJoDzYD4s7ocJYcNSEZRvlxoq3hcPI2kZDZ49IQ1Wkj7/gDJc3X7XiEAAvRGtDzdXJI0tC3IL1g==",
+            "engines": {
+                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -14595,6 +14710,27 @@
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
         },
+        "@contentful/rich-text-plain-text-renderer": {
+            "version": "16.0.6",
+            "resolved": "https://registry.npmjs.org/@contentful/rich-text-plain-text-renderer/-/rich-text-plain-text-renderer-16.0.6.tgz",
+            "integrity": "sha512-CvsU5T8zqwHh2bgzmHKnxKjcxpCMeTkHAklzblUTLPCkHVyJnbBqAZ6h9tpGbyFY3+WIDI6co22+oJIaHUDxuA==",
+            "requires": {
+                "@contentful/rich-text-types": "^16.2.1"
+            }
+        },
+        "@contentful/rich-text-react-renderer": {
+            "version": "15.17.1",
+            "resolved": "https://registry.npmjs.org/@contentful/rich-text-react-renderer/-/rich-text-react-renderer-15.17.1.tgz",
+            "integrity": "sha512-LSsYBYYAzkSCWmAbbVCzxZhcrUNBWdgOo9YY1WgvANmzF9zEUODxml3lCLN7PQ08nGMAjzhJBV5wpyp5YReRjg==",
+            "requires": {
+                "@contentful/rich-text-types": "^16.2.1"
+            }
+        },
+        "@contentful/rich-text-types": {
+            "version": "16.2.1",
+            "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.2.1.tgz",
+            "integrity": "sha512-fBxqYcyG3Nw33DhifuE7Ndw3xlrWlOMjwsOvhLmVP4LO475Qyy9ioRChtEt6DPUdH2SFpobvM0qqC/fVe0MNDA=="
+        },
         "@emotion/is-prop-valid": {
             "version": "0.8.8",
             "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
@@ -17641,6 +17777,45 @@
             "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
             "dev": true
         },
+        "contentful": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/contentful/-/contentful-10.5.0.tgz",
+            "integrity": "sha512-aCXGmUSR8Qn/tz49Eztk9mUPJ6xe1osZfqgMSYzEM2dm1WT+gQbqnxOiBBHOdCckXNAk9OnA535IjihW6yMysw==",
+            "requires": {
+                "@contentful/rich-text-types": "^16.0.2",
+                "axios": "^1.4.0",
+                "contentful-resolve-response": "^1.8.1",
+                "contentful-sdk-core": "^8.1.0",
+                "json-stringify-safe": "^5.0.1",
+                "type-fest": "^4.0.0"
+            },
+            "dependencies": {
+                "type-fest": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.2.0.tgz",
+                    "integrity": "sha512-5zknd7Dss75pMSED270A1RQS3KloqRJA9XbXLe0eCxyw7xXFb3rd+9B0UQ/0E+LQT6lnrLviEolYORlRWamn4w=="
+                }
+            }
+        },
+        "contentful-resolve-response": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.8.1.tgz",
+            "integrity": "sha512-VXGK2c8dBIGcRCknqudKmkDr2PzsUYfjLN6hhx71T09UzoXOdA/c0kfDhsf/BBCBWPWcLaUgaJEFU0lCo45TSg==",
+            "requires": {
+                "fast-copy": "^2.1.7"
+            }
+        },
+        "contentful-sdk-core": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-8.1.0.tgz",
+            "integrity": "sha512-ZXTtrkrx4OlRcVY0WLihrskF+BSuHe7QZuWA8DNEeTlHmkPXAVch9Og5TJDoyGeqNrArR3Ovd7yfaG+1QYo+ag==",
+            "requires": {
+                "fast-copy": "^2.1.7",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
+                "p-throttle": "^4.1.1"
+            }
+        },
         "convert-source-map": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -19005,6 +19180,11 @@
                     }
                 }
             }
+        },
+        "fast-copy": {
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
+            "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA=="
         },
         "fast-deep-equal": {
             "version": "3.1.3",
@@ -21414,6 +21594,11 @@
             "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
             "dev": true
         },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+        },
         "json5": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -21723,8 +21908,12 @@
         "lodash.isplainobject": {
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-            "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-            "dev": true
+            "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+        },
+        "lodash.isstring": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
         },
         "lodash.memoize": {
             "version": "4.1.2",
@@ -22356,6 +22545,11 @@
                     }
                 }
             }
+        },
+        "p-throttle": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-4.1.1.tgz",
+            "integrity": "sha512-TuU8Ato+pRTPJoDzYD4s7ocJYcNSEZRvlxoq3hcPI2kZDZ49IQ1Wkj7/gDJc3X7XiEAAvRGtDzdXJI0tC3IL1g=="
         },
         "p-try": {
             "version": "2.2.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -24,6 +24,8 @@
         "lighthouse": "lhci autorun"
     },
     "dependencies": {
+        "@contentful/rich-text-plain-text-renderer": "^16.0.6",
+        "@contentful/rich-text-react-renderer": "^15.17.1",
         "@headlessui/react": "^1.7.15",
         "@heroicons/react": "^2.0.18",
         "@paralleldrive/cuid2": "^2.2.1",
@@ -42,6 +44,7 @@
         "@tiptap/starter-kit": "^2.0.4",
         "@types/react-beautiful-dnd": "^13.1.4",
         "axios": "^1.4.0",
+        "contentful": "^10.5.0",
         "framer-motion": "^10.13.2",
         "html-react-parser": "^4.2.0",
         "js-cookie": "^3.0.5",
@@ -61,6 +64,7 @@
         "zustand": "^4.3.9"
     },
     "devDependencies": {
+        "@contentful/rich-text-types": "^16.2.1",
         "@lhci/cli": "^0.12.0",
         "@tailwindcss/line-clamp": "^0.4.4",
         "@tailwindcss/typography": "^0.5.9",

--- a/ui/src/components/BlogCard/index.tsx
+++ b/ui/src/components/BlogCard/index.tsx
@@ -14,17 +14,17 @@ const BlogCard: React.FC<Props> = (props) => {
     }, [props.content]);
 
     return (
-        <div className="flex h-full flex-col gap-4 rounded-md p-4 shadow transition-colors hover:bg-grey-50 dark:bg-grey-700 dark:hover:bg-grey-600 xl:p-6">
-            <h3 className="font-montserrat text-lg font-bold leading-snug text-grey-900 transition-colors dark:text-white-50 2xl:text-xl">
+        <div className="blog-card flex h-full flex-col gap-4 rounded-md p-4 shadow transition-colors hover:bg-grey-50 dark:bg-grey-700 dark:hover:bg-grey-600 xl:p-6">
+            <h3 className="blog-card-title font-montserrat text-lg font-bold leading-snug text-grey-900 transition-colors dark:text-white-50 2xl:text-xl">
                 {props.title}
             </h3>
 
             <div className="flex h-full flex-col justify-between gap-6">
-                <div className="text-sm text-grey-800 transition-colors dark:text-white-50 lg:text-base">
+                <div className="blog-card-text text-sm text-grey-800 transition-colors dark:text-white-50 lg:text-base">
                     {shortBlogText}
                 </div>
 
-                <p className="text-xs font-medium tracking-wide text-grey-800 transition-colors dark:text-grey-100">
+                <p className="blog-card-footer text-xs font-medium tracking-wide text-grey-800 transition-colors dark:text-grey-100">
                     By {props.author} | {props.createdAt}
                 </p>
             </div>

--- a/ui/src/components/BlogCard/index.tsx
+++ b/ui/src/components/BlogCard/index.tsx
@@ -1,5 +1,4 @@
 import * as Types from '@types';
-import * as Helpers from '@helpers';
 import { documentToPlainTextString } from '@contentful/rich-text-plain-text-renderer';
 import { useMemo } from 'react';
 

--- a/ui/src/components/BlogCard/index.tsx
+++ b/ui/src/components/BlogCard/index.tsx
@@ -1,0 +1,35 @@
+import * as Types from '@types';
+import * as Helpers from '@helpers';
+import { documentToPlainTextString } from '@contentful/rich-text-plain-text-renderer';
+import { useMemo } from 'react';
+
+type Props = Types.BlogFields & {
+    createdAt: string;
+};
+
+const BlogCard: React.FC<Props> = (props) => {
+    const shortBlogText = useMemo(() => {
+        const text = documentToPlainTextString(props.content).trim();
+        return text.length > 250 ? `${text.slice(0, 250).trim()}...` : text;
+    }, [props.content]);
+
+    return (
+        <div className="flex h-full flex-col gap-4 rounded-md p-4 shadow transition-colors hover:bg-grey-50 dark:bg-grey-700 dark:hover:bg-grey-600 xl:p-6">
+            <h3 className="font-montserrat text-lg font-bold leading-snug text-grey-900 transition-colors dark:text-white-50 2xl:text-xl">
+                {props.title}
+            </h3>
+
+            <div className="flex h-full flex-col justify-between gap-6">
+                <div className="text-sm text-grey-800 transition-colors dark:text-white-50 lg:text-base">
+                    {shortBlogText}
+                </div>
+
+                <p className="text-xs font-medium tracking-wide text-grey-800 transition-colors dark:text-grey-100">
+                    By {props.author} | {props.createdAt}
+                </p>
+            </div>
+        </div>
+    );
+};
+
+export default BlogCard;

--- a/ui/src/components/Footer/index.tsx
+++ b/ui/src/components/Footer/index.tsx
@@ -33,7 +33,7 @@ const Footer: React.FC<Props> = (props: Props): React.ReactElement => (
                         <Assets.Github height={25} width={25} className="fill-white-50" />
                     </Components.Link>
                     <Components.Link
-                        href="https://twitter.com/science_octopus"
+                        href="https://twitter.com/octopus_ac"
                         openNew={true}
                         ariaLabel="Twitter"
                         className="h-fit"

--- a/ui/src/components/index.tsx
+++ b/ui/src/components/index.tsx
@@ -91,3 +91,4 @@ export { default as AuthorAffiliations } from './Publication/AuthorAffiliations'
 export { default as AffiliationCard } from './Publication/AffiliationCard';
 export { default as SimpleModal } from './SimpleModal';
 export { default as EditAffiliationsModal } from './EditAffiliationsModal';
+export { default as BlogCard } from './BlogCard';

--- a/ui/src/config/urls.ts
+++ b/ui/src/config/urls.ts
@@ -11,7 +11,7 @@ const mediaBucket = checkEnvVariable(process.env.NEXT_PUBLIC_MEDIA_BUCKET);
 const orcidAppId = checkEnvVariable(process.env.NEXT_PUBLIC_ORCID_APP_ID);
 const orcidAuthUrl = checkEnvVariable(process.env.NEXT_PUBLIC_ORCID_AUTH_URL);
 
-export const base = {
+const base = {
     title: 'Octopus | Built for Researchers',
     host
 };
@@ -254,7 +254,15 @@ const urls = {
     orcidLogin: {
         path: `${orcidAuthUrl}/authorize?client_id=${orcidAppId}&response_type=code&scope=openid%20/read-limited&prompt=login&redirect_uri=${base.host}/login`
     },
-    mediaBucket
+    mediaBucket,
+    blog: {
+        path: '/blog',
+        title: 'The Octopus Blog',
+        description: 'Stay up to date with the latest from the Octopus team',
+        documentTitle: `The Octopus Blog - ${base.title}`,
+        keywords: ['blog', 'Octopus blog'],
+        canonical: `${base.host}/blog`
+    }
 };
 
 export default urls;

--- a/ui/src/lib/contentfulClient.ts
+++ b/ui/src/lib/contentfulClient.ts
@@ -1,0 +1,8 @@
+import * as Contentful from 'contentful';
+
+const client = Contentful.createClient({
+    space: process.env.NEXT_PUBLIC_CONTENTFUL_SPACE_ID!,
+    accessToken: process.env.NEXT_PUBLIC_CONTENTFUL_ACCESS_TOKEN!
+});
+
+export default client;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1,4 +1,5 @@
 import * as Interfaces from '@interfaces';
+import * as Contentful from 'contentful';
 
 export type { GetServerSideProps, GetServerSidePropsContext, GetServerSidePropsResult, NextPage } from 'next';
 
@@ -335,3 +336,10 @@ export type CreationSteps = {
 export type TabCompletionStatus = 'COMPLETE' | 'INCOMPLETE';
 
 export type BookmarkType = 'PUBLICATION' | 'TOPIC';
+
+export type BlogFields = {
+    title: Contentful.EntryFields.Text;
+    author: Contentful.EntryFields.Text;
+    featuredImage?: Contentful.Asset;
+    content: Contentful.EntryFields.RichText;
+};

--- a/ui/src/pages/blog/index.tsx
+++ b/ui/src/pages/blog/index.tsx
@@ -51,21 +51,19 @@ const Blog: NextPage = (): JSX.Element => {
                             text={Config.urls.blog.description}
                             className="!mx-0 font-montserrat text-lg font-medium text-grey-700 transition-colors duration-500 dark:text-grey-50"
                         />
-                        <p className="pb-8 text-grey-700 transition-colors duration-500 dark:text-grey-50">
+                        <Components.Link
+                            href="https://twitter.com/octopus_ac"
+                            openNew={true}
+                            ariaLabel="Twitter"
+                            className="mb-8 w-fit text-grey-700 transition-colors duration-500 dark:text-grey-50"
+                        >
                             Follow Octopus on Twitter{' '}
-                            <Components.Link
-                                href="https://twitter.com/octopus_ac"
-                                openNew={true}
-                                ariaLabel="Twitter"
-                                className="h-fit"
-                            >
-                                <Assets.Twitter
-                                    width={25}
-                                    height={25}
-                                    className="inline transition-colors dark:fill-white-50"
-                                />
-                            </Components.Link>
-                        </p>
+                            <Assets.Twitter
+                                width={25}
+                                height={25}
+                                className="inline transition-colors dark:fill-white-50"
+                            />
+                        </Components.Link>
                     </div>
                 </section>
 

--- a/ui/src/pages/blog/index.tsx
+++ b/ui/src/pages/blog/index.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import Head from 'next/head';
+import { NextPage } from 'next';
+import useSWR from 'swr';
+import client from '@contentfulClient';
+
+import * as Framer from 'framer-motion';
+import * as Components from '@components';
+import * as Layouts from '@layouts';
+import * as Config from '@config';
+import * as Types from '@types';
+import * as Assets from '@assets';
+import * as Helpers from '@helpers';
+
+const Blog: NextPage = (): JSX.Element => {
+    const [skip, setSkip] = React.useState(0);
+    const { data, error, isLoading } = useSWR(`${skip}`, () =>
+        client.getEntries({ limit: 18, skip, order: ['-sys.createdAt'] })
+    );
+
+    const handleGoNext = async () => {
+        if (!data) {
+            return;
+        }
+        setSkip((prevSkip) => prevSkip + data.limit);
+        Helpers.scrollTopSmooth();
+    };
+
+    const handleGoBack = async () => {
+        if (!data) {
+            return;
+        }
+        setSkip((prevSkip) => (prevSkip - data.limit < 0 ? 0 : prevSkip - data.limit));
+        Helpers.scrollTopSmooth();
+    };
+
+    return (
+        <>
+            <Head>
+                <meta name="description" content={Config.urls.blog.description} />
+                <meta name="keywords" content={Config.urls.blog.keywords.join(', ')} />
+                <link rel="canonical" href={Config.urls.blog.canonical} />
+                <title>{Config.urls.blog.documentTitle}</title>
+            </Head>
+
+            <Layouts.Standard fixedHeader={false}>
+                <section className="container mx-auto px-8 pb-10 pt-10 lg:gap-4 lg:pt-20">
+                    <Components.PageTitle text={Config.urls.blog.title} className="mb-8" />
+                    <div className="flex flex-col justify-between border-b border-grey-100 lg:flex-row lg:gap-4">
+                        <Components.PageSubTitle
+                            text={Config.urls.blog.description}
+                            className="!mx-0 font-montserrat text-lg font-medium text-grey-700 transition-colors duration-500 dark:text-grey-50"
+                        />
+                        <h4 className="pb-8 text-grey-700 transition-colors duration-500 dark:text-grey-50">
+                            Follow Octopus on Twitter{' '}
+                            <Components.Link
+                                href="https://twitter.com/octopus_ac"
+                                openNew={true}
+                                ariaLabel="Twitter"
+                                className="h-fit"
+                            >
+                                <Assets.Twitter
+                                    width={25}
+                                    height={25}
+                                    className="inline transition-colors dark:fill-white-50"
+                                />
+                            </Components.Link>
+                        </h4>
+                    </div>
+                </section>
+
+                <section className="container mx-auto px-8 pb-10">
+                    {!isLoading && !error && !data?.items.length && (
+                        <Components.Alert severity="INFO" title="No results found" />
+                    )}
+                    <div className="grid gap-6 lg:grid-cols-2 xl:grid-cols-3">
+                        {data?.items.map((blog) => {
+                            const blogFields = blog.fields as Types.BlogFields;
+                            const createdAt = Helpers.formatDate(blog.sys.createdAt);
+
+                            return (
+                                <Components.Link key={blog.sys.id} href={`/blog/${blog.sys.id}`}>
+                                    <Components.BlogCard
+                                        title={blogFields.title}
+                                        content={blogFields.content}
+                                        author={blogFields.author}
+                                        createdAt={createdAt}
+                                    />
+                                </Components.Link>
+                            );
+                        })}
+                    </div>
+
+                    {!isLoading && !!data?.items.length && (
+                        <Framer.motion.div
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: 1 }}
+                            exit={{ opacity: 0 }}
+                            transition={{ type: 'tween', duration: 0.75 }}
+                            className="mt-8 w-full items-center justify-between lg:flex lg:flex-row-reverse"
+                        >
+                            <div className="flex justify-between">
+                                <button
+                                    onClick={handleGoBack}
+                                    disabled={skip === 0}
+                                    className="mr-6 rounded font-semibold text-grey-800 underline decoration-teal-500 decoration-2 underline-offset-4 outline-none transition-colors duration-500 focus:ring-2 focus:ring-yellow-500 disabled:decoration-teal-600 disabled:opacity-70 dark:text-white-50"
+                                >
+                                    Previous
+                                </button>
+
+                                <button
+                                    onClick={handleGoNext}
+                                    className="rounded font-semibold text-grey-800 underline decoration-teal-500 decoration-2 underline-offset-4 outline-none transition-colors duration-500 focus:ring-2 focus:ring-yellow-500 disabled:decoration-teal-600 disabled:opacity-70 dark:text-white-50"
+                                    disabled={data.limit + skip >= data.total}
+                                >
+                                    Next
+                                </button>
+                            </div>
+                            <span
+                                id="pagination-info"
+                                className="mt-4 block font-medium text-grey-800 transition-colors duration-500 dark:text-white-50"
+                            >
+                                Showing {data.skip + 1} -{' '}
+                                {data.limit + data.skip > data.total ? data.total : data.limit + data.skip} of{' '}
+                                {data.total}
+                            </span>
+                        </Framer.motion.div>
+                    )}
+                </section>
+            </Layouts.Standard>
+        </>
+    );
+};
+
+export default Blog;

--- a/ui/src/pages/blog/index.tsx
+++ b/ui/src/pages/blog/index.tsx
@@ -51,7 +51,7 @@ const Blog: NextPage = (): JSX.Element => {
                             text={Config.urls.blog.description}
                             className="!mx-0 font-montserrat text-lg font-medium text-grey-700 transition-colors duration-500 dark:text-grey-50"
                         />
-                        <h4 className="pb-8 text-grey-700 transition-colors duration-500 dark:text-grey-50">
+                        <p className="pb-8 text-grey-700 transition-colors duration-500 dark:text-grey-50">
                             Follow Octopus on Twitter{' '}
                             <Components.Link
                                 href="https://twitter.com/octopus_ac"
@@ -65,7 +65,7 @@ const Blog: NextPage = (): JSX.Element => {
                                     className="inline transition-colors dark:fill-white-50"
                                 />
                             </Components.Link>
-                        </h4>
+                        </p>
                     </div>
                 </section>
 

--- a/ui/tsconfig.alias.json
+++ b/ui/tsconfig.alias.json
@@ -15,7 +15,8 @@
             "@helpers": ["./src/lib/helpers"],
             "@api": ["./src/lib/api"],
             "@documentation": ["./src/lib/documentation"],
-            "@contexts": ["./src/contexts"]
+            "@contexts": ["./src/contexts"],
+            "@contentfulClient": ["./src/lib/contentfulClient"]
         }
     }
 }


### PR DESCRIPTION
The purpose of this PR was to create a new /blog page, where we display blog teasers fetched from Contentful API as grid.
The blogs are wrapped with a link to their individual blog page (will be implemented in OCT-740)

---

### Acceptance Criteria:

As per [OCT-734](https://jiscdev.atlassian.net/browse/OCT-734)

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added

---

### Tests:

---

### Screenshots:

<img width="1728" alt="image" src="https://github.com/JiscSD/octopus/assets/48569671/fac3089a-a639-4ce1-981a-6d84ab42793c">

<img width="1726" alt="image" src="https://github.com/JiscSD/octopus/assets/48569671/4998aaae-a65d-4930-b346-3b7ffd7063be">

<img width="362" alt="image" src="https://github.com/JiscSD/octopus/assets/48569671/5c74f027-dc0b-4d2d-a18c-34ad09b6a275">


[OCT-734]: https://jiscdev.atlassian.net/browse/OCT-734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ