### PR TITLE
OCT-740 Creation of an individual blog page

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -15674,6 +15674,7 @@
         },
         "node_modules/node-fetch": {
 <<<<<<< HEAD
+<<<<<<< HEAD
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
             "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
@@ -15688,6 +15689,11 @@
             "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
 >>>>>>> 8b30c2a2 (fixed package-lock)
 >>>>>>> 197cc468 (fixed package-lock)
+=======
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+>>>>>>> 4799353e (fixed package-lock)
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -15673,27 +15673,9 @@
             }
         },
         "node_modules/node-fetch": {
-<<<<<<< HEAD
-<<<<<<< HEAD
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
             "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-=======
-<<<<<<< HEAD
-            "version": "2.6.13",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
-            "integrity": "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==",
-=======
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
->>>>>>> 8b30c2a2 (fixed package-lock)
->>>>>>> 197cc468 (fixed package-lock)
-=======
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
->>>>>>> 4799353e (fixed package-lock)
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -15673,9 +15673,21 @@
             }
         },
         "node_modules/node-fetch": {
+<<<<<<< HEAD
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
             "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+=======
+<<<<<<< HEAD
+            "version": "2.6.13",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
+            "integrity": "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==",
+=======
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+>>>>>>> 8b30c2a2 (fixed package-lock)
+>>>>>>> 197cc468 (fixed package-lock)
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },

--- a/ui/src/components/BlogCard/index.tsx
+++ b/ui/src/components/BlogCard/index.tsx
@@ -17,7 +17,6 @@ const BlogCard: React.FC<Props> = (props) => {
             <h3 className="blog-card-title font-montserrat text-lg font-bold leading-snug text-grey-900 transition-colors dark:text-white-50 2xl:text-xl">
                 {props.title}
             </h3>
-
             <div className="flex h-full flex-col justify-between gap-6">
                 <div className="blog-card-text text-sm text-grey-800 transition-colors dark:text-white-50 lg:text-base">
                     {shortBlogText}

--- a/ui/src/components/BlogCard/index.tsx
+++ b/ui/src/components/BlogCard/index.tsx
@@ -2,7 +2,7 @@ import * as Types from '@types';
 import { documentToPlainTextString } from '@contentful/rich-text-plain-text-renderer';
 import { useMemo } from 'react';
 
-type Props = Types.BlogFields & {
+type Props = Pick<Types.BlogFields, 'title' | 'author' | 'content'> & {
     createdAt: string;
 };
 

--- a/ui/src/config/urls.ts
+++ b/ui/src/config/urls.ts
@@ -17,6 +17,7 @@ const base = {
 };
 
 const urls = {
+    base,
     // Search
     search: {
         path: '/search',

--- a/ui/src/config/values.ts
+++ b/ui/src/config/values.ts
@@ -921,3 +921,5 @@ export const HTMLStylesTiptapEditor = `
 
 export const topicDescription =
     'This is a research topic created to provide authors with a place to attach new problem publications.';
+
+export const blogContentType = 'octopusBlog';

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1,7 +1,14 @@
 import * as Interfaces from '@interfaces';
 import * as Contentful from 'contentful';
 
-export type { GetServerSideProps, GetServerSidePropsContext, GetServerSidePropsResult, NextPage } from 'next';
+export type {
+    GetServerSideProps,
+    GetServerSidePropsContext,
+    GetServerSidePropsResult,
+    NextPage,
+    GetStaticProps,
+    GetStaticPaths
+} from 'next';
 
 export type { AppProps } from 'next/app';
 export type { AxiosError } from 'axios';
@@ -344,6 +351,6 @@ export type BookmarkType = 'PUBLICATION' | 'TOPIC';
 export type BlogFields = {
     title: Contentful.EntryFields.Text;
     author: Contentful.EntryFields.Text;
-    featuredImage?: Contentful.Asset;
     content: Contentful.EntryFields.RichText;
+    slug: Contentful.EntryFields.Text;
 };

--- a/ui/src/pages/blog/[slug].tsx
+++ b/ui/src/pages/blog/[slug].tsx
@@ -1,0 +1,220 @@
+import React from 'react';
+import Head from 'next/head';
+import client from '@contentfulClient';
+import { NextPage } from 'next';
+import { useRouter } from 'next/router';
+import { documentToReactComponents, Options } from '@contentful/rich-text-react-renderer';
+import { BLOCKS, INLINES, MARKS } from '@contentful/rich-text-types';
+import { Entry, EntrySkeletonType } from 'contentful';
+import { documentToPlainTextString } from '@contentful/rich-text-plain-text-renderer';
+
+import * as Components from '@components';
+import * as Layouts from '@layouts';
+import * as Config from '@config';
+import * as Types from '@types';
+import * as Helpers from '@helpers';
+import * as OutlineIcons from '@heroicons/react/24/outline';
+
+/**
+ * rich text render options
+ */
+
+const renderOptions: Options = {
+    renderText: (text) => (text ? text : <br />),
+    renderMark: {
+        [MARKS.BOLD]: (text) => {
+            return (
+                <b className="font-bold" key={`${text}-key`}>
+                    {text}
+                </b>
+            );
+        },
+        [MARKS.CODE]: (text) => <code className="text-sm">{text}</code>
+    },
+    renderNode: {
+        [INLINES.EMBEDDED_ENTRY]: (node) => {
+            const { title, slug } = node.data.target.fields as Types.BlogFields;
+
+            return (
+                <Components.Link
+                    className="font-medium text-teal-600 decoration-2 hover:underline dark:text-teal-400"
+                    href={`${Config.urls.blog.path}/${slug}?canGoBack=true`}
+                    as={`${Config.urls.blog.path}/${slug}`}
+                >
+                    {title}
+                </Components.Link>
+            );
+        },
+        [INLINES.HYPERLINK]: (node, children) => {
+            const isExternalLink = !node.data.uri.startsWith(Config.urls.base.host);
+
+            return (
+                <Components.Link
+                    className="font-medium text-teal-600 decoration-2 hover:underline dark:text-teal-400"
+                    href={node.data.uri}
+                    target={isExternalLink ? '_blank' : '_self'}
+                    rel={isExternalLink ? 'noopener noreferrer' : ''}
+                >
+                    {children}
+                </Components.Link>
+            );
+        },
+        [BLOCKS.HEADING_1]: (node, children) => (
+            <h1 className="mb-4 font-montserrat text-[30px] font-semibold">{children}</h1>
+        ),
+        [BLOCKS.HEADING_2]: (node, children) => (
+            <h2 className="mb-4 font-montserrat text-[25px] font-semibold">{children}</h2>
+        ),
+        [BLOCKS.HEADING_3]: (node, children) => (
+            <h2 className="mb-4 font-montserrat text-[22px] font-semibold">{children}</h2>
+        ),
+        [BLOCKS.HEADING_4]: (node, children) => (
+            <h2 className="mb-4 font-montserrat text-[20px] font-semibold">{children}</h2>
+        ),
+        [BLOCKS.HEADING_5]: (node, children) => (
+            <h2 className="mb-4 font-montserrat text-[18px] font-semibold">{children}</h2>
+        ),
+        [BLOCKS.HEADING_6]: (node, children) => (
+            <h2 className="mb-4 font-montserrat text-[16px] font-semibold">{children}</h2>
+        ),
+        [BLOCKS.PARAGRAPH]: (node, children) => <p className="mb-6 leading-6">{children}</p>,
+        [BLOCKS.EMBEDDED_ASSET]: (node) => {
+            // render the EMBEDDED_ASSET
+            return (
+                <img
+                    src={`https://${node.data.target.fields.file.url}`}
+                    alt={node.data.target.fields.description}
+                    className="w-full py-4"
+                    loading="lazy"
+                />
+            );
+        },
+        [BLOCKS.EMBEDDED_ENTRY]: (node) => {
+            const { title, slug, author, content } = node.data.target.fields as Types.BlogFields;
+            const { createdAt } = node.data.target.sys;
+
+            return (
+                <Components.Link
+                    href={`${Config.urls.blog.path}/${slug}?canGoBack=true`}
+                    as={`${Config.urls.blog.path}/${slug}`}
+                    className="flex"
+                >
+                    <Components.BlogCard
+                        title={title}
+                        content={content}
+                        author={author}
+                        createdAt={Helpers.formatDate(createdAt)}
+                    />
+                </Components.Link>
+            );
+        },
+        [BLOCKS.TABLE]: (node, children) => (
+            <table className="w-full table-fixed border-collapse overflow-hidden rounded-lg border border-grey-100 ring-1 ring-grey-100 dark:bg-grey-600 dark:ring-teal-300">
+                <tbody>{children}</tbody>
+            </table>
+        ),
+        [BLOCKS.TABLE_HEADER_CELL]: (node, children) => (
+            <th className="border border-grey-100 bg-grey-50 p-3 text-left children:m-0 dark:border-teal-300 dark:bg-grey-700">
+                {children}
+            </th>
+        ),
+        [BLOCKS.TABLE_ROW]: (node, children) => <tr>{children}</tr>,
+        [BLOCKS.TABLE_CELL]: (node, children) => (
+            <td className="border border-grey-100 p-3 align-baseline dark:border-teal-300">{children}</td>
+        ),
+        [BLOCKS.HR]: () => <hr className="mb-6 h-2 border-grey-100" />,
+        [BLOCKS.UL_LIST]: (node, children) => <ul className="list-disc pl-6">{children}</ul>,
+        [BLOCKS.OL_LIST]: (node, children) => <ol className="list-decimal pl-6">{children}</ol>,
+        [BLOCKS.LIST_ITEM]: (node, children) => <li className="children:mb-4">{children}</li>,
+        [BLOCKS.QUOTE]: (node, children) => (
+            <blockquote className="border-l-4 border-l-teal-300 pl-4">{children}</blockquote>
+        )
+    }
+};
+
+export const getStaticPaths: Types.GetStaticPaths = async () => {
+    const blogs = await client.getEntries();
+    const paths = blogs.items.map((blog) => ({ params: { slug: blog.fields.slug as string } }));
+
+    return {
+        paths,
+        fallback: 'blocking'
+    };
+};
+
+export const getStaticProps: Types.GetStaticProps = async ({ params }) => {
+    const { slug } = params as { slug: string };
+
+    try {
+        const blog = (await client.getEntries({ content_type: Config.values.blogContentType, 'fields.slug': slug }))
+            .items[0];
+
+        return {
+            props: {
+                blog
+            },
+            // - attempt to re-generate the page every 10 seconds when a request comes in
+            // - useful to show blog updates while writing it
+            revalidate: 10
+        };
+    } catch (error) {
+        console.log(error);
+
+        return {
+            notFound: true
+        };
+    }
+};
+
+type Props = { blog: Entry<EntrySkeletonType<Types.BlogFields>, undefined, string> };
+
+const IndividualBlogPage: NextPage<Props> = (props) => {
+    const router = useRouter();
+    const { title, author, content } = props.blog.fields;
+    const { createdAt } = props.blog.sys;
+    const { canGoBack } = router.query as { canGoBack: string };
+
+    const description = React.useMemo(() => {
+        const descriptionMaxLength = 155;
+        const text = documentToPlainTextString(content).trim();
+        return text.length > descriptionMaxLength ? `${text.slice(0, descriptionMaxLength).trim()}...` : text;
+    }, [content]);
+
+    return (
+        <>
+            <Head>
+                <title>
+                    {title} - {Config.urls.base.title}
+                </title>
+                <meta name="description" content={description} />
+                <meta name="keywords" content={Config.urls.blog.keywords.join(', ')} />
+                <link rel="canonical" href={Config.urls.base.host + router.asPath} />
+            </Head>
+
+            <Layouts.Standard fixedHeader={false}>
+                <section className="container mx-auto px-8 pb-10 pt-4">
+                    <div className="dark:shadow-none sm:p-4 sm:shadow">
+                        <Components.Button
+                            className="children:border-0"
+                            startIcon={<OutlineIcons.ArrowLeftIcon className="h-4 w-4 text-teal-600" />}
+                            title="Back"
+                            onClick={() => (canGoBack === 'true' ? router.back() : router.push(Config.urls.blog.path))}
+                        />
+                        <div className="mx-auto w-full max-w-5xl py-10">
+                            <Components.PageTitle text={title} className="!mb-4" />
+                            <Components.PageSubTitle
+                                className="text-base font-medium"
+                                text={`Written by ${author} on ${Helpers.formatDate(createdAt)}`}
+                            />
+                            <div className="dark:text-white-50">
+                                {documentToReactComponents(content, renderOptions)}
+                            </div>
+                        </div>
+                    </div>
+                </section>
+            </Layouts.Standard>
+        </>
+    );
+};
+
+export default IndividualBlogPage;

--- a/ui/src/pages/blog/[slug].tsx
+++ b/ui/src/pages/blog/[slug].tsx
@@ -66,16 +66,16 @@ const renderOptions: Options = {
             <h2 className="mb-4 font-montserrat text-[25px] font-semibold">{children}</h2>
         ),
         [BLOCKS.HEADING_3]: (node, children) => (
-            <h2 className="mb-4 font-montserrat text-[22px] font-semibold">{children}</h2>
+            <h3 className="mb-4 font-montserrat text-[22px] font-semibold">{children}</h3>
         ),
         [BLOCKS.HEADING_4]: (node, children) => (
-            <h2 className="mb-4 font-montserrat text-[20px] font-semibold">{children}</h2>
+            <h4 className="mb-4 font-montserrat text-[20px] font-semibold">{children}</h4>
         ),
         [BLOCKS.HEADING_5]: (node, children) => (
-            <h2 className="mb-4 font-montserrat text-[18px] font-semibold">{children}</h2>
+            <h5 className="mb-4 font-montserrat text-[18px] font-semibold">{children}</h5>
         ),
         [BLOCKS.HEADING_6]: (node, children) => (
-            <h2 className="mb-4 font-montserrat text-[16px] font-semibold">{children}</h2>
+            <h6 className="mb-4 font-montserrat text-[16px] font-semibold">{children}</h6>
         ),
         [BLOCKS.PARAGRAPH]: (node, children) => <p className="mb-6 leading-6">{children}</p>,
         [BLOCKS.EMBEDDED_ASSET]: (node) => {


### PR DESCRIPTION
The purpose of this PR was to create the individual blog page.
For improved SEO and performance, each blog post is pre-rendered at build time with Nextjs "[getStaticPaths](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-static-paths)" and "[getStaticProps](https://nextjs.org/docs/pages/building-your-application/data-fetching/get-static-props)" instead of being fetched.

For new blog posts and updates I have used Nextjs [ISR](https://nextjs.org/docs/pages/building-your-application/data-fetching/incremental-static-regeneration)

PS. - this branch needs to be rebased with main after [OCT-734](https://jiscdev.atlassian.net/browse/OCT-734) is being merged

---

### Acceptance Criteria:

As per [OCT-740](https://jiscdev.atlassian.net/browse/OCT-740)

---

### Checklist:

- [x] Local manual testing conducted

---

### Tests:

Tested the generation of static pages locally and it worked fine
<img width="610" alt="image" src="https://github.com/JiscSD/octopus/assets/48569671/69ad1473-eb98-48c7-bb71-4d84ba1bf1dd">

When updating a blog post, it's corresponding page is re-generated after ~10 seconds and the updates become visible on the page

---

### Screenshots:


[OCT-740]: https://jiscdev.atlassian.net/browse/OCT-740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OCT-734]: https://jiscdev.atlassian.net/browse/OCT-734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ