### PR TITLE
OCT-620: Allow publishing for problems with 1 topic and no linked publications

### DIFF
--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -522,7 +522,8 @@ export const isReadyToPublish = (publication: I.PublicationWithMetadata): boolea
         return false;
     }
 
-    const hasAtLeastOneLinkTo = publication.linkedTo.length !== 0;
+    const hasAtLeastOneLinkOrTopic =
+        publication.linkedTo.length !== 0 || (publication.type === 'PROBLEM' && publication.topics.length !== 0);
     const hasFilledRequiredFields =
         ['title', 'licence'].every((field) => publication[field]) && !Helpers.isEmptyContent(publication.content || '');
     const conflictOfInterest = validateConflictOfInterest(publication);
@@ -536,7 +537,7 @@ export const isReadyToPublish = (publication: I.PublicationWithMetadata): boolea
     );
 
     return (
-        hasAtLeastOneLinkTo &&
+        hasAtLeastOneLinkOrTopic &&
         hasFilledRequiredFields &&
         conflictOfInterest &&
         !hasPublishDate &&
@@ -551,7 +552,8 @@ export const isReadyToRequestApproval = (publication: I.PublicationWithMetadata)
         return false;
     }
 
-    const hasAtLeastOneLinkTo = publication.linkedTo.length > 0;
+    const hasAtLeastOneLinkOrTopic =
+        publication.linkedTo.length !== 0 || (publication.type === 'PROBLEM' && publication.topics.length !== 0);
     const hasFilledRequiredFields =
         ['title', 'licence'].every((field) => publication[field]) && !Helpers.isEmptyContent(publication.content || '');
     const conflictOfInterest = validateConflictOfInterest(publication);
@@ -563,7 +565,7 @@ export const isReadyToRequestApproval = (publication: I.PublicationWithMetadata)
     );
 
     return (
-        hasAtLeastOneLinkTo &&
+        hasAtLeastOneLinkOrTopic &&
         hasFilledRequiredFields &&
         conflictOfInterest &&
         isDataAndHasEthicalStatement &&

--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -44,6 +44,7 @@ export const publicationFlowLinkedPublication = async (
     await page.keyboard.type(linkedPubSearchTerm);
     await page.locator(`[role="option"]:has-text("${linkedPubTitle}")`).click();
     await page.locator(PageModel.publish.linkedItems.addLink).click();
+    await page.waitForResponse((response) => response.url().includes('/links') && response.ok());
     await expect(page.locator(PageModel.publish.linkedItems.deletePublicationLink)).toBeVisible();
 
     await page.locator(PageModel.publish.nextButton).click();
@@ -289,6 +290,9 @@ interface PublicationTestType {
 }
 
 export const checkPublication = async (page: Page, publication: PublicationTestType) => {
+    // Wait for page to be loaded - viz will try to fetch links
+    await page.waitForResponse((response) => response.url().includes('/links'));
+
     const publicationTemplate = (publication: PublicationTestType): string[] => [
         `aside span:has-text("${publication.pubType}")`,
         `aside span:has-text("${publication.language}")`,
@@ -364,7 +368,8 @@ test.describe('Publication flow', () => {
         await page.locator(PageModel.publish.linkedItems.topicInput).click();
         await page.keyboard.type("test");
         await page.locator(`[role="option"]:has-text("Test topic")`).click();
-        await page.locator(PageModel.publish.linkedItems.addLink).click();
+        await page.locator(PageModel.publish.linkedItems.addLink).click();        
+        await page.waitForResponse((response) => response.url().includes('/publications/') && response.ok());
         await expect(page.locator(PageModel.publish.linkedItems.deleteTopicLink)).toBeVisible();
     });
 

--- a/ui/src/layouts/BuildPublication.tsx
+++ b/ui/src/layouts/BuildPublication.tsx
@@ -64,7 +64,10 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
             if (!store.title) ready = { ready: false, message: 'You must provide a title' };
             if (!store.content) ready = { ready: false, message: 'You must provide main text' };
             if (!store.licence) ready = { ready: false, message: 'You must select a licence' };
-            if (!store.linkTo?.length && !store.topics?.length)
+            if (
+                (store.type === 'PROBLEM' && !store.linkTo?.length && !store.topics?.length) ||
+                (store.type !== 'PROBLEM' && !store.linkTo?.length)
+            )
                 ready = { ready: false, message: 'You must link this publication to at least one other item' };
 
             if (store.conflictOfInterestStatus && !store.conflictOfInterestText.length) {


### PR DESCRIPTION
The purpose of this PR was to correct an issue with the initial work for OCT-620, which allowed users to link publications to topics, but didn't allow them to proceed with publication if there was no linked publication.

---

### Acceptance Criteria:

A research problem can be published if it has 1 topic and no linked publications.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

API + E2E:
<img width="183" alt="Screenshot 2023-09-11 095238" src="https://github.com/JiscSD/octopus/assets/132363734/5b19b363-dc4d-4ce9-97b5-24dc6da97f5b">

UI:

<img width="396" alt="Screenshot 2023-09-11 095330" src="https://github.com/JiscSD/octopus/assets/132363734/f8b8f9e9-4682-46e8-92a0-06d48483dcb6">

