### PR TITLE
OC-396: Ensure end to end tests pass

### DIFF
--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -309,49 +309,49 @@ functions:
         handler: src/components/coauthor/routes.get
         events:
             - http:
-                  path: ${self:custom.versions.v1}/publications/{id}/coauthors
+                  path: ${self:custom.versions.v1}/publicationVersions/{id}/coauthors
                   method: GET
                   cors: true
     updateAll:
         handler: src/components/coauthor/routes.updateAll
         events:
             - http:
-                  path: ${self:custom.versions.v1}/publications/{id}/coauthors
+                  path: ${self:custom.versions.v1}/publicationVersions/{id}/coauthors
                   method: PUT
                   cors: true
     deleteCoAuthor:
         handler: src/components/coauthor/routes.remove
         events:
             - http:
-                  path: ${self:custom.versions.v1}/publications/{id}/coauthors/{coauthor}
+                  path: ${self:custom.versions.v1}/publicationVersions/{id}/coauthors/{coauthor}
                   method: DELETE
                   cors: true
     linkCoAuthor:
         handler: src/components/coauthor/routes.link
         events:
             - http:
-                  path: ${self:custom.versions.v1}/publications/{id}/link-coauthor
+                  path: ${self:custom.versions.v1}/publicationVersions/{id}/link-coauthor
                   method: PATCH
                   cors: true
     updateCoAuthorConfirmation:
         handler: src/components/coauthor/routes.updateConfirmation
         events:
             - http:
-                  path: ${self:custom.versions.v1}/publications/{id}/coauthor-confirmation
+                  path: ${self:custom.versions.v1}/publicationVersions/{id}/coauthor-confirmation
                   method: PATCH
                   cors: true
     requestApproval:
         handler: src/components/coauthor/routes.requestApproval
         events:
             - http:
-                  path: ${self:custom.versions.v1}/publications/{id}/coauthors/request-approval
+                  path: ${self:custom.versions.v1}/publicationVersions/{id}/coauthors/request-approval
                   method: PUT
                   cors: true
     sendApprovalReminder:
         handler: src/components/coauthor/routes.sendApprovalReminder
         events:
             - http:
-                  path: ${self:custom.versions.v1}/publications/{id}/coauthors/{coauthor}/approval-reminder
+                  path: ${self:custom.versions.v1}/publicationVersions/{id}/coauthors/{coauthor}/approval-reminder
                   method: POST
                   cors: true
     getFlag:
@@ -491,7 +491,7 @@ functions:
         handler: src/components/affiliations/routes.updateAffiliations
         events:
             - http:
-                  path: ${self:custom.versions.v1}/publications/{id}/my-affiliations
+                  path: ${self:custom.versions.v1}/publicationVersions/{id}/my-affiliations
                   method: PUT
                   cors: true
 

--- a/api/src/components/affiliations/__tests__/updateAffiliations.test.ts
+++ b/api/src/components/affiliations/__tests__/updateAffiliations.test.ts
@@ -69,7 +69,7 @@ describe('update coAuthor affiliations per publication', () => {
 
     test('Corresponding author can add an affiliation to their DRAFT publication', async () => {
         const updateAffiliationsResponse = await testUtils.agent
-            .put('/publications/publication-problem-draft/my-affiliations')
+            .put('/publicationVersions/publication-problem-draft-v1/my-affiliations')
             .query({ apiKey: '000000005' })
             .send({
                 affiliations: orcidTestAffiliations,
@@ -82,7 +82,7 @@ describe('update coAuthor affiliations per publication', () => {
 
     test('Corresponding author needs to add affiliations if not independent before locking the publication', async () => {
         const updateAffiliationsResponse = await testUtils.agent
-            .put('/publications/publication-problem-draft/my-affiliations')
+            .put('/publicationVersions/publication-problem-draft-v1/my-affiliations')
             .query({ apiKey: '000000005' })
             .send({
                 affiliations: [],
@@ -104,7 +104,7 @@ describe('update coAuthor affiliations per publication', () => {
 
     test('Author needs to fill out affiliations if the publication is LOCKED', async () => {
         const updateAffiliationsResponse = await testUtils.agent
-            .put('/publications/publication-problem-locked/my-affiliations')
+            .put('/publicationVersions/publication-problem-locked-v1/my-affiliations')
             .query({ apiKey: '000000005' })
             .send({
                 affiliations: [],
@@ -117,7 +117,7 @@ describe('update coAuthor affiliations per publication', () => {
 
     test('User cannot add affiliations if they are not part of the publication', async () => {
         const updateAffiliationsResponse = await testUtils.agent
-            .put('/publications/publication-problem-draft/my-affiliations')
+            .put('/publicationVersions/publication-problem-draft-v1/my-affiliations')
             .query({ apiKey: '123456789' })
             .send({
                 affiliations: [],
@@ -132,7 +132,7 @@ describe('update coAuthor affiliations per publication', () => {
 
     test('User cannot add affiliations if the publication is LIVE', async () => {
         const updateAffiliationsResponse = await testUtils.agent
-            .put('/publications/publication-problem-live/my-affiliations')
+            .put('/publicationVersions/publication-problem-live-v1/my-affiliations')
             .query({ apiKey: '123456789' })
             .send({
                 affiliations: [],
@@ -145,7 +145,7 @@ describe('update coAuthor affiliations per publication', () => {
 
     test('Only corresponding author can update his affiliations while the publication is DRAFT', async () => {
         const updateAffiliationsResponse = await testUtils.agent
-            .put('/publications/publication-problem-draft/my-affiliations')
+            .put('/publicationVersions/publication-problem-draft-v1/my-affiliations')
             .query({ apiKey: '000000005' })
             .send({
                 affiliations: orcidTestAffiliations,
@@ -156,7 +156,7 @@ describe('update coAuthor affiliations per publication', () => {
         expect(updateAffiliationsResponse.body.message).toEqual('Successfully updated affiliations.');
 
         const updateAffiliationsResponse2 = await testUtils.agent
-            .put('/publications/publication-problem-draft/my-affiliations')
+            .put('/publicationVersions/publication-problem-draft-v1/my-affiliations')
             .query({ apiKey: '000000006' })
             .send({
                 affiliations: orcidTestAffiliations,
@@ -171,7 +171,7 @@ describe('update coAuthor affiliations per publication', () => {
 
     test('Cannot add duplicate affiliations', async () => {
         const updateAffiliationsResponse = await testUtils.agent
-            .put('/publications/publication-problem-draft/my-affiliations')
+            .put('/publicationVersions/publication-problem-draft-v1/my-affiliations')
             .query({ apiKey: '000000005' })
             .send({
                 affiliations: orcidTestAffiliations.concat(orcidTestAffiliations),

--- a/api/src/components/affiliations/controller.ts
+++ b/api/src/components/affiliations/controller.ts
@@ -15,17 +15,17 @@ export const updateAffiliations = async (
         const isIndependent = event.body.isIndependent;
         const affiliations = event.body.affiliations;
         const publicationVersionId = event.pathParameters.id;
-        // Get publication with current version
+        // Get publication version
         const version = await publicationVersionService.get(publicationVersionId);
 
-        //check that the publication exists
+        // Check that the version exists
         if (!version) {
             return response.json(404, {
                 message: 'This publication does not exist.'
             });
         }
 
-        //check if publication is LIVE
+        // Check if version is LIVE
         if (version.currentStatus === 'LIVE') {
             return response.json(403, {
                 message: 'You cannot add affiliations to a LIVE publication.'
@@ -34,14 +34,14 @@ export const updateAffiliations = async (
 
         const coAuthor = version.coAuthors.find((author) => author.linkedUser === event.user.id);
 
-        // check if this user is an author on this publication's current version
+        // Check if this user is an author on the version
         if (!coAuthor) {
             return response.json(403, {
                 message: 'You do not have permissions to add an affiliation to this publication.'
             });
         }
 
-        // while the publication status is DRAFT, only the corresponding author can update his/her affiliations
+        // While the publication status is DRAFT, only the corresponding author can update his/her affiliations
         if (version.currentStatus === 'DRAFT' && coAuthor.linkedUser !== version.createdBy) {
             return response.json(403, {
                 message: 'You cannot add affiliations while the publication is being edited.'
@@ -62,7 +62,7 @@ export const updateAffiliations = async (
             return response.json(403, { message: 'Duplicate affiliations found.' });
         }
 
-        // check if coauthor (beside the corresponding one) has already approved this publication
+        // Check if coauthor (beside the corresponding one) has already approved this version
         if (coAuthor.linkedUser !== version.createdBy && coAuthor.confirmedCoAuthor) {
             return response.json(403, {
                 message: 'You cannot change your affiliation information while the publication has been approved.'

--- a/api/src/components/affiliations/controller.ts
+++ b/api/src/components/affiliations/controller.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 import * as I from 'interface';
 import * as response from 'lib/response';
-import * as publicationService from 'publication/service';
+import * as publicationVersionService from 'publicationVersion/service';
 import * as userService from 'user/service';
 import * as coAuthorService from 'coauthor/service';
 import * as Helpers from 'lib/helpers';
@@ -14,27 +14,25 @@ export const updateAffiliations = async (
     try {
         const isIndependent = event.body.isIndependent;
         const affiliations = event.body.affiliations;
-        const publicationId = event.pathParameters.id;
+        const publicationVersionId = event.pathParameters.id;
         // Get publication with current version
-        const publication = await publicationService.getWithVersion(publicationId);
+        const version = await publicationVersionService.get(publicationVersionId);
 
         //check that the publication exists
-        if (!publication) {
+        if (!version) {
             return response.json(404, {
                 message: 'This publication does not exist.'
             });
         }
 
-        const currentVersion = publication.versions[0];
-
         //check if publication is LIVE
-        if (currentVersion.currentStatus === 'LIVE') {
+        if (version.currentStatus === 'LIVE') {
             return response.json(403, {
                 message: 'You cannot add affiliations to a LIVE publication.'
             });
         }
 
-        const coAuthor = currentVersion.coAuthors.find((author) => author.linkedUser === event.user.id);
+        const coAuthor = version.coAuthors.find((author) => author.linkedUser === event.user.id);
 
         // check if this user is an author on this publication's current version
         if (!coAuthor) {
@@ -44,14 +42,14 @@ export const updateAffiliations = async (
         }
 
         // while the publication status is DRAFT, only the corresponding author can update his/her affiliations
-        if (currentVersion.currentStatus === 'DRAFT' && coAuthor.linkedUser !== currentVersion.createdBy) {
+        if (version.currentStatus === 'DRAFT' && coAuthor.linkedUser !== version.createdBy) {
             return response.json(403, {
                 message: 'You cannot add affiliations while the publication is being edited.'
             });
         }
 
         // enforce adding affiliations if co-author is not independent
-        if (currentVersion.currentStatus === 'LOCKED' && !isIndependent && !affiliations.length) {
+        if (version.currentStatus === 'LOCKED' && !isIndependent && !affiliations.length) {
             return response.json(403, {
                 message: 'Please fill out your affiliation information.'
             });
@@ -65,7 +63,7 @@ export const updateAffiliations = async (
         }
 
         // check if coauthor (beside the corresponding one) has already approved this publication
-        if (coAuthor.linkedUser !== currentVersion.createdBy && coAuthor.confirmedCoAuthor) {
+        if (coAuthor.linkedUser !== version.createdBy && coAuthor.confirmedCoAuthor) {
             return response.json(403, {
                 message: 'You cannot change your affiliation information while the publication has been approved.'
             });

--- a/api/src/components/coauthor/__tests__/createCoAuthor.test.ts
+++ b/api/src/components/coauthor/__tests__/createCoAuthor.test.ts
@@ -7,9 +7,9 @@ describe('create coauthor', () => {
         await testUtils.testSeed();
     });
 
-    test('Update co-authors for a specific publication', async () => {
+    test('Update co-authors for a specific publication version', async () => {
         const coauthor = await testUtils.agent
-            .put('/publications/publication-problem-draft/coauthors')
+            .put('/publicationVersions/publication-problem-draft-v1/coauthors')
             .query({ apiKey: '000000005' })
             .send([
                 {
@@ -34,12 +34,12 @@ describe('create coauthor', () => {
 
     test('Cannot create a co-author with duplicate email', async () => {
         const coauthor = await testUtils.agent
-            .put('/publications/publication-problem-draft/coauthors')
+            .put('/publicationVersions/publication-problem-draft-v1/coauthors')
             .query({ apiKey: '000000005' })
             .send([
                 {
                     id: createId(),
-                    publicationId: 'publication-problem-draft',
+                    publicationVersionId: 'publication-problem-draft-v1',
                     email: 'email@test.com',
                     linkedUser: null,
                     approvalRequested: false,
@@ -47,7 +47,7 @@ describe('create coauthor', () => {
                 },
                 {
                     id: createId(),
-                    publicationId: 'publication-problem-draft',
+                    publicationVersionId: 'publication-problem-draft-v1',
                     email: 'email@test.com',
                     linkedUser: null,
                     approvalRequested: false,
@@ -55,7 +55,7 @@ describe('create coauthor', () => {
                 },
                 {
                     id: createId(),
-                    publicationId: 'publication-problem-draft',
+                    publicationVersionId: 'publication-problem-draft-v1',
                     email: 'fake-email@domain.com',
                     linkedUser: null,
                     approvalRequested: false,
@@ -63,7 +63,7 @@ describe('create coauthor', () => {
                 },
                 {
                     id: createId(),
-                    publicationId: 'publication-problem-draft',
+                    publicationVersionId: 'publication-problem-draft-v1',
                     email: 'fake-email@test.com',
                     linkedUser: null,
                     approvalRequested: false,
@@ -73,14 +73,14 @@ describe('create coauthor', () => {
         expect(coauthor.status).toEqual(400);
     });
 
-    test('Cannot create a co-author record if the user is not the author of a publication', async () => {
+    test('Cannot create a co-author record if the user is not the author of the publication version', async () => {
         const coauthor = await testUtils.agent
-            .put('/publications/publication-problem-draft/coauthors')
+            .put('/publicationVersions/publication-problem-draft-v1/coauthors')
             .query({ apiKey: '987654321' })
             .send([
                 {
                     id: createId(),
-                    publicationId: 'publication-problem-draft',
+                    publicationVersionId: 'publication-problem-draft-v1',
                     email: 'emailtest@emailtest.com',
                     linkedUser: null,
                     approvalRequested: false,
@@ -91,14 +91,14 @@ describe('create coauthor', () => {
         expect(coauthor.status).toEqual(403);
     });
 
-    test('Cannot create a co-author record on a publication that does not exist', async () => {
+    test('Cannot create a co-author record on a publication version that does not exist', async () => {
         const coauthor = await testUtils.agent
-            .put('/publications/non-existent-publication/coauthors')
+            .put('/publicationVersions/non-existent-publication-version/coauthors')
             .query({ apiKey: '123456789' })
             .send([
                 {
                     id: createId(),
-                    publicationId: 'non-existent-publication',
+                    publicationVersionId: 'non-existent-publication-v1',
                     email: 'emailtest@emailtest.com',
                     linkedUser: null,
                     approvalRequested: false,
@@ -109,14 +109,14 @@ describe('create coauthor', () => {
         expect(coauthor.status).toEqual(404);
     });
 
-    test('Cannot create a co-author record on a publication that is live', async () => {
+    test('Cannot create a co-author record on a publication version that is live', async () => {
         const coauthor = await testUtils.agent
-            .put('/publications/publication-problem-live/coauthors')
+            .put('/publicationVersions/publication-problem-live-v1/coauthors')
             .query({ apiKey: '123456789' })
             .send([
                 {
                     id: createId(),
-                    publicationId: 'publication-problem-live',
+                    publicationVersionId: 'publication-problem-live-v1',
                     email: 'emailtest@emailtest.com',
                     linkedUser: null,
                     approvalRequested: false,

--- a/api/src/components/coauthor/__tests__/deleteCoAuthor.test.ts
+++ b/api/src/components/coauthor/__tests__/deleteCoAuthor.test.ts
@@ -8,39 +8,39 @@ describe('Delete co-author', () => {
 
     test('Delete a co-author', async () => {
         const deleteCoAuthor = await testUtils.agent
-            .delete('/publications/publication-problem-draft/coauthors/coauthor-test-user-6-problem-draft')
+            .delete('/publicationVersions/publication-problem-draft-v1/coauthors/coauthor-test-user-6-problem-draft')
             .query({ apiKey: '000000005' });
 
         expect(deleteCoAuthor.status).toEqual(200);
     });
 
-    test('Cannot Delete a co-author without a valid id/coauthor has not been added to this publication', async () => {
+    test('Cannot Delete a co-author without a valid id/coauthor has not been added to this publication version', async () => {
         const deleteCoAuthor = await testUtils.agent
-            .delete('/publications/publication-problem-draft/coauthors/invalid-id')
+            .delete('/publicationVersions/publication-problem-draft-v1/coauthors/invalid-id')
             .query({ apiKey: '000000005' });
 
         expect(deleteCoAuthor.status).toEqual(404);
     });
 
-    test('Cannot Delete a co-author record if the user is not the author of a publication', async () => {
+    test('Cannot Delete a co-author record if the user is not the author of a publication version', async () => {
         const deleteCoAuthor = await testUtils.agent
-            .delete('/publications/publication-problem-draft/coauthors/coauthor-test-user-5-problem-draft')
+            .delete('/publicationVersions/publication-problem-draft-v1/coauthors/coauthor-test-user-5-problem-draft')
             .query({ apiKey: '987654321' });
 
         expect(deleteCoAuthor.status).toEqual(403);
     });
 
-    test('Cannot Delete a co-author record if the publication is live', async () => {
+    test('Cannot Delete a co-author record if the publication version is live', async () => {
         const deleteCoAuthor = await testUtils.agent
-            .delete('/publications/publication-problem-draft/coauthors/co-author-test-user-6-problem-live')
+            .delete('/publicationVersions/publication-problem-draft-v1/coauthors/co-author-test-user-6-problem-live')
             .query({ apiKey: '000000005' });
 
         expect(deleteCoAuthor.status).toEqual(404);
     });
 
-    test('Cannot Delete a co-author record on a publication that does not exist', async () => {
+    test('Cannot Delete a co-author record on a publication version that does not exist', async () => {
         const deleteCoAuthor = await testUtils.agent
-            .delete('/publications/non-existent-publication/coauthors/coauthor-test-user-5-problem-draft')
+            .delete('/publicationVersions/non-existent-publication-v1/coauthors/coauthor-test-user-5-problem-draft')
             .query({ apiKey: '123456789' });
 
         expect(deleteCoAuthor.status).toEqual(404);

--- a/api/src/components/coauthor/__tests__/linkCoAuthor.test.ts
+++ b/api/src/components/coauthor/__tests__/linkCoAuthor.test.ts
@@ -7,9 +7,9 @@ describe('Link co-author', () => {
         await testUtils.testSeed();
     });
 
-    test('Link a co-author to a publication (allow)', async () => {
+    test('Link a co-author to a publication version (allow)', async () => {
         const link = await testUtils.agent
-            .patch('/publications/publication-hypothesis-draft/link-coauthor')
+            .patch('/publicationVersions/publication-hypothesis-draft-v1/link-coauthor')
             .query({ apiKey: '000000007' })
             .send({
                 email: 'test-user-7@jisc.ac.uk',
@@ -25,9 +25,9 @@ describe('Link co-author', () => {
         expect(dbLink?.linkedUser).toEqual('test-user-7');
     });
 
-    test('Link a co-author to a publication (do not allow) with authentication', async () => {
+    test('Link a co-author to a publication version (do not allow) with authentication', async () => {
         const link = await testUtils.agent
-            .patch('/publications/publication-problem-draft/link-coauthor')
+            .patch('/publicationVersions/publication-problem-draft-v1/link-coauthor')
             .query({ apiKey: '987654321' })
             .send({
                 email: 'test-user-7@jisc.ac.uk',
@@ -43,9 +43,9 @@ describe('Link co-author', () => {
         expect(dbLink).toEqual(null);
     });
 
-    test('Link a co-author to a publication (do not allow) without authentication', async () => {
+    test('Link a co-author to a publication version (do not allow) without authentication', async () => {
         const link = await testUtils.agent
-            .patch('/publications/publication-problem-draft/link-coauthor')
+            .patch('/publicationVersions/publication-problem-draft-v1/link-coauthor')
             .query({ apiKey: '987654321' })
             .send({
                 email: 'test-user-7@jisc.ac.uk',
@@ -58,7 +58,7 @@ describe('Link co-author', () => {
 
     test('Cannot link as co-author if you are the creator', async () => {
         const link = await testUtils.agent
-            .patch('/publications/publication-problem-draft/link-coauthor')
+            .patch('/publicationVersions/publication-problem-draft-v1/link-coauthor')
             .query({ apiKey: '000000005' })
             .send({
                 email: 'test-user-7@jisc.ac.uk',
@@ -71,7 +71,7 @@ describe('Link co-author', () => {
 
     test('Cannot link co-author if user has already been linked as another co-author', async () => {
         const link = await testUtils.agent
-            .patch('/publications/publication-problem-draft/link-coauthor')
+            .patch('/publicationVersions/publication-problem-draft-v1/link-coauthor')
             .query({ apiKey: '000000006' })
             .send({
                 email: 'test-user-6@jisc.ac.uk',
@@ -84,7 +84,7 @@ describe('Link co-author', () => {
 
     test('Cannot override co-authorship', async () => {
         const link = await testUtils.agent
-            .patch('/publications/publication-problem-draft/link-coauthor')
+            .patch('/publicationVersions/publication-problem-draft-v1/link-coauthor')
             .query({ apiKey: '987654321' })
             .send({
                 email: 'test-user-6@jisc.ac.uk',
@@ -99,7 +99,7 @@ describe('Link co-author', () => {
     test('Cannot link co-author with a different email address', async () => {
         // trying to accept invitation with a user which is not a co-author
         const response = await testUtils.agent
-            .patch('/publications/publication-problem-draft/link-coauthor')
+            .patch('/publicationVersions/publication-problem-draft-v1/link-coauthor')
             .query({ apiKey: '000000004' })
             .send({
                 email: 'test-user-7@jisc.ac.uk',
@@ -112,7 +112,7 @@ describe('Link co-author', () => {
 
         // trying to accept invitation with a different co-author account
         const response2 = await testUtils.agent
-            .patch('/publications/publication-problem-draft/link-coauthor')
+            .patch('/publicationVersions/publication-problem-draft-v1/link-coauthor')
             .query({ apiKey: '000000008' })
             .send({
                 email: 'test-user-7@jisc.ac.uk',

--- a/api/src/components/coauthor/__tests__/requestApproval.test.ts
+++ b/api/src/components/coauthor/__tests__/requestApproval.test.ts
@@ -6,41 +6,41 @@ describe('Request co-authors approvals', () => {
         await testUtils.testSeed();
     });
 
-    test('Can request approvals only if the publication is DRAFT or LOCKED', async () => {
-        const draftPublicationResponse = await testUtils.agent
-            .put('/publications/publication-problem-draft/coauthors/request-approval')
+    test('Can request approvals only if the publication version is DRAFT or LOCKED', async () => {
+        const draftPublicationVersionResponse = await testUtils.agent
+            .put('/publicationVersions/publication-problem-draft-v1/coauthors/request-approval')
             .query({ apiKey: '000000005' });
 
-        expect(draftPublicationResponse.status).toEqual(200);
+        expect(draftPublicationVersionResponse.status).toEqual(200);
 
-        const lockedPublicationResponse = await testUtils.agent
-            .put('/publications/publication-problem-locked/coauthors/request-approval')
+        const lockedPublicationVersionResponse = await testUtils.agent
+            .put('/publicationVersions/publication-problem-locked-v1/coauthors/request-approval')
             .query({ apiKey: '000000005' });
 
-        expect(lockedPublicationResponse.status).toEqual(200);
+        expect(lockedPublicationVersionResponse.status).toEqual(200);
     });
 
-    test('Cannot request approvals for a LIVE publication', async () => {
-        const livePublicationResponse = await testUtils.agent
-            .put('/publications/publication-problem-live/coauthors/request-approval')
+    test('Cannot request approvals for a LIVE publication version', async () => {
+        const livePublicationVersionResponse = await testUtils.agent
+            .put('/publicationVersions/publication-problem-live-v1/coauthors/request-approval')
             .query({ apiKey: '123456789' });
 
-        expect(livePublicationResponse.status).toEqual(403);
+        expect(livePublicationVersionResponse.status).toEqual(403);
     });
 
     test('Cannot request approvals if user is not the creator', async () => {
-        const draftPublicationResponse = await testUtils.agent
-            .put('/publications/publication-problem-draft/coauthors/request-approval')
+        const draftPublicationVersionResponse = await testUtils.agent
+            .put('/publicationVersions/publication-problem-draft-v1/coauthors/request-approval')
             .query({ apiKey: '000000006' });
 
-        expect(draftPublicationResponse.status).toEqual(403);
+        expect(draftPublicationVersionResponse.status).toEqual(403);
     });
 
     test('Cannot request approvals if publication has no-coauthors', async () => {
-        const draftPublicationResponse = await testUtils.agent
-            .put('/publications/publication-2/coauthors/request-approval')
+        const draftPublicationVersionResponse = await testUtils.agent
+            .put('/publicationVersions/publication-2-v1/coauthors/request-approval')
             .query({ apiKey: '987654321' });
 
-        expect(draftPublicationResponse.status).toEqual(403);
+        expect(draftPublicationVersionResponse.status).toEqual(403);
     });
 });

--- a/api/src/components/coauthor/__tests__/sendApprovalReminder.test.ts
+++ b/api/src/components/coauthor/__tests__/sendApprovalReminder.test.ts
@@ -6,68 +6,68 @@ describe('Request co-authors approvals', () => {
         await testUtils.testSeed();
     });
 
-    test('Can send approval reminder only if publication status is LOCKED', async () => {
+    test('Can send approval reminder only if publication version status is LOCKED', async () => {
         // test LIVE
-        const livePublicationResponse = await testUtils.agent
+        const livePublicationVersionResponse = await testUtils.agent
             .post(
-                '/publications/publication-problem-live/coauthors/coauthor-test-user-6-problem-live/approval-reminder'
+                '/publicationVersions/publication-problem-live-v1/coauthors/coauthor-test-user-6-problem-live/approval-reminder'
             )
             .query({ apiKey: '123456789' });
 
-        expect(livePublicationResponse.status).toEqual(403);
-        expect(livePublicationResponse.body.message).toEqual(
+        expect(livePublicationVersionResponse.status).toEqual(403);
+        expect(livePublicationVersionResponse.body.message).toEqual(
             'A reminder is not able to be sent unless approval is being requested'
         );
 
         // test DRAFT
-        const draftPublicationResponse = await testUtils.agent
+        const draftPublicationVersionResponse = await testUtils.agent
             .post(
-                '/publications/publication-problem-draft/coauthors/coauthor-test-user-7-problem-draft/approval-reminder'
+                '/publicationVersions/publication-problem-draft-v1/coauthors/coauthor-test-user-7-problem-draft/approval-reminder'
             )
             .query({ apiKey: '000000005' });
 
-        expect(draftPublicationResponse.status).toEqual(403);
-        expect(draftPublicationResponse.body.message).toEqual(
+        expect(draftPublicationVersionResponse.status).toEqual(403);
+        expect(draftPublicationVersionResponse.body.message).toEqual(
             'A reminder is not able to be sent unless approval is being requested'
         );
 
         // test LOCKED
-        const lockedPublicationResponse = await testUtils.agent
+        const lockedPublicationVersionResponse = await testUtils.agent
             .post(
-                '/publications/publication-problem-locked/coauthors/coauthor-test-user-7-problem-locked/approval-reminder'
+                '/publicationVersions/publication-problem-locked-v1/coauthors/coauthor-test-user-7-problem-locked/approval-reminder'
             )
             .query({ apiKey: '000000005' });
 
-        expect(lockedPublicationResponse.status).toEqual(200);
-        expect(lockedPublicationResponse.body.message).toEqual('Reminder sent to test-user-7@jisc.ac.uk');
+        expect(lockedPublicationVersionResponse.status).toEqual(200);
+        expect(lockedPublicationVersionResponse.body.message).toEqual('Reminder sent to test-user-7@jisc.ac.uk');
     });
 
     test('Cannot send approval reminder if a co-author already approved', async () => {
         const response = await testUtils.agent
             .post(
-                '/publications/locked-publication-problem-confirmed-co-authors/coauthors/test-user-2/approval-reminder'
+                '/publicationVersions/locked-publication-problem-confirmed-co-authors-v1/coauthors/test-user-2/approval-reminder'
             )
             .query({ apiKey: '123456789' });
 
         expect(response.status).toEqual(400);
-        expect(response.body.message).toEqual('This author has already approved this publication');
+        expect(response.body.message).toEqual('This author has already approved this publication version');
     });
 
     test('Cannot send approval reminder to a user which is not a co-author', async () => {
         const response = await testUtils.agent
             .post(
-                '/publications/locked-publication-problem-confirmed-co-authors/coauthors/test-user-22/approval-reminder'
+                '/publicationVersions/locked-publication-problem-confirmed-co-authors-v1/coauthors/test-user-22/approval-reminder'
             )
             .query({ apiKey: '123456789' });
 
         expect(response.status).toEqual(404);
-        expect(response.body.message).toEqual('This author does not exist on this publication');
+        expect(response.body.message).toEqual('This author does not exist on this publication version');
     });
 
     test('Cannot send approval reminder to the same co-author twice', async () => {
         const response1 = await testUtils.agent
             .post(
-                '/publications/publication-problem-locked/coauthors/coauthor-test-user-7-problem-locked/approval-reminder'
+                '/publicationVersions/publication-problem-locked-v1/coauthors/coauthor-test-user-7-problem-locked/approval-reminder'
             )
             .query({ apiKey: '000000005' });
 
@@ -76,7 +76,7 @@ describe('Request co-authors approvals', () => {
 
         const response2 = await testUtils.agent
             .post(
-                '/publications/publication-problem-locked/coauthors/coauthor-test-user-7-problem-locked/approval-reminder'
+                '/publicationVersions/publication-problem-locked-v1/coauthors/coauthor-test-user-7-problem-locked/approval-reminder'
             )
             .query({ apiKey: '000000005' });
 

--- a/api/src/components/coauthor/__tests__/updateCoAuthor.test.ts
+++ b/api/src/components/coauthor/__tests__/updateCoAuthor.test.ts
@@ -8,7 +8,7 @@ describe('Update co-author status', () => {
 
     test('Co-author updates their status to true', async () => {
         const coAuthor = await testUtils.agent
-            .patch('/publications/publication-problem-locked/coauthor-confirmation')
+            .patch('/publicationVersions/publication-problem-locked-v1/coauthor-confirmation')
             .query({ apiKey: '000000006' })
             .send({
                 confirm: true
@@ -19,7 +19,7 @@ describe('Update co-author status', () => {
 
     test('Co-author updates their status to false', async () => {
         const coAuthor = await testUtils.agent
-            .patch('/publications/publication-problem-locked/coauthor-confirmation')
+            .patch('/publicationVersions/publication-problem-locked-v1/coauthor-confirmation')
             .query({ apiKey: '000000006' })
             .send({
                 confirm: false
@@ -30,7 +30,7 @@ describe('Update co-author status', () => {
 
     test('Cannot update co-author if not a co-author (1)', async () => {
         const coAuthor = await testUtils.agent
-            .patch('/publications/publication-problem-locked/coauthor-confirmation')
+            .patch('/publicationVersions/publication-problem-locked-v1/coauthor-confirmation')
             .query({ apiKey: '123456789' })
             .send({
                 confirm: true
@@ -41,7 +41,7 @@ describe('Update co-author status', () => {
 
     test('Cannot update co-author if not a co-author (2)', async () => {
         const coAuthor = await testUtils.agent
-            .patch('/publications/publication-problem-locked/coauthor-confirmation')
+            .patch('/publicationVersions/publication-problem-locked-v1/coauthor-confirmation')
             .query({ apiKey: '987654321' })
             .send({
                 confirm: true

--- a/api/src/components/coauthor/controller.ts
+++ b/api/src/components/coauthor/controller.ts
@@ -230,7 +230,7 @@ export const link = async (
             // check if this was the last co-author who denied their involvement
             if (version.coAuthors.length === 2) {
                 // this means only the creator remained and we can safely update publication status back to DRAFT
-                // to avoid publication being LOCKED without co-authors
+                // to avoid version being LOCKED without co-authors
                 await publicationVersionService.updateStatus(version.id, 'DRAFT');
             }
 
@@ -472,7 +472,7 @@ export const sendApprovalReminder = async (
         });
     }
 
-    // Can only send reminder on publications that have been locked for review
+    // Can only send reminder on publication versions that have been locked for review
     if (version.currentStatus !== 'LOCKED') {
         return response.json(403, {
             message: 'A reminder is not able to be sent unless approval is being requested'

--- a/api/src/components/coauthor/controller.ts
+++ b/api/src/components/coauthor/controller.ts
@@ -9,38 +9,36 @@ export const get = async (
     event: I.AuthenticatedAPIRequest<undefined, undefined, I.CreateCoAuthorPathParams>
 ): Promise<I.JSONResponse> => {
     try {
-        const publicationId = event.pathParameters.id;
+        const versionId = event.pathParameters.id;
 
-        const publication = await publicationService.getWithVersion(publicationId);
+        const version = await publicationVersionService.get(versionId);
 
-        if (!publication) {
+        if (!version) {
             return response.json(404, {
-                message: 'This publication does not exist.'
+                message: 'This publication version does not exist.'
             });
         }
 
-        const currentVersion = publication.versions[0];
+        const coAuthors = version.coAuthors;
 
-        const coAuthors = currentVersion.coAuthors;
-
-        const correspondingAuthor = coAuthors.find((coAuthor) => coAuthor.linkedUser === currentVersion.createdBy);
+        const correspondingAuthor = coAuthors.find((coAuthor) => coAuthor.linkedUser === version.createdBy);
 
         // enforce adding corresponding author if it's missing - this will fix old publications which don't have the corresponding author in the coAuthors list
         if (!correspondingAuthor) {
-            const correspondingAuthor = await coAuthorService.createCorrespondingAuthor(currentVersion);
+            const correspondingAuthor = await coAuthorService.createCorrespondingAuthor(version);
 
             // put corresponding author in the first position
             coAuthors.unshift({
                 ...correspondingAuthor,
                 user: {
-                    firstName: currentVersion.user.firstName,
-                    lastName: currentVersion.user.lastName,
-                    orcid: currentVersion.user.orcid
+                    firstName: version.user.firstName,
+                    lastName: version.user.lastName,
+                    orcid: version.user.orcid
                 }
             });
         }
 
-        return response.json(200, currentVersion.coAuthors);
+        return response.json(200, version.coAuthors);
     } catch (err) {
         console.log(err);
 
@@ -52,29 +50,27 @@ export const updateAll = async (
     event: I.AuthenticatedAPIRequest<I.CoAuthor[], undefined, I.CreateCoAuthorPathParams>
 ): Promise<I.JSONResponse> => {
     try {
-        const publicationId = event.pathParameters.id;
-        const publication = await publicationService.getWithVersion(publicationId);
+        const versionId = event.pathParameters.id;
+        const version = await publicationVersionService.get(versionId);
 
-        // Does the publication exist?
-        if (!publication) {
+        // Does the publication version exist?
+        if (!version) {
             return response.json(404, {
-                message: 'This publication does not exist.'
+                message: 'This publication version does not exist.'
             });
         }
 
-        const currentVersion = publication.versions[0];
-
         // Is this user the author of this version of the publication?
-        if (currentVersion.user.id !== event?.user.id) {
+        if (version.user.id !== event?.user.id) {
             return response.json(403, {
                 message: 'You do not have the right permissions for this action.'
             });
         }
 
         // Is the current version of the publication not live?
-        if (currentVersion.currentStatus === 'LIVE') {
+        if (version.currentStatus === 'LIVE') {
             return response.json(403, {
-                message: 'This publication is LIVE and therefore cannot be edited.'
+                message: 'This publication version is LIVE and therefore cannot be edited.'
             });
         }
 
@@ -87,7 +83,7 @@ export const updateAll = async (
         }
 
         const newCoAuthorsArray = event.body;
-        const oldCoAuthorsArray = currentVersion.coAuthors;
+        const oldCoAuthorsArray = version.coAuthors;
         const removedCoAuthors = oldCoAuthorsArray.filter(
             (oldCoAuthor) => !newCoAuthorsArray.find((newCoAuthor) => oldCoAuthor.email === newCoAuthor.email)
         );
@@ -95,7 +91,7 @@ export const updateAll = async (
         // check if corresponding author is trying to remove themself
         if (removedCoAuthors.some((author) => author.linkedUser === event.user.id)) {
             return response.json(403, {
-                message: 'You are not allowed to remove yourself from the publication.'
+                message: 'You are not allowed to remove yourself from the publication version.'
             });
         }
 
@@ -104,7 +100,7 @@ export const updateAll = async (
             // notify co-authors that they've been removed (if their approval has been requested)
             for (const coAuthor of removedCoAuthors) {
                 // remove co-author from this publication
-                await coAuthorService.deleteCoAuthorByEmail(currentVersion.id, coAuthor.email);
+                await coAuthorService.deleteCoAuthorByEmail(version.id, coAuthor.email);
 
                 if (coAuthor.approvalRequested) {
                     // notify co-author that they've been removed
@@ -113,14 +109,14 @@ export const updateAll = async (
                             email: coAuthor.email
                         },
                         publication: {
-                            title: currentVersion.title || ''
+                            title: version.title || ''
                         }
                     });
                 }
             }
         }
 
-        await coAuthorService.updateAll(currentVersion.id, newCoAuthorsArray);
+        await coAuthorService.updateAll(version.id, newCoAuthorsArray);
 
         return response.json(200, 'Successfully updated publication authors');
     } catch (err) {
@@ -134,35 +130,33 @@ export const remove = async (
     event: I.AuthenticatedAPIRequest<undefined, undefined, I.DeleteCoAuthorPathParams>
 ): Promise<I.JSONResponse> => {
     try {
-        const publication = await publicationService.getWithVersion(event.pathParameters.id);
+        const version = await publicationVersionService.get(event.pathParameters.id);
 
-        // Does the publication exist?
-        if (!publication) {
+        // Does the publication version exist?
+        if (!version) {
             return response.json(404, {
-                message: 'This publication does not exist.'
+                message: 'This publication version does not exist.'
             });
         }
 
-        const currentVersion = publication.versions[0];
-
         // Is this user the author of this version of the publication?
-        if (currentVersion.user.id !== event.user.id) {
+        if (version.user.id !== event.user.id) {
             return response.json(403, {
                 message: 'You do not have the right permissions for this action.'
             });
         }
 
         // Is the current version of the publication not live?
-        if (currentVersion.currentStatus === 'LIVE') {
+        if (version.currentStatus === 'LIVE') {
             return response.json(403, {
-                message: 'This publication is LIVE and therefore cannot be edited.'
+                message: 'This publication version is LIVE and therefore cannot be edited.'
             });
         }
 
         // Is the coauthor actually a coauthor of this version of the publication
-        if (!currentVersion.coAuthors.some((coAuthor) => coAuthor.id === event.pathParameters.coauthor)) {
+        if (!version.coAuthors.some((coAuthor) => coAuthor.id === event.pathParameters.coauthor)) {
             return response.json(404, {
-                message: 'This coauthor has not been added to this publication.'
+                message: 'This coauthor has not been added to this publication version.'
             });
         }
 
@@ -171,12 +165,10 @@ export const remove = async (
         // notify co-author that they've been removed
         await email.notifyCoAuthorRemoval({
             coAuthor: {
-                email:
-                    currentVersion.coAuthors.find((coAuthor) => coAuthor.id === event.pathParameters.coauthor)?.email ||
-                    ''
+                email: version.coAuthors.find((coAuthor) => coAuthor.id === event.pathParameters.coauthor)?.email || ''
             },
             publication: {
-                title: currentVersion.title || ''
+                title: version.title || ''
             }
         });
 
@@ -192,23 +184,21 @@ export const link = async (
     event: I.OptionalAuthenticatedAPIRequest<I.ConfirmCoAuthorBody, undefined, I.ConfirmCoAuthorPathParams>
 ): Promise<I.JSONResponse> => {
     try {
-        const publication = await publicationService.getWithVersion(event.pathParameters.id);
+        const version = await publicationVersionService.get(event.pathParameters.id);
 
-        if (!publication) {
+        if (!version) {
             return response.json(404, {
-                message: 'This publication does not exist.'
+                message: 'This publication version does not exist.'
             });
         }
 
-        const currentVersion = publication.versions[0];
-
-        if (currentVersion.currentStatus === 'LIVE') {
+        if (version.currentStatus === 'LIVE') {
             return response.json(403, {
-                message: 'This publication is LIVE and therefore cannot be edited.'
+                message: 'This publication version is LIVE and therefore cannot be edited.'
             });
         }
 
-        const coAuthorByEmail = currentVersion.coAuthors.find((coAuthor) => coAuthor.email === event.body.email);
+        const coAuthorByEmail = version.coAuthors.find((coAuthor) => coAuthor.email === event.body.email);
 
         // check if this user is part of co-authors list
         if (!coAuthorByEmail) {
@@ -224,7 +214,7 @@ export const link = async (
                 });
             }
 
-            await coAuthorService.removeFromPublicationVersion(currentVersion.id, event.body.email, event.body.code);
+            await coAuthorService.removeFromPublicationVersion(version.id, event.body.email, event.body.code);
 
             // notify main author about rejection
             await email.notifyCoAuthorRejection({
@@ -232,16 +222,16 @@ export const link = async (
                     email: event.body.email
                 },
                 publication: {
-                    title: currentVersion.title || '',
-                    authorEmail: currentVersion.user.email || ''
+                    title: version.title || '',
+                    authorEmail: version.user.email || ''
                 }
             });
 
             // check if this was the last co-author who denied their involvement
-            if (currentVersion.coAuthors.length === 2) {
+            if (version.coAuthors.length === 2) {
                 // this means only the creator remained and we can safely update publication status back to DRAFT
                 // to avoid publication being LOCKED without co-authors
-                await publicationVersionService.updateStatus(currentVersion.id, 'DRAFT');
+                await publicationVersionService.updateStatus(version.id, 'DRAFT');
             }
 
             return response.json(200, 'Removed co-author from publication');
@@ -261,14 +251,14 @@ export const link = async (
         }
 
         // Cannot link user to co-author if it is the author of the current version
-        if (currentVersion.user.id === event.user.id) {
+        if (version.user.id === event.user.id) {
             return response.json(404, {
                 message: 'You cannot link yourself as a co-author if you are already the corresponding author.'
             });
         }
 
         // User is already linked as a co-author
-        if (currentVersion.coAuthors.some((coAuthor) => coAuthor.linkedUser === event.user?.id)) {
+        if (version.coAuthors.some((coAuthor) => coAuthor.linkedUser === event.user?.id)) {
             return response.json(404, {
                 message: 'You are already linked as an author on this draft'
             });
@@ -283,7 +273,7 @@ export const link = async (
 
         // check if the user email is the same as the one the invitation has been sent to
         if (event.user.email !== coAuthorByEmail.email) {
-            const isCoAuthor = currentVersion.coAuthors.some((coAuthor) => coAuthor.email === event.user?.email); // check that this user is a coAuthor
+            const isCoAuthor = version.coAuthors.some((coAuthor) => coAuthor.email === event.user?.email); // check that this user is a coAuthor
 
             return response.json(isCoAuthor ? 403 : 404, {
                 message: isCoAuthor
@@ -292,7 +282,7 @@ export const link = async (
             });
         }
 
-        await coAuthorService.linkUser(event.user.id, currentVersion.id, event.body.email, event.body.code);
+        await coAuthorService.linkUser(event.user.id, version.id, event.body.email, event.body.code);
 
         return response.json(200, 'Linked user account');
     } catch (err) {
@@ -306,33 +296,31 @@ export const updateConfirmation = async (
     event: I.AuthenticatedAPIRequest<I.ChangeCoAuthorRequestBody, undefined, I.UpdateCoAuthorPathParams>
 ): Promise<I.JSONResponse> => {
     try {
-        const publication = await publicationService.getWithVersion(event.pathParameters.id);
+        const version = await publicationVersionService.get(event.pathParameters.id);
 
-        // Does the publication exist?
-        if (!publication) {
+        // Does the publication version exist?
+        if (!version) {
             return response.json(404, {
-                message: 'This publication does not exist.'
+                message: 'This publication version does not exist.'
             });
         }
-
-        const currentVersion = publication.versions[0];
 
         // Is the publication's current version in locked mode?
-        if (currentVersion.currentStatus !== 'LOCKED') {
+        if (version.currentStatus !== 'LOCKED') {
             return response.json(403, {
                 message:
-                    currentVersion.currentStatus === 'LIVE'
-                        ? 'You cannot approve a LIVE publication'
-                        : 'This publication is not ready for review yet'
+                    version.currentStatus === 'LIVE'
+                        ? 'You cannot approve a LIVE publication version'
+                        : 'This publication version is not ready for review yet'
             });
         }
 
-        const coAuthor = currentVersion.coAuthors.find((coAuthor) => coAuthor.linkedUser === event.user.id);
+        const coAuthor = version.coAuthors.find((coAuthor) => coAuthor.linkedUser === event.user.id);
 
-        // Is the coauthor actually a coauthor of this publication
+        // Is the coauthor actually a coauthor of this publication version
         if (!coAuthor) {
             return response.json(403, {
-                message: 'You are not a co-author of this publication.'
+                message: 'You are not a co-author of this publication version.'
             });
         }
 
@@ -344,7 +332,7 @@ export const updateConfirmation = async (
         }
 
         // update coAuthor confirmation status
-        await coAuthorService.updateConfirmation(currentVersion.id, event.user.id, event.body.confirm);
+        await coAuthorService.updateConfirmation(version.id, event.user.id, event.body.confirm);
 
         if (event.body.confirm) {
             // notify main author about confirmation
@@ -354,12 +342,12 @@ export const updateConfirmation = async (
                     lastName: event.user.lastName || ''
                 },
                 publication: {
-                    authorEmail: currentVersion.user.email || '',
-                    title: currentVersion.title || '',
-                    url: `${process.env.BASE_URL}/publications/${publication.id}`
+                    authorEmail: version.user.email || '',
+                    title: version.title || '',
+                    url: `${process.env.BASE_URL}/publications/${version.versionOf}`
                 },
                 remainingConfirmationsCount:
-                    currentVersion.coAuthors.filter((coAuthor) => !coAuthor.confirmedCoAuthor).length - 1
+                    version.coAuthors.filter((coAuthor) => !coAuthor.confirmedCoAuthor).length - 1
             });
         } else {
             // notify main author about rejection
@@ -368,8 +356,8 @@ export const updateConfirmation = async (
                     email: event.user.email || ''
                 },
                 publication: {
-                    title: currentVersion.title || '',
-                    authorEmail: currentVersion.user.email || ''
+                    title: version.title || '',
+                    authorEmail: version.user.email || ''
                 }
             });
         }
@@ -386,60 +374,64 @@ export const requestApproval = async (
     event: I.AuthenticatedAPIRequest<undefined, undefined, I.CreateCoAuthorPathParams>
 ): Promise<I.JSONResponse> => {
     try {
-        const publicationId = event.pathParameters.id;
-        const publication = await publicationService.getWithVersion(publicationId);
+        const versionId = event.pathParameters.id;
+        const version = await publicationVersionService.get(versionId);
 
-        if (!publication) {
-            return response.json(404, { message: 'Publication not found' });
+        if (!version) {
+            return response.json(404, { message: 'Publication version not found' });
         }
 
-        const currentVersion = publication.versions[0];
-
-        if (currentVersion.currentStatus === 'LIVE') {
-            return response.json(403, { message: 'Cannot request approvals for a LIVE publication.' });
+        if (version.currentStatus === 'LIVE') {
+            return response.json(403, { message: 'Cannot request approvals for a LIVE publication version.' });
         }
 
         // check if user is not the corresponding author
-        if (event.user.id !== currentVersion.createdBy) {
+        if (event.user.id !== version.createdBy) {
             return response.json(403, {
-                message: 'You are not allowed to request approvals for this publication.'
+                message: 'You are not allowed to request approvals for this publication version.'
             });
         }
 
         // check if publication actually has co-authors
-        if (currentVersion.coAuthors.length < 2) {
+        if (version.coAuthors.length < 2) {
             return response.json(403, { message: 'There is no co-author to request approval from.' });
         }
 
-        if (currentVersion.currentStatus === 'DRAFT') {
-            if (!publicationService.isReadyToRequestApproval(publication)) {
-                return response.json(403, {
-                    message:
-                        'Approval emails cannot be sent because the publication is not ready to be LOCKED. Make sure all fields are filled in.'
-                });
-            }
+        if (version.currentStatus === 'DRAFT') {
+            const publication = await publicationService.getWithVersion(version.versionOf, version.versionNumber);
 
-            // check if this version was LOCKED before
-            if (currentVersion.publicationStatus.some(({ status }) => status === 'LOCKED')) {
-                // notify linked co-authors about changes
-                const linkedCoAuthors = currentVersion.coAuthors.filter(
-                    (author) => author.linkedUser && author.linkedUser !== currentVersion.createdBy
-                );
-
-                for (const linkedCoAuthor of linkedCoAuthors) {
-                    await email.notifyCoAuthorsAboutChanges({
-                        coAuthor: { email: linkedCoAuthor.email },
-                        publication: {
-                            title: currentVersion.title || '',
-                            url: `${process.env.BASE_URL}/publications/${publication.id}`
-                        }
+            if (publication) {
+                if (!publicationService.isReadyToRequestApproval(publication)) {
+                    return response.json(403, {
+                        message:
+                            'Approval emails cannot be sent because the publication is not ready to be LOCKED. Make sure all fields are filled in.'
                     });
                 }
+
+                // check if this version was LOCKED before
+                if (version.publicationStatus.some(({ status }) => status === 'LOCKED')) {
+                    // notify linked co-authors about changes
+                    const linkedCoAuthors = version.coAuthors.filter(
+                        (author) => author.linkedUser && author.linkedUser !== version.createdBy
+                    );
+
+                    for (const linkedCoAuthor of linkedCoAuthors) {
+                        await email.notifyCoAuthorsAboutChanges({
+                            coAuthor: { email: linkedCoAuthor.email },
+                            publication: {
+                                title: version.title || '',
+                                url: `${process.env.BASE_URL}/publications/${publication.id}`
+                            }
+                        });
+                    }
+                }
+            } else {
+                throw Error('Could not get details of publication');
             }
         }
 
         // get all pending co authors
-        const pendingCoAuthors = await coAuthorService.getPendingApprovalForPublicationVersion(currentVersion.id);
+        const pendingCoAuthors = await coAuthorService.getPendingApprovalForPublicationVersion(version.id);
 
         // email pending co authors and update their record
         for (const pendingCoAuthor of pendingCoAuthors) {
@@ -448,14 +440,15 @@ export const requestApproval = async (
                 userFirstName: event.user.firstName,
                 userLastName: event.user.lastName,
                 code: pendingCoAuthor.code,
-                publicationId,
-                publicationTitle: currentVersion.title || 'No title yet'
+                publicationId: version.versionOf,
+                versionId: version.id,
+                publicationTitle: version.title || 'No title yet'
             });
 
-            await coAuthorService.updateRequestApprovalStatus(currentVersion.id, pendingCoAuthor.email);
+            await coAuthorService.updateRequestApprovalStatus(version.id, pendingCoAuthor.email);
         }
 
-        const coAuthors = await coAuthorService.getAllByPublicationVersion(currentVersion.id);
+        const coAuthors = await coAuthorService.getAllByPublicationVersion(version.id);
 
         return response.json(200, coAuthors);
     } catch (err) {
@@ -470,33 +463,31 @@ export const sendApprovalReminder = async (
 ): Promise<I.JSONResponse> => {
     const { coauthor, id } = event.pathParameters;
 
-    const publication = await publicationService.getWithVersion(id);
+    const version = await publicationVersionService.get(id);
     const author = await coAuthorService.get(coauthor);
 
-    if (!publication) {
+    if (!version) {
         return response.json(404, {
-            message: 'This publication does not exist.'
+            message: 'This publication version does not exist.'
         });
     }
 
-    const currentVersion = publication.versions[0];
-
     // Can only send reminder on publications that have been locked for review
-    if (currentVersion.currentStatus !== 'LOCKED') {
+    if (version.currentStatus !== 'LOCKED') {
         return response.json(403, {
             message: 'A reminder is not able to be sent unless approval is being requested'
         });
     }
 
-    if (event.user.id !== currentVersion.createdBy) {
+    if (event.user.id !== version.createdBy) {
         return response.json(403, {
             message: 'You do not have the right permissions for this action.'
         });
     }
 
-    if (!author || author.publicationVersionId !== currentVersion.id) {
+    if (!author || author.publicationVersionId !== version.id) {
         return response.json(404, {
-            message: 'This author does not exist on this publication'
+            message: 'This author does not exist on this publication version'
         });
     }
 
@@ -507,7 +498,7 @@ export const sendApprovalReminder = async (
      */
     if (author.confirmedCoAuthor) {
         return response.json(400, {
-            message: 'This author has already approved this publication'
+            message: 'This author has already approved this publication version'
         });
     }
 
@@ -529,9 +520,10 @@ export const sendApprovalReminder = async (
         await email.sendApprovalReminder({
             coAuthor: { email: author.email, code: author.code },
             publication: {
-                id: id,
-                title: currentVersion.title || '',
-                creator: `${currentVersion.user.firstName} ${currentVersion.user.lastName}`
+                id: version.versionOf,
+                title: version.title || '',
+                creator: `${version.user.firstName} ${version.user.lastName}`,
+                versionId: version.id
             }
         });
 

--- a/api/src/components/coauthor/schema/updateAll.ts
+++ b/api/src/components/coauthor/schema/updateAll.ts
@@ -8,7 +8,7 @@ const updateAll: I.Schema = {
             id: {
                 type: 'string'
             },
-            publicationId: {
+            publicationVersionId: {
                 type: 'string'
             },
             email: {

--- a/api/src/components/publication/__tests__/updateStatus.test.ts
+++ b/api/src/components/publication/__tests__/updateStatus.test.ts
@@ -222,7 +222,7 @@ describe('Update publication status', () => {
 
         // request co-authors approvals
         const requestApprovalsResponse = await testUtils.agent
-            .put('/publications/publication-problem-draft/coauthors/request-approval')
+            .put('/publicationVersions/publication-problem-draft-v1/coauthors/request-approval')
             .query({
                 apiKey: '000000005'
             });

--- a/api/src/components/publication/controller.ts
+++ b/api/src/components/publication/controller.ts
@@ -283,12 +283,12 @@ export const updateStatus = async (
 
         if (currentStatus === 'DRAFT') {
             if (newStatus === 'LOCKED') {
-                // check if publication actually has co-authors
+                // check if publication version actually has co-authors
                 if (currentVersion.coAuthors.length === 1) {
                     return response.json(403, { message: 'Publication cannot be LOCKED without co-authors.' });
                 }
 
-                // check if publication is ready to be LOCKED
+                // check if publication version is ready to be LOCKED
                 if (!publicationService.isReadyToLock(publication)) {
                     return response.json(403, {
                         message: 'Publication is not ready to be LOCKED. Make sure all fields are filled in.'
@@ -338,7 +338,7 @@ export const updateStatus = async (
 
         const updatedVersion = await publicationVersionService.updateStatus(currentVersion.id, newStatus);
 
-        // now that the publication is LIVE, we store in opensearch
+        // now that the publication version is LIVE, add/update the opensearch record
         await publicationService.createOpenSearchRecord({
             id: publicationId,
             type: updatedVersion.publication.type,
@@ -353,7 +353,7 @@ export const updateStatus = async (
 
         const references = await referenceService.getAllByPublicationVersion(updatedVersion.id);
 
-        // Publication is live, so update the DOI
+        // Publication version is live, so update the DOI
         await helpers.updateDOI(publication.doi, publication, references);
 
         // send message to the pdf generation queue

--- a/api/src/components/publication/controller.ts
+++ b/api/src/components/publication/controller.ts
@@ -340,7 +340,7 @@ export const updateStatus = async (
 
         // now that the publication is LIVE, we store in opensearch
         await publicationService.createOpenSearchRecord({
-            id: updatedVersion.id,
+            id: publicationId,
             type: updatedVersion.publication.type,
             title: updatedVersion.title,
             licence: updatedVersion.licence,

--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -159,7 +159,15 @@ export const getWithVersionMerged = async (id: string, versionNumber?: number) =
                                     publishedDate: true,
                                     currentStatus: true,
                                     description: true,
-                                    keywords: true
+                                    keywords: true,
+                                    user: {
+                                        select: {
+                                            id: true,
+                                            firstName: true,
+                                            lastName: true,
+                                            orcid: true
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -189,7 +197,15 @@ export const getWithVersionMerged = async (id: string, versionNumber?: number) =
                                     publishedDate: true,
                                     currentStatus: true,
                                     description: true,
-                                    keywords: true
+                                    keywords: true,
+                                    user: {
+                                        select: {
+                                            id: true,
+                                            firstName: true,
+                                            lastName: true,
+                                            orcid: true
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/api/src/components/publicationVersion/service.ts
+++ b/api/src/components/publicationVersion/service.ts
@@ -8,6 +8,16 @@ export const get = async (id: string) => {
             id
         },
         include: {
+            publication: {
+                select: {
+                    id: true,
+                    type: true,
+                    doi: true,
+                    linkedTo: true,
+                    linkedFrom: true,
+                    topics: true
+                }
+            },
             publicationStatus: {
                 select: {
                     status: true,
@@ -81,7 +91,10 @@ export const updateStatus = async (id: string, status: I.PublicationStatusEnum) 
                     status
                 }
             },
-            ...(status === 'LIVE' && { publishedDate: new Date().toISOString() })
+            ...(status === 'LIVE' && {
+                publishedDate: new Date().toISOString(),
+                isLatestLiveVersion: true
+            })
         },
         include: {
             publicationStatus: {

--- a/api/src/components/topic/service.ts
+++ b/api/src/components/topic/service.ts
@@ -56,6 +56,13 @@ export const get = async (id: string) => {
                 }
             },
             publications: {
+                where: {
+                    versions: {
+                        some: {
+                            isLatestLiveVersion: true
+                        }
+                    }
+                },
                 select: {
                     id: true,
                     versions: {

--- a/api/src/lib/email.ts
+++ b/api/src/lib/email.ts
@@ -205,29 +205,30 @@ type NotifyCoAuthor = {
     userFirstName: string;
     userLastName: string | null;
     coAuthor: string;
-    publicationId: string | null;
-    publicationTitle: string | null;
+    publicationId: string;
+    versionId: string;
+    publicationTitle: string;
     code: string;
 };
 
 export const notifyCoAuthor = async (options: NotifyCoAuthor): Promise<void> => {
     const html = `
-    <p>${options.userFirstName} ${options?.userLastName} has added you as an author of the following publication on Octopus:</p>
+    <p>${options.userFirstName} ${options.userLastName} has added you as an author of the following publication on Octopus:</p>
     <br>
     <p style="text-align: center;"><strong><i>${options.publicationTitle}</i></strong></p>
     <br>
     <p>Please use the button below to confirm that you are involved with the publication and review the draft to ensure you are happy with it:</p> 
     <br>
-    <p style="text-align: center;"><a style="${styles.button}" href='${baseURL}/author-link?email=${options.coAuthor}&code=${options.code}&publication=${options.publicationId}&approve=true'>Confirm & Review Publication</a></p>
+    <p style="text-align: center;"><a style="${styles.button}" href='${baseURL}/author-link?email=${options.coAuthor}&code=${options.code}&publicationId=${options.publicationId}&versionId=${options.versionId}&approve=true'>Confirm & Review Publication</a></p>
     <br>
     <p>If you are not an author of this publication, please click the button below:</p>
     <br>
-    <p style="text-align: center;"><a style="${styles.button}" href='${baseURL}/author-link?email=${options.coAuthor}&code=${options.code}&publication=${options.publicationId}&approve=false'>I am not an author</a></p>
+    <p style="text-align: center;"><a style="${styles.button}" href='${baseURL}/author-link?email=${options.coAuthor}&code=${options.code}&publicationId=${options.publicationId}&versionId=${options.versionId}&approve=false'>I am not an author</a></p>
     </br>
     <p>An Octopus user has provided this email address so that you can receive this message. If you select that you are not involved with the publication named above, your data will be deleted immediately.</p>
     `;
 
-    const text = `${options.userFirstName} ${options.userLastName} has added you as an author of the following publication on Octopus: ${options.publicationTitle}. To confirm your involvement, and see a preview of the publication, you can use this link: ${baseURL}/author-link?email=${options.coAuthor}&code=${options.code}&publication=${options.publicationId}&approve=true . If you are not an author of this publication, you can use this link: ${baseURL}/author-link?email=${options.coAuthor}&code=${options.code}&publication=${options.publicationId}&approve=false . An Octopus user has provided this email address so that you can receive this message. If you select that you are not involved with the publication named above, your data will be deleted immediately.`;
+    const text = `${options.userFirstName} ${options.userLastName} has added you as an author of the following publication on Octopus: ${options.publicationTitle}. To confirm your involvement, and see a preview of the publication, you can use this link: ${baseURL}/author-link?email=${options.coAuthor}&code=${options.code}&publicationId=${options.publicationId}&versionId=${options.versionId}&approve=true . If you are not an author of this publication, you can use this link: ${baseURL}/author-link?email=${options.coAuthor}&code=${options.code}&publicationId=${options.publicationId}&versionId=${options.versionId}&approve=false . An Octopus user has provided this email address so that you can receive this message. If you select that you are not involved with the publication named above, your data will be deleted immediately.`;
 
     await send({
         html: standardHTMLEmailTemplate('You’ve been added as a co-author on Octopus', html),
@@ -583,6 +584,7 @@ type SendApprovalReminder = {
         id: string;
         title: string;
         creator: string;
+        versionId: string;
     };
 };
 
@@ -594,16 +596,16 @@ export const sendApprovalReminder = async (options: SendApprovalReminder): Promi
         <br>
         <p>Please use the button below to confirm that you are involved with the publication and review the draft to ensure you are happy with it:</p> 
         <br>
-        <p style="text-align: center;"><a style="${styles.button}" href='${baseURL}/author-link?email=${options.coAuthor.email}&code=${options.coAuthor.code}&publication=${options.publication.id}&approve=true'>Confirm & Review Publication</a></p>
+        <p style="text-align: center;"><a style="${styles.button}" href='${baseURL}/author-link?email=${options.coAuthor.email}&code=${options.coAuthor.code}&publicationId=${options.publication.id}&versionId=${options.publication.versionId}&approve=true'>Confirm & Review Publication</a></p>
         <br>
         <p>If you are not an author of this publication, please click the button below:</p>
         <br>
-        <p style="text-align: center;"><a style="${styles.button}" href='${baseURL}/author-link?email=${options.coAuthor.email}&code=${options.coAuthor.code}&publication=${options.publication.id}&approve=false'>I am not an author</a></p>
+        <p style="text-align: center;"><a style="${styles.button}" href='${baseURL}/author-link?email=${options.coAuthor.email}&code=${options.coAuthor.code}&publicationId=${options.publication.id}&versionId=${options.publication.versionId}&approve=false'>I am not an author</a></p>
         </br>
         <p>An Octopus user has provided this email address so that you can receive this message. If you select that you are not involved with the publication named above, your data will be deleted immediately.</p>
     `;
 
-    const text = `${options.publication.creator} has sent you a reminder to confirm or deny your involvement as an author of the following publication on Octopus: ${options.publication.title}. To confirm your involvement, and see a preview of the publication, follow this link: ${baseURL}/author-link?email=${options.coAuthor.email}&code=${options.coAuthor.code}&publication=${options.publication.id}&approve=true. If you are not the co-author, follow this link: ${baseURL}/author-link?email=${options.coAuthor.email}&code=${options.coAuthor.code}&publication=${options.publication.id}&approve=false. An Octopus user has provided this email address so that you can receive this message. If you select that you are not involved with the publication named above, your data will be deleted immediately.`;
+    const text = `${options.publication.creator} has sent you a reminder to confirm or deny your involvement as an author of the following publication on Octopus: ${options.publication.title}. To confirm your involvement, and see a preview of the publication, follow this link: ${baseURL}/author-link?email=${options.coAuthor.email}&code=${options.coAuthor.code}&publicationId=${options.publication.id}&versionId=${options.publication.versionId}&approve=true. If you are not the co-author, follow this link: ${baseURL}/author-link?email=${options.coAuthor.email}&code=${options.coAuthor.code}&publicationId=${options.publication.id}&versionId=${options.publication.versionId}&approve=false. An Octopus user has provided this email address so that you can receive this message. If you select that you are not involved with the publication named above, your data will be deleted immediately.`;
 
     await send({
         html: standardHTMLEmailTemplate('You’ve been added as a co-author on Octopus', html),

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -15,6 +15,9 @@ import {
 import * as publicationService from 'publication/service';
 import * as publicationVersionService from 'publicationVersion/service';
 
+// Helpful utility - make one property optional e.g. PartialBy<Publication, 'title'>
+type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
+
 export {
     ImageExtension,
     Languages,
@@ -166,7 +169,13 @@ export type PublicationWithVersionAttached = Exclude<
     null
 >;
 
-export type PublicationVersion = Exclude<Prisma.PromiseReturnType<typeof publicationVersionService.get>, null>;
+export type PublicationVersionWithPublication = Exclude<
+    Prisma.PromiseReturnType<typeof publicationVersionService.get>,
+    null
+>;
+
+// An interface that will fit versions gotten directly from publicationVersionService, or from the versions attribute on a publication.
+export type PublicationVersion = PartialBy<PublicationVersionWithPublication, 'publication'>;
 
 /**
  * @description Links
@@ -391,7 +400,7 @@ export interface CoAuthor {
     confirmedCoAuthor: boolean;
     approvalRequested: boolean;
     email: string;
-    publicationId: string;
+    publicationVersionId: string;
     createdAt?: string;
     reminderDate?: string | null;
     isIndependent: boolean;

--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -1119,7 +1119,7 @@ test.describe('Publication flow + co-authors', () => {
         await deletePublication(page);
 
         // reject co-author invite
-        await rejectCoAuthorInvitation(browser, Helpers.user2, true, 'This publication does not exist.');
+        await rejectCoAuthorInvitation(browser, Helpers.user2, true, 'This publication version does not exist.');
 
         await page.close();
     });
@@ -1186,7 +1186,7 @@ test.describe('Publication flow + co-authors', () => {
             browser,
             Helpers.user2,
             true,
-            'This publication is LIVE and therefore cannot be edited.'
+            'This publication version is LIVE and therefore cannot be edited.'
         );
 
         await page.close();

--- a/ui/src/components/ApprovalsTracker/index.tsx
+++ b/ui/src/components/ApprovalsTracker/index.tsx
@@ -88,7 +88,7 @@ const ApprovalsTracker: React.FC<Props> = (props): React.ReactElement => {
                 try {
                     // update publication authors
                     await api.put(
-                        `${Config.endpoints.publications}/${props.publication.id}/coauthors`,
+                        `${Config.endpoints.publicationVersions}/${props.publication.versionId}/coauthors`,
                         newAuthorsArray,
                         Helpers.getJWT()
                     );
@@ -96,7 +96,7 @@ const ApprovalsTracker: React.FC<Props> = (props): React.ReactElement => {
                     // request approval again
                     // this will trigger an invitation email for the new author
                     await api.put(
-                        `${Config.endpoints.publications}/${props.publication.id}/coauthors/request-approval`,
+                        `${Config.endpoints.publicationVersions}/${props.publication.versionId}/coauthors/request-approval`,
                         {},
                         Helpers.getJWT()
                     );
@@ -130,7 +130,7 @@ const ApprovalsTracker: React.FC<Props> = (props): React.ReactElement => {
             setSendingReminder(true);
             try {
                 await api.post(
-                    `${Config.endpoints.publications}/${props.publication.id}/coauthors/${author.id}/approval-reminder`,
+                    `${Config.endpoints.publicationVersions}/${props.publication.versionId}/coauthors/${author.id}/approval-reminder`,
                     {},
                     Helpers.getJWT()
                 );

--- a/ui/src/components/EditAffiliationsModal/index.tsx
+++ b/ui/src/components/EditAffiliationsModal/index.tsx
@@ -33,7 +33,7 @@ const EditAffiliationsModal: React.FC<Props> = (props) => {
     useSWR(
         !props.autoUpdate || isValidating || error
             ? null
-            : `${Config.endpoints.publications}/${props.author.publicationId}/my-affiliations`,
+            : `${Config.endpoints.publicationVersions}/${props.author.publicationVersionId}/my-affiliations`,
         (url) => {
             const updatedAuthorAffiliations = orcidAffiliations.filter((affiliation) =>
                 authorAffiliations.some(({ id }) => affiliation.id === id)
@@ -73,7 +73,7 @@ const EditAffiliationsModal: React.FC<Props> = (props) => {
         try {
             // update author affiliations
             await api.put(
-                `${Config.endpoints.publications}/${props.author.publicationId}/my-affiliations`,
+                `${Config.endpoints.publicationVersions}/${props.author.publicationVersionId}/my-affiliations`,
                 { affiliations: authorAffiliations, isIndependent: isIndependentAuthor },
                 Helpers.getJWT()
             );

--- a/ui/src/components/Publication/Card/index.tsx
+++ b/ui/src/components/Publication/Card/index.tsx
@@ -25,7 +25,7 @@ const Card: React.FC<Props> = (props): React.ReactElement => {
                 approvalRequested: false,
                 confirmedCoAuthor: true,
                 email: correspondingUser.email || '',
-                publicationId: props.publication.id,
+                publicationVersionId: props.publication.versionId,
                 linkedUser: correspondingUser.id,
                 isIndependent: true,
                 affiliations: [],

--- a/ui/src/components/Publication/Creation/CoAuthor.tsx
+++ b/ui/src/components/Publication/Creation/CoAuthor.tsx
@@ -4,6 +4,7 @@ import * as OutlineIcons from '@heroicons/react/24/outline';
 import * as Framer from 'framer-motion';
 import * as api from '@api';
 import * as Components from '@components';
+import * as Config from '@config';
 import * as Stores from '@stores';
 import * as Helpers from '@helpers';
 import * as I from '@interfaces';
@@ -78,6 +79,7 @@ const CoAuthor: React.FC = (): React.ReactElement => {
     const coAuthors = Stores.usePublicationCreationStore((state) => state.coAuthors);
     const updateCoAuthors = Stores.usePublicationCreationStore((state) => state.updateCoAuthors);
     const publicationId = Stores.usePublicationCreationStore((state) => state.id);
+    const versionId = Stores.usePublicationCreationStore((state) => state.versionId);
     const user = Stores.useAuthStore((state) => state.user);
 
     const [loading, setLoading] = React.useState(false);
@@ -134,7 +136,7 @@ const CoAuthor: React.FC = (): React.ReactElement => {
 
         const newAuthor = {
             id: createId(),
-            publicationId: publicationId,
+            publicationVersionId: versionId,
             email: coAuthor,
             linkedUser: null,
             approvalRequested: false,
@@ -146,7 +148,7 @@ const CoAuthor: React.FC = (): React.ReactElement => {
         authorsArray.push(newAuthor);
         updateCoAuthors(authorsArray);
         setLoading(false);
-    }, [coAuthors, coAuthor, publicationId, updateCoAuthors]);
+    }, [coAuthors, coAuthor, versionId, updateCoAuthors]);
 
     const deleteCoAuthor = async (coAuthorId: string) => {
         updateCoAuthors(coAuthors.filter((item) => item.id !== coAuthorId));
@@ -156,7 +158,10 @@ const CoAuthor: React.FC = (): React.ReactElement => {
         setLoading(true);
 
         try {
-            const response = await api.get(`/publications/${publicationId}/coauthors`, user?.token);
+            const response = await api.get(
+                `${Config.endpoints.publicationVersions}/${versionId}/coauthors`,
+                user?.token
+            );
             updateCoAuthors(response.data);
             setLoading(false);
         } catch {

--- a/ui/src/components/Publication/Creation/LinkToEntry/index.tsx
+++ b/ui/src/components/Publication/Creation/LinkToEntry/index.tsx
@@ -17,6 +17,8 @@ const LinkToEntry: React.FC<Props> = (props): React.ReactElement => {
         props.deleteLink(props.link.id);
     };
 
+    const latestVersion = props.link.publicationToRef.versions[0];
+
     return (
         <tr key={props.link.id}>
             <td className="space-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
@@ -25,14 +27,14 @@ const LinkToEntry: React.FC<Props> = (props): React.ReactElement => {
                         {Helpers.formatPublicationType(props.link.publicationToRef.type)}
                     </span>
                     <p className="text-grey-800 transition-colors duration-500 dark:text-white-50">
-                        {props.link.publicationToRef.title}
+                        {latestVersion.title}
                     </p>
                     <div className="flex items-center space-x-2">
                         <span className="text-xs text-grey-700 transition-colors duration-500 dark:text-white-100">
-                            {Helpers.formatDate(props.link.publicationToRef.publishedDate)},
+                            {Helpers.formatDate(latestVersion.publishedDate)},
                         </span>
                         <span className="text-sm text-grey-700 transition-colors duration-500 dark:text-white-100">
-                            {props.link.publicationToRef.user.firstName[0]}. {props.link.publicationToRef.user.lastName}
+                            {latestVersion.user.firstName[0]}. {latestVersion.user.lastName}
                         </span>
                     </div>
                 </div>

--- a/ui/src/components/Publication/Creation/MainText.tsx
+++ b/ui/src/components/Publication/Creation/MainText.tsx
@@ -73,6 +73,7 @@ const MainText: React.FC = (): React.ReactElement | null => {
     const {
         id: publicationId,
         updateDescription,
+        versionId,
         keywords,
         updateKeywords,
         content,
@@ -109,7 +110,7 @@ const MainText: React.FC = (): React.ReactElement | null => {
             const newReference = getTransformedReference(
                 {
                     id: createId(),
-                    publicationId,
+                    publicationVersionId: versionId,
                     type: 'TEXT',
                     text: currentParagraph,
                     location: null
@@ -269,7 +270,7 @@ const MainText: React.FC = (): React.ReactElement | null => {
                                                                     setSelectedReferenceIndex(index);
                                                                     setSelectedReference({
                                                                         id: createId(), // generate new id
-                                                                        publicationId,
+                                                                        publicationVersionId: versionId,
                                                                         text: '',
                                                                         type: 'TEXT',
                                                                         location: null

--- a/ui/src/components/Publication/Link/index.tsx
+++ b/ui/src/components/Publication/Link/index.tsx
@@ -33,7 +33,7 @@ const Link: React.FC<Props> = (props) => (
             href={`${Config.urls.viewPublication.path}/${props.publicationRef.id}`}
             className="block w-fit rounded text-teal-600 outline-0 transition-colors duration-500 hover:underline focus:ring-2 focus:ring-yellow-400 dark:text-teal-400"
         >
-            <span className="block font-normal leading-relaxed">{props.publicationRef.title}</span>
+            <span className="block font-normal leading-relaxed">{props.publicationRef.versions[0].title}</span>
         </Components.Link>
     </div>
 );

--- a/ui/src/components/Publication/Visualization/index.tsx
+++ b/ui/src/components/Publication/Visualization/index.tsx
@@ -17,7 +17,7 @@ interface BoxEntry {
     authorFirstName: string;
     authorLastName: string;
     publishedDate: string;
-    authors: Pick<Interfaces.CoAuthor, 'id' | 'linkedUser' | 'publicationId' | 'user'>[];
+    authors: Pick<Interfaces.CoAuthor, 'id' | 'linkedUser' | 'publicationVersionId' | 'user'>[];
     pointers: string[];
 }
 
@@ -124,23 +124,27 @@ const getPublicationsByType = (data: Interfaces.PublicationWithLinks, type: stri
 
     if (publication.type === type) {
         // Push the selected publication first
-        publications.push({
-            id: publication.id,
-            title: publication.title,
-            type: publication.type,
-            createdBy: publication.createdBy,
-            publishedDate: publication.publishedDate,
-            authorFirstName: publication.user.firstName,
-            authorLastName: publication.user.lastName,
-            authors: publication.coAuthors,
-            pointers: linkedFrom
-                .filter(
-                    (linkedPublication) =>
-                        linkedPublication.type !== 'PEER_REVIEW' &&
-                        linkedPublication.parentPublication === publication.id
-                )
-                .map((publication) => publication.id) // get the ids of all direct child publications
-        });
+        const latestVersion = publication.versions.find((version) => version.isLatestLiveVersion);
+
+        if (latestVersion) {
+            publications.push({
+                id: publication.id,
+                title: latestVersion.title,
+                type: publication.type,
+                createdBy: latestVersion.createdBy,
+                publishedDate: latestVersion.publishedDate,
+                authorFirstName: latestVersion.user.firstName,
+                authorLastName: latestVersion.user.lastName,
+                authors: latestVersion.coAuthors,
+                pointers: linkedFrom
+                    .filter(
+                        (linkedPublication) =>
+                            linkedPublication.type !== 'PEER_REVIEW' &&
+                            linkedPublication.parentPublication === publication.id
+                    )
+                    .map((publication) => publication.id) // get the ids of all direct child publications
+            });
+        }
     }
 
     // ignore publications above 'PROBLEM'

--- a/ui/src/config/endpoints.ts
+++ b/ui/src/config/endpoints.ts
@@ -2,6 +2,7 @@ import * as api from '@api';
 
 const endpoints = {
     publications: `${api.baseURL}/publications`,
+    publicationVersions: `${api.baseURL}/publicationVersions`,
     users: `${api.baseURL}/users`,
     links: `${api.baseURL}/links`,
     authorization: `${api.baseURL}/authorization`,

--- a/ui/src/layouts/BuildPublication.tsx
+++ b/ui/src/layouts/BuildPublication.tsx
@@ -165,7 +165,6 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
                 language: store.language,
                 conflictOfInterestStatus: store.conflictOfInterestStatus,
                 conflictOfInterestText: store.conflictOfInterestText,
-                affiliationStatement: store.affiliationsStatement,
                 fundersStatement: store.funderStatement
             };
 
@@ -187,21 +186,21 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
 
             // update references for this publication
             await api.put(
-                `${Config.endpoints.publications}/${props.publication.id}/reference`,
+                `${Config.endpoints.publicationVersions}/${props.publication.versionId}/reference`,
                 store.references,
                 props.token
             );
 
-            // update co-authors for this publications - should really be put
+            // update co-authors for this publications
             await api.put(
-                `${Config.endpoints.publications}/${props.publication.id}/coauthors`,
+                `${Config.endpoints.publicationVersions}/${props.publication.versionId}/coauthors`,
                 store.coAuthors,
                 props.token
             );
 
             // update author affiliations
             await api.put(
-                `${Config.endpoints.publications}/${props.publication.id}/my-affiliations`,
+                `${Config.endpoints.publicationVersions}/${props.publication.versionId}/my-affiliations`,
                 { affiliations: store.authorAffiliations, isIndependent: store.isIndependentAuthor },
                 props.token
             );
@@ -257,7 +256,7 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
 
             // request co-authors approvals
             await api.put(
-                `${Config.endpoints.publications}/${props.publication.id}/coauthors/request-approval`,
+                `${Config.endpoints.publicationVersions}/${props.publication.versionId}/coauthors/request-approval`,
                 {},
                 props.token
             );

--- a/ui/src/lib/interfaces.ts
+++ b/ui/src/lib/interfaces.ts
@@ -25,16 +25,16 @@ export interface PublicationStatus {
 
 export interface PublicationRef {
     id: string;
-    title: string;
-    publishedDate: string;
-    currentStatus: PublicationStatus;
     type: Types.PublicationType;
-    user: {
-        id: string;
-        firstName: string;
-        lastName: string;
-        orcid: string;
-    };
+    doi: string;
+    versions: {
+        title: string;
+        publishedDate: string;
+        currentStatus: PublicationStatus;
+        description: string;
+        keywords: string[];
+        user: User;
+    }[];
     linkedTo: LinkTo[];
     linkedFrom: LinkFrom[];
 }
@@ -51,29 +51,72 @@ export interface LinkFrom {
 
 export interface CorePublication {
     id: string;
-    title: string;
     type: Types.PublicationType;
     doi: string | null;
+    url_slug: string;
+    linkedFrom: LinkFrom[];
+    linkedTo: LinkTo[];
+    topics: BaseTopic[];
+    publicationFlags: Flag[];
+}
+
+export interface PublicationVersion {
+    id: string;
+    versionOf: string;
+    versionNumber: number;
+    isLatestVersion: boolean;
+    isLatestLiveVersion: boolean;
+    createdBy: string;
+    createdAt: string;
+    updatedAt: string;
+    currentStatus: Types.PublicationStatuses;
+    publishedDate: string;
+    title: string;
+    licence: Types.LicenceType;
+    conflictOfInterestStatus: boolean | undefined;
+    conflictOfInterestText: string | null;
+    ethicalStatement: string;
+    ethicalStatementFreeText: string | null;
+    dataPermissionsStatement: string | null;
+    dataPermissionsStatementProvidedBy: string | null;
+    dataAccessStatement: string | null;
+    selfDeclaration: boolean;
+    description: string;
+    keywords: string[];
+    content: string;
+    language: Types.Languages;
+    fundersStatement: string | null;
+    user: User;
+    publicationStatus: PublicationStatus[];
+    funders: Funder[];
+    coAuthors: CoAuthor[];
+}
+
+export interface PublicationWithVersions extends CorePublication {
+    versions: PublicationVersion[];
+}
+
+// The form of publication generally expected by the UI, with versionable data merged into the object.
+export interface Publication extends CorePublication {
+    versionId: string;
+    versionNumber: number;
+    isLatestVersion: boolean;
+    isLatestLiveVersion: boolean;
+    title: string;
     description: string;
     keywords: string[];
     createdBy: string;
     createdAt: string;
     updatedAt: string;
-    publishedDate: string;
     currentStatus: Types.PublicationStatuses;
-    url_slug: string;
+    publishedDate: string;
     licence: Types.LicenceType;
     content: string;
     language: Types.Languages;
     ethicalStatement: string;
     ethicalStatementFreeText: string | null;
-}
-
-export interface Publication extends CorePublication {
     publicationStatus: PublicationStatus[];
     user: User;
-    linkedFrom: LinkFrom[];
-    linkedTo: LinkTo[];
     conflictOfInterestStatus: boolean | undefined;
     conflictOfInterestText: string | null;
     dataAccessStatement: string | null;
@@ -83,11 +126,7 @@ export interface Publication extends CorePublication {
     coAuthors: CoAuthor[];
     funders: Funder[];
     fundersStatement: string | null;
-    affiliations: Affiliations[];
-    affiliationStatement: string | null;
-    publicationFlags: Flag[];
     references: Reference[];
-    topics: BaseTopic[];
 }
 
 export interface LinkedToPublication {
@@ -101,7 +140,7 @@ export interface LinkedToPublication {
     createdBy: string;
     authorFirstName: string;
     authorLastName: string;
-    authors: Pick<CoAuthor, 'id' | 'linkedUser' | 'publicationId' | 'user'>[];
+    authors: Pick<CoAuthor, 'id' | 'linkedUser' | 'publicationVersionId' | 'user'>[];
 }
 
 export interface LinkedFromPublication {
@@ -115,11 +154,11 @@ export interface LinkedFromPublication {
     createdBy: string;
     authorFirstName: string;
     authorLastName: string;
-    authors: Pick<CoAuthor, 'id' | 'linkedUser' | 'publicationId' | 'user'>[];
+    authors: Pick<CoAuthor, 'id' | 'linkedUser' | 'publicationVersionId' | 'user'>[];
 }
 
 export interface PublicationWithLinks {
-    publication: Publication;
+    publication: PublicationWithVersions;
     linkedTo: LinkedToPublication[];
     linkedFrom: LinkedFromPublication[];
 }
@@ -128,7 +167,7 @@ export type ReferenceType = 'URL' | 'DOI' | 'TEXT';
 
 export interface Reference {
     id: string;
-    publicationId: string;
+    publicationVersionId: string;
     type: ReferenceType;
     text: string;
     location?: string | null;
@@ -140,7 +179,7 @@ export interface CoAuthor {
     confirmedCoAuthor: boolean;
     approvalRequested: boolean;
     email: string;
-    publicationId: string;
+    publicationVersionId: string;
     createdAt?: string;
     reminderDate?: string | null;
     affiliations: MappedOrcidAffiliation[];
@@ -381,7 +420,6 @@ export interface PublicationUpdateRequestBody extends JSON {
     dataPermissionsStatement?: string | null;
     dataPermissionsStatementProvidedBy?: string | null;
     selfDeclaration?: boolean;
-    affiliationStatement?: string | null;
 }
 
 export interface CreationStep {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -44,6 +44,8 @@ export type PublicationCreationStoreType = {
     setError: (error: string | null) => void;
     id: string;
     updateId: (id: string) => void;
+    versionId: string;
+    updateVersionId: (versionId: string) => void;
     title: string;
     updateTitle: (title: string) => void;
     type: PublicationType;

--- a/ui/src/pages/author-link.tsx
+++ b/ui/src/pages/author-link.tsx
@@ -11,9 +11,16 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
     let email: string | null = null;
     let code: string | null = null;
     let approve = null;
-    let publication: string | null = null;
+    let publicationId: string | null = null;
+    let versionId: string | null = null;
 
-    if (!context.query.code || !context.query.email || !context.query.approve || !context.query.publication) {
+    if (
+        !context.query.code ||
+        !context.query.email ||
+        !context.query.approve ||
+        !context.query.publicationId ||
+        !context.query.versionId
+    ) {
         return {
             props: {
                 message: 'Invalid link.'
@@ -24,7 +31,10 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
     email = Array.isArray(context.query.email) ? context.query.email[0] : context.query.email;
     code = Array.isArray(context.query.code) ? context.query.code[0] : context.query.code;
     approve = Array.isArray(context.query.approve) ? context.query.approve[0] : context.query.approve;
-    publication = Array.isArray(context.query.publication) ? context.query.publication[0] : context.query.publication;
+    publicationId = Array.isArray(context.query.publicationId)
+        ? context.query.publicationId[0]
+        : context.query.publicationId;
+    versionId = Array.isArray(context.query.versionId) ? context.query.versionId[0] : context.query.versionId;
 
     if (!['true', 'false'].includes(approve)) {
         return {
@@ -38,7 +48,7 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
         return Helpers.withServerSession(async (context) => {
             try {
                 await api.patch(
-                    `/publications/${publication}/link-coauthor`,
+                    `/publicationVersions/${versionId}/link-coauthor`,
                     {
                         email,
                         code,
@@ -66,13 +76,13 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
             }
 
             return {
-                redirect: { permanent: true, destination: `${Config.urls.viewPublication.path}/${publication}` }
+                redirect: { permanent: true, destination: `${Config.urls.viewPublication.path}/${publicationId}` }
             };
         })(context);
     }
 
     try {
-        await api.patch(`/publications/${publication}/link-coauthor`, {
+        await api.patch(`/publicationVersions/${versionId}/link-coauthor`, {
             email,
             code,
             approve: false

--- a/ui/src/pages/publications/[id]/edit.tsx
+++ b/ui/src/pages/publications/[id]/edit.tsx
@@ -189,7 +189,10 @@ const Edit: Types.NextPage<Props> = (props): React.ReactElement => {
     const fetchAndSetReferences = React.useCallback(async () => {
         if (props.draftedPublication.id) {
             try {
-                const response = await api.get(`/publications/${props.draftedPublication.id}/reference`, props.token);
+                const response = await api.get(
+                    `/publicationVersions/${props.draftedPublication.versionId}/reference`,
+                    props.token
+                );
                 store.updateReferences(response.data);
             } catch (err) {
                 // todo: improve error handling
@@ -201,7 +204,10 @@ const Edit: Types.NextPage<Props> = (props): React.ReactElement => {
     const fetchAndSetAuthors = React.useCallback(async () => {
         if (props.draftedPublication.id) {
             try {
-                const response = await api.get(`/publications/${props.draftedPublication.id}/coauthors`, props.token);
+                const response = await api.get(
+                    `${Config.endpoints.publicationVersions}/${props.draftedPublication.versionId}/coauthors`,
+                    props.token
+                );
                 store.updateCoAuthors(response.data);
             } catch (err) {
                 // todo: improve error handling
@@ -218,6 +224,10 @@ const Edit: Types.NextPage<Props> = (props): React.ReactElement => {
     React.useEffect(() => {
         if (props.draftedPublication.id) {
             store.updateId(props.draftedPublication.id);
+        }
+
+        if (props.draftedPublication.versionId) {
+            store.updateVersionId(props.draftedPublication.versionId);
         }
 
         if (props.draftedPublication.title) {
@@ -288,7 +298,6 @@ const Edit: Types.NextPage<Props> = (props): React.ReactElement => {
         store.updateAuthorAffiliations(correspondingAuthor?.affiliations || []);
         store.updateIsIndependentAuthor(correspondingAuthor?.isIndependent || false);
 
-        store.updateAffiliationsStatement(props.draftedPublication.affiliationStatement);
         store.updateConflictOfInterestStatus(props.draftedPublication.conflictOfInterestStatus);
     }, []);
 

--- a/ui/src/pages/publications/[id]/index.tsx
+++ b/ui/src/pages/publications/[id]/index.tsx
@@ -102,7 +102,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
     );
 
     const { data: references = [] } = useSWR<Interfaces.Reference[]>(
-        `${Config.endpoints.publications}/${props.publicationId}/reference`,
+        `${Config.endpoints.publicationVersions}/${props.publication.versionId}/reference`,
         (url) => api.get(url, props.userToken).then(({ data }) => data),
         {
             fallbackData: []
@@ -123,16 +123,9 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
     const isBookmarkButtonVisible = useMemo(() => {
         if (!user || !publicationData) {
             return false;
-        }
-
-        const isCoAuthor = publicationData.coAuthors.some((author) => author.id == user.id);
-        const isOwner = user.id === publicationData.createdBy;
-
-        if (!isCoAuthor && !isOwner) {
+        } else {
             return true;
         }
-
-        return false;
     }, [publicationData, user]);
     const topics = publicationData?.topics || [];
 
@@ -191,7 +184,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
             setApprovalError('');
             try {
                 await api.patch(
-                    `/publications/${publicationData?.id}/coauthor-confirmation`,
+                    `/publicationVersions/${publicationData?.versionId}/coauthor-confirmation`,
                     {
                         confirm
                     },
@@ -356,7 +349,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                 approvalRequested: false,
                 confirmedCoAuthor: true,
                 email: correspondingUser.email || '',
-                publicationId: publicationData.id,
+                publicationVersionId: publicationData.versionId,
                 linkedUser: correspondingUser.id,
                 isIndependent: true,
                 affiliations: [],

--- a/ui/src/stores/publicationCreation.ts
+++ b/ui/src/stores/publicationCreation.ts
@@ -25,6 +25,7 @@ let store: any = (set: (params: any) => void) => ({
         set(() => {
             return {
                 id: '',
+                versionId: '',
                 title: '',
                 type: Config.values.octopusInformation.publications.PROBLEM.id,
                 content: '',
@@ -51,6 +52,10 @@ let store: any = (set: (params: any) => void) => ({
     // ID
     id: '',
     updateId: (id: string) => set(() => ({ id })),
+
+    // Version ID
+    versionId: '',
+    updateVersionId: (versionId: string) => set(() => ({ versionId })),
 
     // Title
     title: '',


### PR DESCRIPTION
The purpose of this PR was to check that the end to end tests still work properly after versioning has been introduced.

Mostly it was adjusting the UI to accommodate the API changes made so far, but I also changed the coauthor API routes and the my-affiliations API route to take a version ID instead of a publication ID (as we've done for References).

I did notice an issue where, when viewing a published hypothesis, the visualisation was showing an unexpected problem (as well as the one problem the hypothesis was linked to). Since this seems to be an issue with the API response from the get links function which is being worked on in parallel, I think we should check if it's still a bug after that work is done, since it might fix it.

---

### Acceptance Criteria:

The end to end test suite passes on the versioning branch.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added - none added but some changes
- [ ] Documentation updated

---

### Tests:

UI:
<img width="396" alt="Screenshot 2023-09-20 131611" src="https://github.com/JiscSD/octopus/assets/132363734/94423d27-7f4f-4de8-befa-54380cb85e72">

API:
<img width="180" alt="Screenshot 2023-09-20 132032" src="https://github.com/JiscSD/octopus/assets/132363734/b0fb19cb-2a53-45cf-9a10-5ef09ab76a9c">

E2E:
<img width="127" alt="Screenshot 2023-09-20 130011" src="https://github.com/JiscSD/octopus/assets/132363734/164a8034-be63-4c31-84f7-25435d314171">
