### PR TITLE
OC-711: Co-authors cannot accept invitations

### DIFF
--- a/api/src/components/coauthor/__tests__/createCoAuthor.test.ts
+++ b/api/src/components/coauthor/__tests__/createCoAuthor.test.ts
@@ -126,4 +126,27 @@ describe('create coauthor', () => {
 
         expect(coauthor.status).toEqual(403);
     });
+
+    test('Co-author email is converted to lower case on save', async () => {
+        await testUtils.agent
+            .put('/publications/publication-data-draft/coauthors')
+            .query({ apiKey: '123456789' })
+            .send([
+                {
+                    id: createId(),
+                    publicationId: 'publication-problem-draft',
+                    email: 'MULTIcaseAddress@emailtest.COM',
+                    linkedUser: null,
+                    approvalRequested: false,
+                    confirmedCoAuthor: false
+                }
+            ]);
+
+        const coAuthors = await testUtils.agent
+            .get('/publications/publication-data-draft/coauthors')
+            .query({ apiKey: '123456789' });
+
+        expect(coAuthors.body.length).toEqual(2); // corresponding author and this new one
+        expect(coAuthors.body[1]).toMatchObject({ email: 'multicaseaddress@emailtest.com' });
+    });
 });

--- a/api/src/components/coauthor/controller.ts
+++ b/api/src/components/coauthor/controller.ts
@@ -78,7 +78,9 @@ export const updateAll = async (
         const isDuplicate = authorEmails.some((coAuthor, index) => authorEmails.indexOf(coAuthor) != index);
 
         if (isDuplicate) {
-            return response.json(400, { message: 'Duplicate coAuthors' });
+            return response.json(400, {
+                message: 'Duplicate co-authors supplied. Make sure all email addresses are unique.'
+            });
         }
 
         const newCoAuthorsArray = event.body;
@@ -87,7 +89,7 @@ export const updateAll = async (
             (oldCoAuthor) => !newCoAuthorsArray.find((newCoAuthor) => oldCoAuthor.email === newCoAuthor.email)
         );
 
-        // check if corresponding author is trying to remove himself
+        // check if corresponding author is trying to remove themselves
         if (removedCoAuthors.some((author) => author.linkedUser === event.user.id)) {
             return response.json(403, {
                 message: 'You are not allowed to remove yourself from the publication.'

--- a/api/src/components/coauthor/service.ts
+++ b/api/src/components/coauthor/service.ts
@@ -83,7 +83,7 @@ export const updateAll = (publicationId: string, authors: I.CoAuthor[]) =>
                     publicationId_email: { publicationId, email: author.email }
                 },
                 create: {
-                    email: author.email,
+                    email: author.email.toLowerCase(),
                     approvalRequested: false,
                     confirmedCoAuthor: false,
                     publicationId,

--- a/ui/src/components/Publication/Creation/CoAuthor.tsx
+++ b/ui/src/components/Publication/Creation/CoAuthor.tsx
@@ -83,7 +83,7 @@ const CoAuthor: React.FC = (): React.ReactElement => {
     const [loading, setLoading] = React.useState(false);
     const [coAuthor, setCoAuthor] = React.useState('');
     const [emailValidated, setEmailValidated] = React.useState(true);
-    const [emailDuplicated, SetEmailDuplicated] = React.useState(true);
+    const [emailDuplicated, setEmailDuplicated] = React.useState(false);
     const [isMounted, setIsMounted] = useState(false);
 
     useEffect(() => {
@@ -104,8 +104,8 @@ const CoAuthor: React.FC = (): React.ReactElement => {
 
     const handleEmailChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
         setEmailValidated(true);
-        SetEmailDuplicated(true);
-        setCoAuthor(event.target.value?.trim());
+        setEmailDuplicated(false);
+        setCoAuthor(event.target.value);
     };
 
     // Validate email for co author regex to use -
@@ -115,14 +115,15 @@ const CoAuthor: React.FC = (): React.ReactElement => {
         const authorsArray = coAuthors || [];
 
         // check to ensure co-author email is not already in the store/database
-        const emailDuplicate = authorsArray.some((author) => author.email.toLowerCase() === coAuthor.toLowerCase());
+        const coAuthorEmail = coAuthor.trim().toLowerCase();
+        const emailDuplicate = authorsArray.some((author) => author.email.toLowerCase() === coAuthorEmail);
         if (emailDuplicate) {
-            SetEmailDuplicated(false);
+            setEmailDuplicated(true);
             setLoading(false);
             return;
         }
 
-        const validEmail = Helpers.validateEmail(coAuthor);
+        const validEmail = Helpers.validateEmail(coAuthorEmail);
 
         if (!validEmail) {
             setEmailValidated(false);
@@ -135,7 +136,7 @@ const CoAuthor: React.FC = (): React.ReactElement => {
         const newAuthor = {
             id: createId(),
             publicationId: publicationId,
-            email: coAuthor,
+            email: coAuthorEmail,
             linkedUser: null,
             approvalRequested: false,
             confirmedCoAuthor: false,
@@ -216,7 +217,7 @@ const CoAuthor: React.FC = (): React.ReactElement => {
                         className="mt-3 w-2/3"
                     />
                 )}
-                {!emailDuplicated && (
+                {emailDuplicated && (
                     <Components.Alert
                         data-testid="email-error"
                         severity="ERROR"


### PR DESCRIPTION
The purpose of this PR was to ensure that co-authors' email addresses are saved in lower case to prevent situations where their email from their account (always lower case) is checked against the saved email (potentially mixed case) and incorrectly judged to be different.

Also included a few minor tweaks - the main one was changing the emailDuplicated state variable during coauthor creation so that it's true when there is a duplicate email, which makes more sense.

---

### Acceptance Criteria:

We should always store emails in a lowercase format.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI:
<img width="407" alt="Screenshot 2023-10-04 082834" src="https://github.com/JiscSD/octopus/assets/132363734/ad9010e3-d2f1-4f30-9471-85e8059058d6">

E2E:
<img width="120" alt="Screenshot 2023-10-03 163030" src="https://github.com/JiscSD/octopus/assets/132363734/6f13737a-611d-4a51-8129-5eefed8d326e">

API:
<img width="157" alt="Screenshot 2023-10-04 083946" src="https://github.com/JiscSD/octopus/assets/132363734/bb55b867-a5c7-47cd-864b-0e2aecd83271">
