### PR TITLE
OC-75: Preview link candidate details on hover

### DIFF
--- a/ui/src/components/Publication/Creation/LinkedItems/LinkedPublicationsCombobox.tsx
+++ b/ui/src/components/Publication/Creation/LinkedItems/LinkedPublicationsCombobox.tsx
@@ -125,6 +125,11 @@ const LinkedPublicationsCombobox: React.FC<LinkedPublicationsComboboxProps> = (p
                                     } ${index === 0 && 'rounded-t'} ${index === results.length - 1 && 'rounded-b'}`
                                 }
                                 value={publicationVersion}
+                                title={
+                                    publicationVersion.content
+                                        ? Helpers.truncateString(Helpers.htmlToText(publicationVersion.content), 220)
+                                        : ''
+                                }
                             >
                                 <div className="space-y-2">
                                     <span className="font-montserrat text-sm font-medium text-teal-600">


### PR DESCRIPTION
The purpose of this PR was to add a way to show more information about a publication to the user when they are considering whether to link to it, and perhaps the title alone is not enough information.

---

### Acceptance Criteria:

As per [OC-75](https://jiscdev.atlassian.net/browse/OC-75)

Note: although this solution doesn't show the preview on focus, it shows on hover and is available to assistive technologies on focus, so agreed with PO that this is a fair compromise in order to achieve this with a neat + standard solution as opposed to something complex and homebrew.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI:
<img width="265" alt="image" src="https://github.com/JiscSD/octopus/assets/132363734/263f85c2-e0b8-4175-82a9-3575c2ed3166">

E2E:
<img width="134" alt="Screenshot 2023-10-13 120800" src="https://github.com/JiscSD/octopus/assets/132363734/13871f1a-8a7b-467f-b943-5949174d94c1">



[OC-75]: https://jiscdev.atlassian.net/browse/OC-75?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ