### PR TITLE
OC-638: Hide "Write a linked publication" option on all draft publications

### DIFF
--- a/ui/src/components/Publication/SidebarCard/Actions/index.tsx
+++ b/ui/src/components/Publication/SidebarCard/Actions/index.tsx
@@ -144,111 +144,116 @@ const Actions: React.FC<ActionProps> = (props): React.ReactElement => {
                 </>
             </Components.Modal>
 
-            <Components.SectioBreak name="Actions" />
-
-            {/** Download options */}
             {props.publication.currentStatus === 'LIVE' && (
-                <div className="flex">
-                    <span className="mr-2 text-sm font-semibold text-grey-800 transition-colors duration-500 dark:text-grey-50">
-                        Download:
-                    </span>
-                    <button
-                        aria-label="Print"
-                        onClick={() => {
-                            window.open(
-                                `${Config.endpoints.publications}/${props.publication.id}/pdf?redirectToPreview=true`,
-                                '_blank'
-                            );
-                        }}
-                        className="mr-4 flex items-center rounded border-transparent text-right text-sm font-medium text-teal-600 outline-0 transition-colors duration-500 hover:underline focus:overflow-hidden focus:ring-2 focus:ring-yellow-400 dark:text-teal-400"
-                    >
-                        <Image src="/images/pdf.svg" alt="PDF Icon" width={18} height={18} />
-                        <span className="ml-1">pdf</span>
-                    </button>
-                    <button
-                        aria-label="Download JSON"
-                        onClick={() =>
-                            Helpers.blobFileDownload(
-                                `${Config.endpoints.publications}/${props.publication.id}`,
-                                `${props.publication.id}.json`
-                            )
-                        }
-                        className="mr-4 flex items-center rounded border-transparent text-right text-sm font-medium text-teal-600 outline-0 transition-colors duration-500 hover:underline focus:overflow-hidden focus:ring-2 focus:ring-yellow-400 dark:text-teal-400"
-                    >
-                        <Image src="/images/json.svg" alt="PDF Icon" width={18} height={18} />
-                        <span className="ml-1">json</span>
-                    </button>
-                </div>
-            )}
-            {user && user.email ? (
                 <>
-                    {/* if the publication is a peer review, no options shall be given to write a linked publication */}
-                    {props.publication.type !== 'PEER_REVIEW' && (
-                        <>
-                            {Helpers.linkedPublicationTypes[
-                                props.publication.type as keyof typeof Helpers.linkedPublicationTypes
-                            ].map((item: any) => {
-                                return (
-                                    <Components.PublicationSidebarCardActionsButton
-                                        label={`Write a linked ${Helpers.formatPublicationType(item)}`}
-                                        key={item}
-                                        onClick={() => {
-                                            router.push({
-                                                pathname: `${Config.urls.createPublication.path}`,
-                                                query: {
-                                                    for: props.publication.id,
-                                                    type: item
-                                                }
-                                            });
-                                        }}
-                                    />
+                    <Components.SectionBreak name="Actions" />
+                    {/** Download options */}
+                    <div className="flex">
+                        <span className="mr-2 text-sm font-semibold text-grey-800 transition-colors duration-500 dark:text-grey-50">
+                            Download:
+                        </span>
+                        <button
+                            aria-label="Print"
+                            onClick={() => {
+                                window.open(
+                                    `${Config.endpoints.publications}/${props.publication.id}/pdf?redirectToPreview=true`,
+                                    '_blank'
                                 );
-                            })}
-                            {props.publication.user.id !== user.id && (
+                            }}
+                            className="mr-4 flex items-center rounded border-transparent text-right text-sm font-medium text-teal-600 outline-0 transition-colors duration-500 hover:underline focus:overflow-hidden focus:ring-2 focus:ring-yellow-400 dark:text-teal-400"
+                        >
+                            <Image src="/images/pdf.svg" alt="PDF Icon" width={18} height={18} />
+                            <span className="ml-1">pdf</span>
+                        </button>
+                        <button
+                            aria-label="Download JSON"
+                            onClick={() =>
+                                Helpers.blobFileDownload(
+                                    `${Config.endpoints.publications}/${props.publication.id}`,
+                                    `${props.publication.id}.json`
+                                )
+                            }
+                            className="mr-4 flex items-center rounded border-transparent text-right text-sm font-medium text-teal-600 outline-0 transition-colors duration-500 hover:underline focus:overflow-hidden focus:ring-2 focus:ring-yellow-400 dark:text-teal-400"
+                        >
+                            <Image src="/images/json.svg" alt="PDF Icon" width={18} height={18} />
+                            <span className="ml-1">json</span>
+                        </button>
+                    </div>
+                    {user && user.email ? (
+                        <>
+                            {/* if the publication is a peer review, no options shall be given to write a linked publication */}
+                            {props.publication.type !== 'PEER_REVIEW' && (
                                 <>
-                                    <Components.PublicationSidebarCardActionsButton
-                                        label="Write a review"
-                                        onClick={() => {
-                                            router.push({
-                                                pathname: `${Config.urls.createPublication.path}`,
-                                                query: {
-                                                    for: props.publication.id,
-                                                    type: 'PEER_REVIEW'
-                                                }
-                                            });
-                                        }}
-                                    />
-                                    <Components.PublicationSidebarCardActionsButton
-                                        label="Flag a concern with this publication"
-                                        onClick={() => setShowRedFlagModel(true)}
-                                    />
+                                    {Helpers.linkedPublicationTypes[
+                                        props.publication.type as keyof typeof Helpers.linkedPublicationTypes
+                                    ].map((item: any) => {
+                                        return (
+                                            <Components.PublicationSidebarCardActionsButton
+                                                label={`Write a linked ${Helpers.formatPublicationType(item)}`}
+                                                key={item}
+                                                onClick={() => {
+                                                    router.push({
+                                                        pathname: `${Config.urls.createPublication.path}`,
+                                                        query: {
+                                                            for: props.publication.id,
+                                                            type: item
+                                                        }
+                                                    });
+                                                }}
+                                            />
+                                        );
+                                    })}
+                                    {props.publication.user.id !== user.id && (
+                                        <>
+                                            <Components.PublicationSidebarCardActionsButton
+                                                label="Write a review"
+                                                onClick={() => {
+                                                    router.push({
+                                                        pathname: `${Config.urls.createPublication.path}`,
+                                                        query: {
+                                                            for: props.publication.id,
+                                                            type: 'PEER_REVIEW'
+                                                        }
+                                                    });
+                                                }}
+                                            />
+                                            <Components.PublicationSidebarCardActionsButton
+                                                label="Flag a concern with this publication"
+                                                onClick={() => setShowRedFlagModel(true)}
+                                            />
+                                        </>
+                                    )}
                                 </>
                             )}
                         </>
+                    ) : user && !user.email ? (
+                        <>
+                            <Components.Link
+                                href={`${Config.urls.verify.path}?state=${encodeURIComponent(
+                                    `${Config.urls.viewPublication.path}/${props.publication.id}`
+                                )}`}
+                                className="flex items-center rounded border-transparent text-sm font-medium text-teal-600 outline-0 transition-colors duration-500 hover:underline focus:overflow-hidden focus:ring-2 focus:ring-yellow-400 dark:text-teal-400"
+                            >
+                                Verify your email for more actions
+                            </Components.Link>
+                        </>
+                    ) : (
+                        <>
+                            <Components.Link
+                                href={`${Config.urls.orcidLogin.path}&state=${encodeURIComponent(
+                                    `${Config.urls.viewPublication.path}/${props.publication.id}`
+                                )}`}
+                                className="flex items-center rounded border-transparent text-sm font-medium text-teal-600 outline-0 transition-colors duration-500 hover:underline focus:overflow-hidden focus:ring-2 focus:ring-yellow-400 dark:text-teal-400"
+                            >
+                                <Assets.ORCID
+                                    width={25}
+                                    height={25}
+                                    className="mr-2 rounded-md bg-orcid fill-white-50 p-1"
+                                />
+                                <span> Sign in for more actions</span>
+                            </Components.Link>
+                        </>
                     )}
-                </>
-            ) : user && !user.email ? (
-                <>
-                    <Components.Link
-                        href={`${Config.urls.verify.path}?state=${encodeURIComponent(
-                            `${Config.urls.viewPublication.path}/${props.publication.id}`
-                        )}`}
-                        className="flex items-center rounded border-transparent text-sm font-medium text-teal-600 outline-0 transition-colors duration-500 hover:underline focus:overflow-hidden focus:ring-2 focus:ring-yellow-400 dark:text-teal-400"
-                    >
-                        Verify your email for more actions
-                    </Components.Link>
-                </>
-            ) : (
-                <>
-                    <Components.Link
-                        href={`${Config.urls.orcidLogin.path}&state=${encodeURIComponent(
-                            `${Config.urls.viewPublication.path}/${props.publication.id}`
-                        )}`}
-                        className="flex items-center rounded border-transparent text-sm font-medium text-teal-600 outline-0 transition-colors duration-500 hover:underline focus:overflow-hidden focus:ring-2 focus:ring-yellow-400 dark:text-teal-400"
-                    >
-                        <Assets.ORCID width={25} height={25} className="mr-2 rounded-md bg-orcid fill-white-50 p-1" />
-                        <span> Sign in for more actions</span>
-                    </Components.Link>
                 </>
             )}
         </>

--- a/ui/src/components/Publication/SidebarCard/Sections/index.tsx
+++ b/ui/src/components/Publication/SidebarCard/Sections/index.tsx
@@ -8,7 +8,7 @@ type Props = {
 
 const Sections: React.FC<Props> = (props): React.ReactElement => (
     <>
-        <Components.SectioBreak name="Sections" />
+        <Components.SectionBreak name="Sections" />
         {!!props.sectionList && (
             <div className="space-y-2">
                 {props.sectionList.map((section) => (

--- a/ui/src/components/index.tsx
+++ b/ui/src/components/index.tsx
@@ -72,7 +72,7 @@ export { default as ScrollToTop } from './ScrollToTop';
 export { default as Search } from './SearchToggle';
 export { default as SearchDesktop } from './SearchToggle/Desktop';
 export { default as SearchMobile } from './SearchToggle/Mobile';
-export { default as SectioBreak } from './SectionBreak';
+export { default as SectionBreak } from './SectionBreak';
 export { default as SurveyWidget } from './SurveyWidget';
 export { default as Tabs } from './Tabs';
 export { default as TextEditor } from './TextEditor';


### PR DESCRIPTION
The purpose of this PR was to remove the "Write a linked {publication type}" from the /publications/{id} page when the publication status is DRAFT. Going by the reasoning in the item I have used a slightly different condition - where status is not LIVE, as we wouldn't want these options to show on LOCKED publications either.

I haven't changed the API as that already prevents links from being saved where the publication being linked to is not LIVE.

---

### Acceptance Criteria:

As per [OC-638](https://jiscdev.atlassian.net/browse/OC-638)

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI:
<img width="396" alt="Screenshot 2023-10-04 114620" src="https://github.com/JiscSD/octopus/assets/132363734/0c58e1ca-e6b5-4093-be01-63ac08311d82">

E2E:
<img width="126" alt="Screenshot 2023-10-04 125319" src="https://github.com/JiscSD/octopus/assets/132363734/88cfffa3-0266-42ec-a05e-e17312857095">

---

### Screenshots:

The Actions section of the sidebar isn't shown when the publication isn't LIVE.

<img width="259" alt="Screenshot 2023-10-04 132112" src="https://github.com/JiscSD/octopus/assets/132363734/68cf07dc-a850-47da-a95b-7be2d5a61f86">



[OC-638]: https://jiscdev.atlassian.net/browse/OC-638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ