### PR TITLE
OC-153 Co-authors changing their mind triggers "denied involvement" email

### DIFF
--- a/api/src/components/coauthor/controller.ts
+++ b/api/src/components/coauthor/controller.ts
@@ -348,14 +348,13 @@ export const updateConfirmation = async (
                     version.coAuthors.filter((coAuthor) => !coAuthor.confirmedCoAuthor).length - 1
             });
         } else {
-            // notify main author about rejection
-            await email.notifyCoAuthorRejection({
-                coAuthor: {
-                    email: event.user.email || ''
-                },
+            // notify corresponding author about cancelled approval
+            await email.notifyCoAuthorCancelledApproval({
                 publication: {
+                    id: version.versionOf,
                     title: version.title || '',
-                    authorEmail: version.user.email || ''
+                    authorEmail: version.user.email || '',
+                    url: `${process.env.BASE_URL}/publications/${version.versionOf}`
                 }
             });
         }

--- a/api/src/lib/email.ts
+++ b/api/src/lib/email.ts
@@ -647,3 +647,31 @@ export const notifyCoAuthorsAboutChanges = async (options: NotifyCoAuthorsAboutC
         subject: 'Changes have been made to a publication that you are an author on'
     });
 };
+
+type NotifyCoAuthorCancelledApproval = {
+    publication: {
+        id: string;
+        title: string;
+        authorEmail: string;
+        url: string;
+    };
+};
+
+export const notifyCoAuthorCancelledApproval = async (options: NotifyCoAuthorCancelledApproval): Promise<void> => {
+    const html = `
+                <p>A co-author had previously approved your publication, <strong><i>${options.publication.title}</i></strong>, but has now changed their mind, indicating that changes might be needed.</p>
+                <br>
+                <p style="text-align: center;"><a style="${styles.button}" href="${options.publication.url}">View publication</a></p>
+                <br>
+                <p>This author’s approval is required before publishing. Please discuss whether any further changes are needed with the author.</p>
+            `;
+
+    const text = `A co-author had previously approved your publication, ${options.publication.title}, but has now changed their mind, indicating that changes might be needed. You can view the publication following this link: ${options.publication.url}. This author’s approval is required before publishing. Please discuss whether any further changes are needed with the author.`;
+
+    await send({
+        html: standardHTMLEmailTemplate('A co-author has cancelled their approval', html),
+        text,
+        to: options.publication.authorEmail,
+        subject: 'A co-author has cancelled their approval'
+    });
+};


### PR DESCRIPTION
The purpose of this PR was to add a new notification type when co-authors cancel their approvals after they approved initially.

---

### Acceptance Criteria:

As per [OC-153](https://jiscdev.atlassian.net/browse/OC-153)

---

### Checklist:

- [x] Local manual testing conducted

---

### Tests:

---

### Screenshots:
<img width="1252" alt="image" src="https://github.com/JiscSD/octopus/assets/48569671/011d72cd-6a64-416b-b04d-ab191c4a90eb">


[OC-153]: https://jiscdev.atlassian.net/browse/OC-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ