### PR TITLE
OCT-728: Rremove og title and description from document level

### DIFF
--- a/ui/src/pages/_document.tsx
+++ b/ui/src/pages/_document.tsx
@@ -16,11 +16,6 @@ const AppDocument = () => (
 
             <meta property="og:url" content="https://octopus.ac" />
             <meta property="og:type" content="website" />
-            <meta property="og:title" content="Octopus" />
-            <meta
-                property="og:description"
-                content="Octopus is a new way to register research. It is the place to publish the version of record, enabling peer review and quality assessment and allowing the academic community to build upon the latest work."
-            />
             <meta property="og:image" content="https://octopus.ac/meta/og-image.jpg" />
             <meta
                 property="og:image:alt"


### PR DESCRIPTION
The purpose of this PR was to address an issue that was in the original work for this item. The og:title and og:description meta tags were set at the document level and were overriding the values set per page.

---

### Acceptance Criteria:

As per [OC-95](https://jiscdev.atlassian.net/browse/OC-95)

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated


[OC-95]: https://jiscdev.atlassian.net/browse/OC-95?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ