### PR TITLE
OCT-733 - Blog link in nav bar

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -15674,6 +15674,7 @@
         },
         "node_modules/node-fetch": {
 <<<<<<< HEAD
+<<<<<<< HEAD
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
             "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
@@ -15688,6 +15689,11 @@
             "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
 >>>>>>> 8b30c2a2 (fixed package-lock)
 >>>>>>> 197cc468 (fixed package-lock)
+=======
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+>>>>>>> 4799353e (fixed package-lock)
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -15673,27 +15673,9 @@
             }
         },
         "node_modules/node-fetch": {
-<<<<<<< HEAD
-<<<<<<< HEAD
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
             "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-=======
-<<<<<<< HEAD
-            "version": "2.6.13",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
-            "integrity": "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==",
-=======
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
->>>>>>> 8b30c2a2 (fixed package-lock)
->>>>>>> 197cc468 (fixed package-lock)
-=======
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
->>>>>>> 4799353e (fixed package-lock)
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -15673,9 +15673,21 @@
             }
         },
         "node_modules/node-fetch": {
+<<<<<<< HEAD
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
             "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+=======
+<<<<<<< HEAD
+            "version": "2.6.13",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
+            "integrity": "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==",
+=======
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+>>>>>>> 8b30c2a2 (fixed package-lock)
+>>>>>>> 197cc468 (fixed package-lock)
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },

--- a/ui/src/components/BlogCard/index.tsx
+++ b/ui/src/components/BlogCard/index.tsx
@@ -21,7 +21,6 @@ const BlogCard: React.FC<Props> = (props) => {
                 <div className="blog-card-text text-sm text-grey-800 transition-colors dark:text-white-50 lg:text-base">
                     {shortBlogText}
                 </div>
-
                 <p className="blog-card-footer text-xs font-medium tracking-wide text-grey-800 transition-colors dark:text-grey-100">
                     By {props.author} | {props.createdAt}
                 </p>

--- a/ui/src/components/Nav/index.tsx
+++ b/ui/src/components/Nav/index.tsx
@@ -29,6 +29,10 @@ const Nav: React.FC = (): React.ReactElement => {
                 value: Config.urls.browsePublications.path
             },
             {
+                label: 'Blog',
+                value: Config.urls.blog.path
+            },
+            {
                 label: 'How To',
                 value: '',
                 subItems: [


### PR DESCRIPTION
The purpose of this PR was to add a nav link to the blog page.

This is branched off from OCT-740 because it needed the URL config for the blog page so it should probably be merged after that.

---

### Acceptance Criteria:

As per [OCT-733](https://jiscdev.atlassian.net/browse/OCT-733?atlOrigin=eyJpIjoiY2MxN2QxNTM5NjBkNDYxMTlmNjRkYTA2Yjk5ZTgzZWYiLCJwIjoiaiJ9)

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated


[OCT-733]: https://jiscdev.atlassian.net/browse/OCT-733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ