### PR TITLE
Turn off Lambda Provisioned Concurrency

### DIFF
--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -100,10 +100,6 @@ custom:
         v1: v1
     serverless-offline:
         useChildProcesses: true
-    provisionedConcurrencyCount:
-        local: 0
-        int: 1
-        prod: 2
     serverless-offline-ssm:
         stages:
             - local
@@ -153,7 +149,6 @@ functions:
         handler: src/lib/testUtils.openSearchSeed
     # Publications
     getPublications:
-        provisionedConcurrency: ${self:custom.provisionedConcurrencyCount.${self:provider.stage}}
         handler: src/components/publication/routes.getAll
         events:
             - http:
@@ -161,7 +156,6 @@ functions:
                   method: GET
                   cors: true
     getPublication:
-        provisionedConcurrency: ${self:custom.provisionedConcurrencyCount.${self:provider.stage}}
         handler: src/components/publication/routes.get
         events:
             - http:
@@ -204,7 +198,6 @@ functions:
                   method: DELETE
                   cors: true
     getPublicationLinks:
-        provisionedConcurrency: ${self:custom.provisionedConcurrencyCount.${self:provider.stage}}
         handler: src/components/publication/routes.getPublicationLinks
         events:
             - http:
@@ -220,7 +213,6 @@ functions:
                   method: GET
                   cors: true
     getResearchTopics:
-        provisionedConcurrency: ${self:custom.provisionedConcurrencyCount.${self:provider.stage}}
         handler: src/components/publication/routes.getResearchTopics
         events:
             - http:
@@ -229,7 +221,6 @@ functions:
                   cors: true
     # Users
     getUsers:
-        provisionedConcurrency: ${self:custom.provisionedConcurrencyCount.${self:provider.stage}}
         handler: src/components/user/routes.getAll
         events:
             - http:
@@ -244,7 +235,6 @@ functions:
                   method: GET
                   cors: true
     getUserPublications:
-        provisionedConcurrency: ${self:custom.provisionedConcurrencyCount.${self:provider.stage}}
         handler: src/components/user/routes.getPublications
         events:
             - http:
@@ -261,7 +251,6 @@ functions:
                   cors: true
     # Auth
     authorization:
-        provisionedConcurrency: ${self:custom.provisionedConcurrencyCount.${self:provider.stage}}
         handler: src/components/authorization/routes.authorize
         events:
             - http:
@@ -471,7 +460,6 @@ functions:
                   cors: true
     # References
     getReferences:
-        provisionedConcurrency: ${self:custom.provisionedConcurrencyCount.${self:provider.stage}}
         handler: src/components/reference/routes.get
         events:
             - http:
@@ -519,7 +507,6 @@ functions:
                   method: GET
                   cors: true
     getTopics:
-        provisionedConcurrency: ${self:custom.provisionedConcurrencyCount.${self:provider.stage}}
         handler: src/components/topic/routes.getTopics
         events:
             - http:


### PR DESCRIPTION
The purpose of this PR was to remove Lambda Provisioned Concurrency due to increased aws costs for lambdas

---

### Acceptance Criteria:

---

### Checklist:

- [ ] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

---

### Screenshots:
