### PR TITLE
OCT-620 - stop non-problem publications being linkable to topics

### DIFF
--- a/api/src/components/publication/controller.ts
+++ b/api/src/components/publication/controller.ts
@@ -204,19 +204,26 @@ export const update = async (
             publication.type !== 'HYPOTHESIS'
         ) {
             return response.json(400, {
-                message: 'You can not declare a self declaration for a publication that is not a protocol or hypothesis'
+                message:
+                    'You can not declare a self declaration for a publication that is not a protocol or hypothesis.'
             });
         }
 
         if (event.body.dataAccessStatement !== undefined && publication.type !== 'DATA') {
             return response.json(400, {
-                message: 'You can not supply a data access statement on and non data publication.'
+                message: 'You can not supply a data access statement on a non data publication.'
             });
         }
 
         if (event.body.dataPermissionsStatement !== undefined && publication.type !== 'DATA') {
             return response.json(400, {
-                message: 'You can not supply a data permissions statement on and non data publication.'
+                message: 'You can not supply a data permissions statement on a non data publication.'
+            });
+        }
+
+        if (event.body.topics !== undefined && publication.type !== 'PROBLEM') {
+            return response.json(400, {
+                message: 'You can not supply topics for a publication that is not a problem.'
             });
         }
 

--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -368,6 +368,26 @@ test.describe('Publication flow', () => {
         await expect(page.locator(PageModel.publish.linkedItems.deleteTopicLink)).toBeVisible();
     });
 
+    test('Cannot link a non-problem publication to a topic', async ({ browser }) => {
+        // Start up test
+        const page = await browser.newPage();
+
+        // Login
+        await page.goto(Helpers.UI_BASE);
+        await Helpers.login(page, browser);
+        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
+
+        await createPublication(page, 'hypothesis that should not be linkable to a topic', 'HYPOTHESIS');
+        // Go to Linked Items tab
+        await (await page.waitForSelector("aside button:has-text('Linked items')")).click();
+        // Entity type select should not be visible
+        await expect(page.locator(PageModel.publish.linkedItems.entityTypeSelect)).not.toBeVisible();
+        // Publication combobox should be visible
+        await expect(page.locator(PageModel.publish.linkedItems.publicationInput)).toBeVisible();
+        // Topic combobox should not be visible
+        await expect(page.locator(PageModel.publish.linkedItems.topicInput)).not.toBeVisible();
+    });
+
     test('Create a problem from an existing research topic', async ({ browser }) => {
         // Start up test
         const page = await browser.newPage();

--- a/ui/src/components/Publication/Creation/LinkedItems/index.tsx
+++ b/ui/src/components/Publication/Creation/LinkedItems/index.tsx
@@ -113,7 +113,7 @@ const Links: React.FC = (): React.ReactElement => {
             <div className="relative">
                 <Components.PublicationCreationStepTitle text="Add links" required />
                 <div className="flex flex-col flex-wrap gap-4 sm:flex-row sm:items-center">
-                    {!!isProblem && (
+                    {isProblem && (
                         <select
                             name="linked-entity-type"
                             id="linked-entity-type"
@@ -129,7 +129,7 @@ const Links: React.FC = (): React.ReactElement => {
                         </select>
                     )}
                     <div className="flex-1">
-                        {entityType === 'TOPIC' && !!isProblem ? (
+                        {entityType === 'TOPIC' ? (
                             <Components.LinkedTopicsCombobox
                                 fetchAndSetLinks={fetchAndSetLinks}
                                 setError={setError}
@@ -158,7 +158,7 @@ const Links: React.FC = (): React.ReactElement => {
                     entityType="PUBLICATION"
                 />
             )}
-            {!error && !!topics.length && !!isProblem && (
+            {!error && !!topics.length && (
                 <Components.LinkedItemTable deleteLink={deleteTopicLink} entities={topics} entityType="TOPIC" />
             )}
             {!error && !linkTos.length && !topics.length && (

--- a/ui/src/components/Publication/Creation/LinkedItems/index.tsx
+++ b/ui/src/components/Publication/Creation/LinkedItems/index.tsx
@@ -113,19 +113,21 @@ const Links: React.FC = (): React.ReactElement => {
             <div className="relative">
                 <Components.PublicationCreationStepTitle text="Add links" required />
                 <div className="flex flex-col flex-wrap gap-4 sm:flex-row sm:items-center">
-                    <select
-                        name="linked-entity-type"
-                        id="linked-entity-type"
-                        onChange={(e) => {
-                            const value: Types.LinkedEntityType = e.target.value as Types.LinkedEntityType;
-                            setEntityType(value);
-                        }}
-                        value={entityType}
-                        className="block rounded-md border border-grey-200 outline-none focus:ring-2 focus:ring-yellow-500 sm:mr-0"
-                    >
-                        <option value="PUBLICATION">Publications</option>
-                        <option value="TOPIC">Research topics</option>
-                    </select>
+                    {!!isProblem && (
+                        <select
+                            name="linked-entity-type"
+                            id="linked-entity-type"
+                            onChange={(e) => {
+                                const value: Types.LinkedEntityType = e.target.value as Types.LinkedEntityType;
+                                setEntityType(value);
+                            }}
+                            value={entityType}
+                            className="block rounded-md border border-grey-200 outline-none focus:ring-2 focus:ring-yellow-500 sm:mr-0"
+                        >
+                            <option value="PUBLICATION">Publications</option>
+                            <option value="TOPIC">Research topics</option>
+                        </select>
+                    )}
                     <div className="flex-1">
                         {entityType === 'PUBLICATION' ? (
                             <Components.LinkedPublicationsCombobox
@@ -156,7 +158,7 @@ const Links: React.FC = (): React.ReactElement => {
                     entityType="PUBLICATION"
                 />
             )}
-            {!error && !!topics.length && (
+            {!error && !!topics.length && !!isProblem && (
                 <Components.LinkedItemTable deleteLink={deleteTopicLink} entities={topics} entityType="TOPIC" />
             )}
             {!error && !linkTos.length && !topics.length && (

--- a/ui/src/components/Publication/Creation/LinkedItems/index.tsx
+++ b/ui/src/components/Publication/Creation/LinkedItems/index.tsx
@@ -129,20 +129,20 @@ const Links: React.FC = (): React.ReactElement => {
                         </select>
                     )}
                     <div className="flex-1">
-                        {entityType === 'PUBLICATION' ? (
-                            <Components.LinkedPublicationsCombobox
-                                fetchAndSetLinks={fetchAndSetLinks}
-                                setError={setError}
-                                loading={loading}
-                                setLoading={setLoading}
-                            />
-                        ) : (
+                        {entityType === 'TOPIC' && !!isProblem ? (
                             <Components.LinkedTopicsCombobox
                                 fetchAndSetLinks={fetchAndSetLinks}
                                 setError={setError}
                                 loading={loading}
                                 setLoading={setLoading}
                                 topics={topics}
+                            />
+                        ) : (
+                            <Components.LinkedPublicationsCombobox
+                                fetchAndSetLinks={fetchAndSetLinks}
+                                setError={setError}
+                                loading={loading}
+                                setLoading={setLoading}
                             />
                         )}
                     </div>


### PR DESCRIPTION
The purpose of this PR was to correct a bug with the original work on OCT-620. Only research problems should have the option to link to a topic, but in testing, any publication type could do this.

---

### Acceptance Criteria:

Only research problems can be linked to a topic using the UI.

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated
