### PR TITLE
OCT-743 - Listing author affiliations on PDFs

### DIFF
--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -474,6 +474,14 @@ const formatPDFDate = (date: Date): string => {
     return `${day}<sup>${nthNumber}</sup> ${month} ${year}`;
 };
 
+export const formatAffiliationName = (affiliation: I.MappedOrcidAffiliation): string => {
+    const organization = affiliation.organization;
+
+    return `${organization.name}: ${organization.address.city}, ${
+        organization.address.region ? `${organization.address.region}, ` : ''
+    }${organization.address.country}`;
+};
+
 export const createPublicationHTMLTemplate = (
     publication: I.Publication & I.PublicationWithMetadata,
     references: I.Reference[]
@@ -484,7 +492,6 @@ export const createPublicationHTMLTemplate = (
         coAuthors,
         funders,
         conflictOfInterestText,
-        affiliations,
         type,
         language,
         licence,
@@ -519,6 +526,28 @@ export const createPublicationHTMLTemplate = (
             affiliations: []
         });
     }
+
+    // Get array of all affiliations from all authors
+    const allAffiliations = authors
+        .map((author) => author.affiliations)
+        .flat() as unknown as I.MappedOrcidAffiliation[];
+    const allAffiliationsWithNames = allAffiliations.map((affiliation) => ({
+        ...affiliation,
+        name: formatAffiliationName(affiliation)
+    })) as I.AffiliationWithFormattedName[];
+
+    // De-duplicate affiliations based on their name
+    const seen = new Set();
+    const uniqueAffiliations = allAffiliationsWithNames.filter((affiliation) => {
+        const duplicate = seen.has(affiliation.name);
+        seen.add(affiliation.name);
+
+        return !duplicate;
+    });
+    // Sort affiliations by name
+    const affiliations = uniqueAffiliations.sort((a, b) => {
+        return a.name.localeCompare(b.name);
+    });
 
     const base64InterRegular = fs.readFileSync('assets/fonts/Inter-Regular.ttf', { encoding: 'base64' });
     const base64InterSemiBold = fs.readFileSync('assets/fonts/Inter-SemiBold.ttf', { encoding: 'base64' });
@@ -721,11 +750,6 @@ export const createPublicationHTMLTemplate = (
                     .join(', ')}
             </p>
             <p class="metadata">
-                <strong>Affiliations:</strong> ${affiliations
-                    .map((affiliation) => `<a href="${affiliation.link}">${affiliation.name}</a>`)
-                    .join(', ')}
-            </p>
-            <p class="metadata">
                 <strong>Publication Type:</strong> ${formatPublicationType(type)}
             </p>
             <p class="metadata">
@@ -748,6 +772,24 @@ export const createPublicationHTMLTemplate = (
 
             <div id="main-text">
                 ${mainText}
+            </div>
+
+            <div class="section affiliations">
+                <h5 class="section-title">Affiliations</h5>
+                ${
+                    affiliations.length
+                        ? affiliations
+                              .map(
+                                  (affiliation) =>
+                                      '<p>' +
+                                      (affiliation.url
+                                          ? `<a href="${affiliation.url}">${affiliation.name}</a>`
+                                          : affiliation.name) +
+                                      '</p>'
+                              )
+                              .join('')
+                        : '<p>No affiliations have been specified for this publication.</p>'
+                }
             </div>
 
             <div class="section references">

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -735,6 +735,10 @@ export interface MappedOrcidAffiliation {
     url?: string;
 }
 
+export interface AffiliationWithFormattedName extends MappedOrcidAffiliation {
+    name: string;
+}
+
 export interface LegacyAffiliation {
     name: string;
     country: string;


### PR DESCRIPTION
The purpose of this PR was to update the publication PDF template to display a deduplicated list of affiliations from the publication's coauthors, instead of the current publication-level affiliations (which have been migrated to coauthor level and removed).

---

### Acceptance Criteria:

- Each author affiliation is listed in a combined list under the “affiliations” section of publication PDFs
  - The list is alphabetised by affiliation name
  - The list is de-duplicated by affiliation name

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

---

### Screenshots:
<img width="506" alt="Screenshot 2023-08-30 154819" src="https://github.com/JiscSD/octopus/assets/132363734/c6f81c96-19fb-4189-8753-079e13d6c30f">
