### PR TITLE
OCT-762: differentiate role name by environment

### DIFF
--- a/infra/modules/s3/main.tf
+++ b/infra/modules/s3/main.tf
@@ -82,7 +82,7 @@ resource "aws_lambda_function" "pdf_processing_lambda" {
 }
 
 resource "aws_iam_role" "pdf_processing_lambda_role" {
-  name = "pdf_processing_lambda_role"
+  name = "octopus_${var.environment}_pdf_processing_lambda_role"
 
   assume_role_policy = jsonencode({
     "Version": "2012-10-17",


### PR DESCRIPTION
The purpose of this PR was to fix a small issue with the pubrouter terraform where an IAM role name was the same when using different workspaces, causing "already exists" conflicts when attempting to deploy.

---

### Acceptance Criteria:

Terraform deploy works on multiple environments without clashing resource names.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated
