### PR TITLE
OC-697 Include all live publications when getting links

### DIFF
--- a/api/src/components/publication/controller.ts
+++ b/api/src/components/publication/controller.ts
@@ -372,14 +372,15 @@ export const getLinksForPublication = async (
     event: I.APIRequest<undefined, undefined, I.GetPublicationPathParams>
 ): Promise<I.JSONResponse> => {
     try {
-        const data = await publicationService.getLinksForPublication(event.pathParameters.id);
+        const { publication, linkedFrom, linkedTo } = await publicationService.getLinksForPublication(
+            event.pathParameters.id
+        );
 
-        // If publication doesn't exist or has no LIVE version
-        if (!data.publication || !data.publication.versions.some((version) => version.isLatestLiveVersion)) {
+        if (!publication) {
             return response.json(404, { message: 'Not found.' });
         }
 
-        return response.json(200, data);
+        return response.json(200, { publication, linkedFrom, linkedTo });
     } catch (err) {
         console.log(err);
 

--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -4,7 +4,6 @@ import * as I from 'interface';
 import * as client from 'lib/client';
 import * as referenceService from 'reference/service';
 import * as Helpers from 'lib/helpers';
-import { Links } from '@prisma/client';
 import { Browser, launch } from 'puppeteer-core';
 
 import { PutObjectCommand } from '@aws-sdk/client-s3';
@@ -1008,8 +1007,26 @@ export const isReadyToLock = (publication: I.PublicationWithVersionAttached): bo
     return isReadyToRequestApproval(publication) && hasRequestedApprovals;
 };
 
-export const getLinksForPublication = async (id: string) => {
+export const getLinksForPublication = async (id: string): Promise<I.PublicationWithLinks> => {
     const publication = await get(id);
+
+    if (!publication) {
+        return {
+            publication: null,
+            linkedFrom: [],
+            linkedTo: []
+        };
+    }
+
+    const latestLiveVersion = publication?.versions.find((version) => version.isLatestLiveVersion);
+
+    if (!latestLiveVersion) {
+        return {
+            publication: null,
+            linkedFrom: [],
+            linkedTo: []
+        };
+    }
 
     /*
      * This set of queries provides two result sets:
@@ -1026,16 +1043,16 @@ export const getLinksForPublication = async (id: string) => {
      * 2. To limit the tree size, a linked publication cannot be of the same type (for instance, we aren't looking to return problems linked to other problems)
      */
 
-    const linkedTo: Links[] = await client.prisma.$queryRaw`
+    const linkedTo = await client.prisma.$queryRaw<I.LinkedToPublication[]>`
         WITH RECURSIVE to_left AS (
             SELECT "Links"."publicationFrom" "childPublication",
                    "Links"."publicationTo" "id",
                    "pfrom".type "childPublicationType",
                    "pto".type,
-                   "pto_latest_version".title,
-                   "pto_first_version"."createdBy",
-                   "pto_latest_version"."publishedDate",
-                   "pto_latest_version"."currentStatus",
+                   "pto_version".title,
+                   "pto_version"."createdBy",
+                   "pto_version"."publishedDate",
+                   "pto_version"."currentStatus",
                    "pto_user"."firstName" "authorFirstName",
                    "pto_user"."lastName" "authorLastName"
 
@@ -1046,16 +1063,12 @@ export const getLinksForPublication = async (id: string) => {
               LEFT JOIN "Publication" AS pto
               ON "pto".id = "Links"."publicationTo"
 
-              LEFT JOIN "PublicationVersion" AS pto_latest_version
-              ON "pto".id = "pto_latest_version"."versionOf"
-              AND "pto_latest_version"."isLatestVersion" = 't'
-
-              LEFT JOIN "PublicationVersion" AS pto_first_version
-              ON "pto".id = "pto_first_version"."versionOf"
-              AND "pto_first_version"."versionNumber" = 1
+              LEFT JOIN "PublicationVersion" AS pto_version
+              ON "pto".id = "pto_version"."versionOf"
+              AND "pto_version"."isLatestLiveVersion" = TRUE
 
               LEFT JOIN "User" AS pto_user
-              ON "pto_first_version"."createdBy" = "pto_user"."id"
+              ON "pto_version"."createdBy" = "pto_user"."id"
 
             WHERE "Links"."publicationFrom" = ${id}
 
@@ -1065,10 +1078,10 @@ export const getLinksForPublication = async (id: string) => {
                    l."publicationTo" "id",
                    "pfrom".type "childPublicationType",
                    "pto".type,
-                   "pto_latest_version".title,
-                   "pto_first_version"."createdBy",
-                   "pto_latest_version"."publishedDate",
-                   "pto_latest_version"."currentStatus",
+                   "pto_version".title,
+                   "pto_version"."createdBy",
+                   "pto_version"."publishedDate",
+                   "pto_version"."currentStatus",
                    "pto_user"."firstName" "authorFirstName",
                    "pto_user"."lastName" "authorLastName"
 
@@ -1082,16 +1095,12 @@ export const getLinksForPublication = async (id: string) => {
               LEFT JOIN "Publication" AS pto
               ON "pto".id = "l"."publicationTo"
 
-              LEFT JOIN "PublicationVersion" AS pto_latest_version
-              ON "pto".id = "pto_latest_version"."versionOf"
-              AND "pto_latest_version"."isLatestVersion" = 't'
-
-              LEFT JOIN "PublicationVersion" AS pto_first_version
-              ON "pto".id = "pto_first_version"."versionOf"
-              AND "pto_first_version"."versionNumber" = 1
+              LEFT JOIN "PublicationVersion" AS pto_version
+              ON "pto".id = "pto_version"."versionOf"
+              AND "pto_version"."isLatestLiveVersion" = TRUE
 
               LEFT JOIN "User" AS pto_user
-              ON "pto_first_version"."createdBy" = "pto_user"."id"
+              ON "pto_version"."createdBy" = "pto_user"."id"
         )
         
         SELECT * FROM to_left
@@ -1100,16 +1109,16 @@ export const getLinksForPublication = async (id: string) => {
             AND "currentStatus" = 'LIVE';
     `;
 
-    const linkedFrom: Links[] = await client.prisma.$queryRaw`
+    const linkedFrom = await client.prisma.$queryRaw<I.LinkedFromPublication[]>`
         WITH RECURSIVE to_right AS (
             SELECT "Links"."publicationFrom" "id",
                    "Links"."publicationTo" "parentPublication",
                    "pfrom".type,
                    "pto".type "parentPublicationType",
-                   "pfrom_latest_version"."title",
-                   "pfrom_first_version"."createdBy",
-                   "pfrom_latest_version"."publishedDate",
-                   "pfrom_latest_version"."currentStatus",
+                   "pfrom_version"."title",
+                   "pfrom_version"."createdBy",
+                   "pfrom_version"."publishedDate",
+                   "pfrom_version"."currentStatus",
                    "pfrom_user"."firstName" "authorFirstName",
                    "pfrom_user"."lastName" "authorLastName"
 
@@ -1117,19 +1126,15 @@ export const getLinksForPublication = async (id: string) => {
               LEFT JOIN "Publication" AS pfrom
               ON "pfrom".id = "Links"."publicationFrom"
 
-              LEFT JOIN "PublicationVersion" AS pfrom_latest_version
-              ON "pfrom".id = "pfrom_latest_version"."versionOf"
-              AND "pfrom_latest_version"."isLatestVersion" = 't'
-
-              LEFT JOIN "PublicationVersion" AS pfrom_first_version
-              ON "pfrom".id = "pfrom_first_version"."versionOf"
-              AND "pfrom_first_version"."versionNumber" = 1
+              LEFT JOIN "PublicationVersion" AS pfrom_version
+              ON "pfrom".id = "pfrom_version"."versionOf"
+              AND "pfrom_version"."isLatestVersion" = TRUE
 
               LEFT JOIN "Publication" AS pto
               ON "pto".id = "Links"."publicationTo"
 
               LEFT JOIN "User" AS pfrom_user
-              ON "pfrom_first_version"."createdBy" = "pfrom_user"."id"
+              ON "pfrom_version"."createdBy" = "pfrom_user"."id"
 
             WHERE "Links"."publicationTo" = ${id}
 
@@ -1139,10 +1144,10 @@ export const getLinksForPublication = async (id: string) => {
                    l."publicationTo" "parentPublication",
                    "pfrom".type,
                    "pto".type "parentPublicationType",
-                   "pfrom_latest_version"."title",
-                   "pfrom_first_version"."createdBy",
-                   "pfrom_latest_version"."publishedDate",
-                   "pfrom_latest_version"."currentStatus",
+                   "pfrom_version"."title",
+                   "pfrom_version"."createdBy",
+                   "pfrom_version"."publishedDate",
+                   "pfrom_version"."currentStatus",
                    "pfrom_user"."firstName" "authorFirstName",
                    "pfrom_user"."lastName" "authorLastName"
               FROM "Links" l
@@ -1152,19 +1157,15 @@ export const getLinksForPublication = async (id: string) => {
               LEFT JOIN "Publication" AS pfrom
               ON "pfrom".id = "l"."publicationFrom"
 
-              LEFT JOIN "PublicationVersion" AS pfrom_latest_version
-              ON "pfrom".id = "pfrom_latest_version"."versionOf"
-              AND "pfrom_latest_version"."isLatestVersion" = 't'
-
-              LEFT JOIN "PublicationVersion" AS pfrom_first_version
-              ON "pfrom".id = "pfrom_first_version"."versionOf"
-              AND "pfrom_first_version"."versionNumber" = 1
+              LEFT JOIN "PublicationVersion" AS pfrom_version
+              ON "pfrom".id = "pfrom_version"."versionOf"
+              AND "pfrom_version"."isLatestVersion" = TRUE
 
               LEFT JOIN "Publication" AS pto
               ON "pto".id = "l"."publicationTo"
 
               LEFT JOIN "User" AS pfrom_user
-              ON "pfrom_first_version"."createdBy" = "pfrom_user"."id"
+              ON "pfrom_version"."createdBy" = "pfrom_user"."id"
 
               WHERE "pto"."type" != 'PROBLEM'
         )
@@ -1175,62 +1176,75 @@ export const getLinksForPublication = async (id: string) => {
            AND "currentStatus" = 'LIVE';
     `;
 
-    const linkedPublications = await client.prisma.publication.findMany({
+    const publicationIds = linkedTo.map((link) => link.id).concat(linkedFrom.map((link) => link.id));
+
+    // get coAuthors for each latest LIVE version of each publication
+    const versions = await client.prisma.publicationVersion.findMany({
         where: {
-            id: {
-                in: linkedTo.map((link) => link.id).concat(linkedFrom.map((link) => link.id))
+            isLatestLiveVersion: true,
+            versionOf: {
+                in: publicationIds
             }
         },
         select: {
-            id: true,
-            versions: {
-                where: {
-                    isLatestVersion: true
-                },
-                include: {
-                    coAuthors: {
+            versionOf: true,
+            coAuthors: {
+                select: {
+                    id: true,
+                    linkedUser: true,
+                    user: {
                         select: {
-                            id: true,
-                            linkedUser: true,
-                            publicationVersionId: true,
-                            user: {
-                                select: {
-                                    orcid: true,
-                                    firstName: true,
-                                    lastName: true
-                                }
-                            }
-                        },
-                        orderBy: {
-                            position: 'asc'
+                            orcid: true,
+                            firstName: true,
+                            lastName: true
                         }
                     }
+                },
+                orderBy: {
+                    position: 'asc'
                 }
             }
-        },
-        orderBy: {
-            type: 'asc'
         }
     });
 
     // add authors to 'linkedTo' publications
     linkedTo.forEach((link) => {
+        const authors = versions.find((version) => version.versionOf === link.id)?.coAuthors || [];
+
         Object.assign(link, {
-            // This comes from the versions array, however we should only get one back because
-            // we are filtering it down to versions that have isLatestVersion = true. So we access it at [0].
-            authors: linkedPublications.find((publication) => publication.id === link.id)?.versions[0].coAuthors || []
+            authors
         });
     });
 
     // add authors to 'linkedFrom' publications
     linkedFrom.forEach((link) => {
+        const authors = versions.find((version) => version.versionOf === link.id)?.coAuthors || [];
+
         Object.assign(link, {
-            authors: linkedPublications.find((publication) => publication.id === link.id)?.versions[0].coAuthors || []
+            authors
         });
     });
 
     return {
-        publication,
+        publication: {
+            id: publication.id,
+            type: publication.type,
+            title: latestLiveVersion.title || '',
+            createdBy: latestLiveVersion.createdBy,
+            currentStatus: latestLiveVersion.currentStatus,
+            publishedDate: latestLiveVersion.publishedDate?.toISOString() || '',
+            authorFirstName: latestLiveVersion.user.firstName,
+            authorLastName: latestLiveVersion.user.lastName || '',
+            authors: latestLiveVersion.coAuthors.map((author) => ({
+                id: author.id,
+                linkedUser: author.linkedUser,
+                user: {
+                    orcid: author.user?.orcid || '',
+                    firstName: author.user?.firstName || '',
+                    lastName: author.user?.lastName || ''
+                }
+            }))
+        },
         linkedTo,
         linkedFrom
     };

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -5,7 +5,8 @@ import {
     PublicationFlagCategoryEnum,
     PublicationType,
     Role,
-    BookmarkType
+    BookmarkType,
+    PublicationStatusEnum
 } from '@prisma/client';
 import {
     APIGatewayProxyEventPathParameters,
@@ -174,6 +175,34 @@ export type PublicationVersion = Exclude<Prisma.PromiseReturnType<typeof publica
 export interface CreateLinkBody {
     to: string;
     from: string;
+}
+
+export interface Link {
+    id: string;
+    type: PublicationType;
+    title: string;
+    publishedDate: string;
+    currentStatus: PublicationStatusEnum;
+    createdBy: string;
+    authorFirstName: string;
+    authorLastName: string;
+    authors: Pick<CoAuthor, 'id' | 'linkedUser' | 'user'>[];
+}
+
+export interface LinkedToPublication extends Link {
+    childPublication: string;
+    childPublicationType: PublicationType;
+}
+
+export interface LinkedFromPublication extends Link {
+    parentPublication: string;
+    parentPublicationType: PublicationType;
+}
+
+export interface PublicationWithLinks {
+    publication: Link | null;
+    linkedTo: LinkedToPublication[];
+    linkedFrom: LinkedFromPublication[];
 }
 
 /**

--- a/ui/src/components/Publication/Visualization/index.tsx
+++ b/ui/src/components/Publication/Visualization/index.tsx
@@ -6,7 +6,6 @@ import * as Components from '@components';
 import * as Config from '@config';
 import * as Helpers from '@helpers';
 import * as Interfaces from '@interfaces';
-import * as Axios from 'axios';
 import * as Framer from 'framer-motion';
 
 interface BoxEntry {
@@ -17,7 +16,7 @@ interface BoxEntry {
     authorFirstName: string;
     authorLastName: string;
     publishedDate: string;
-    authors: Pick<Interfaces.CoAuthor, 'id' | 'linkedUser' | 'publicationId' | 'user'>[];
+    authors: Interfaces.Link['authors'];
     pointers: string[];
 }
 
@@ -130,9 +129,9 @@ const getPublicationsByType = (data: Interfaces.PublicationWithLinks, type: stri
             type: publication.type,
             createdBy: publication.createdBy,
             publishedDate: publication.publishedDate,
-            authorFirstName: publication.user.firstName,
-            authorLastName: publication.user.lastName,
-            authors: publication.coAuthors,
+            authorFirstName: publication.authorFirstName,
+            authorLastName: publication.authorLastName,
+            authors: publication.authors,
             pointers: linkedFrom
                 .filter(
                     (linkedPublication) =>

--- a/ui/src/lib/interfaces.ts
+++ b/ui/src/lib/interfaces.ts
@@ -90,10 +90,8 @@ export interface Publication extends CorePublication {
     topics: BaseTopic[];
 }
 
-export interface LinkedToPublication {
+export interface Link {
     id: string;
-    childPublication: string;
-    childPublicationType: Types.PublicationType;
     type: Types.PublicationType;
     title: string;
     publishedDate: string;
@@ -101,25 +99,21 @@ export interface LinkedToPublication {
     createdBy: string;
     authorFirstName: string;
     authorLastName: string;
-    authors: Pick<CoAuthor, 'id' | 'linkedUser' | 'publicationId' | 'user'>[];
+    authors: Pick<CoAuthor, 'id' | 'linkedUser' | 'user'>[];
 }
 
-export interface LinkedFromPublication {
-    id: string;
+export interface LinkedToPublication extends Link {
+    childPublication: string;
+    childPublicationType: Types.PublicationType;
+}
+
+export interface LinkedFromPublication extends Link {
     parentPublication: string;
-    type: Types.PublicationType;
     parentPublicationType: Types.PublicationType;
-    title: string;
-    publishedDate: string;
-    currentStatus: Types.PublicationStatuses;
-    createdBy: string;
-    authorFirstName: string;
-    authorLastName: string;
-    authors: Pick<CoAuthor, 'id' | 'linkedUser' | 'publicationId' | 'user'>[];
 }
 
 export interface PublicationWithLinks {
-    publication: Publication;
+    publication: Link;
     linkedTo: LinkedToPublication[];
     linkedFrom: LinkedFromPublication[];
 }


### PR DESCRIPTION
The purpose of this PR was to rework GET /publications/{id}/links endpoint used for visualisation so that it returns latest LIVE version of each link. Removed unnecessary fields like "content", "publicationStatus", etc from the response since they are not needed for Visualisation.
Had to do some minor changes on the UI in order to match with the endpoint response.

---

### Acceptance Criteria:

As per [OC-697](https://jiscdev.atlassian.net/browse/OC-697)

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

---

### Screenshots:

<img width="843" alt="image" src="https://github.com/JiscSD/octopus/assets/48569671/6482ee90-d1a5-4172-bb50-8dacd01a932f">



[OC-697]: https://jiscdev.atlassian.net/browse/OC-697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ