### PR TITLE
OC-633: Change error message when users raise a duplicate red flag

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -22,6 +22,7 @@ RUN mkdir /root/.aws && echo '[octopus-docker]\naws_access_key_id=setkey\naws_se
 RUN mkdir -p /app
 WORKDIR /app
 COPY package.json /app
+COPY package-lock.json /app
 
 # Only npm install if we're not using act or GH Actions (where we cache)
 # ARG RUNNER

--- a/api/src/components/flag/controller.ts
+++ b/api/src/components/flag/controller.ts
@@ -81,7 +81,7 @@ export const createFlag = async (
 
         if (doesDuplicateFlagExist) {
             return response.json(400, {
-                message: 'An unresolved flag created by you, for this publication and category already exists.'
+                message: 'An unresolved flag created by you for this publication and category already exists.'
             });
         }
 

--- a/ui/src/components/ApprovalsTracker/index.tsx
+++ b/ui/src/components/ApprovalsTracker/index.tsx
@@ -218,7 +218,12 @@ const ApprovalsTracker: React.FC<Props> = (props): React.ReactElement => {
                                     </td>
                                     <td className="whitespace-nowrap px-6 py-4  text-sm text-grey-900 duration-500 dark:text-white-50">
                                         {isCorrespondingUser && !author.linkedUser && author.reminderDate ? (
-                                            <>Reminder sent at {Helpers.formatDateTime(author.reminderDate, 'short')}</>
+                                            <>
+                                                Reminder sent at{' '}
+                                                <time suppressHydrationWarning>
+                                                    {Helpers.formatDateTime(author.reminderDate, 'short')}
+                                                </time>
+                                            </>
                                         ) : author.linkedUser === props.publicationVersion.createdBy ? (
                                             <>Corresponding author</>
                                         ) : author.confirmedCoAuthor ? (

--- a/ui/src/components/BlogCard/index.tsx
+++ b/ui/src/components/BlogCard/index.tsx
@@ -21,7 +21,7 @@ const BlogCard: React.FC<Props> = (props) => {
                     {shortBlogText}
                 </div>
                 <p className="blog-card-footer text-xs font-medium tracking-wide text-grey-800 transition-colors dark:text-grey-100">
-                    By {props.author} | {Helpers.formatDate(props.publishedDate)}
+                    By {props.author} | <time suppressHydrationWarning>{Helpers.formatDate(props.publishedDate)}</time>
                 </p>
             </div>
         </div>

--- a/ui/src/components/Flag/Comment/index.tsx
+++ b/ui/src/components/Flag/Comment/index.tsx
@@ -22,7 +22,7 @@ const Comment: React.FC<Props> = (props): React.ReactElement => (
                 {props.flagComment.user.firstName} {props.flagComment.user.lastName}
             </span>
             <span className="block text-xs text-grey-500 transition-colors duration-500 group-hover:underline dark:text-white-100">
-                Posted: {Helpers.formatDate(props.flagComment.createdAt)}
+                Posted: <time suppressHydrationWarning>{Helpers.formatDate(props.flagComment.createdAt)}</time>
             </span>
         </Components.Link>
         <div className="col-span-12 lg:col-span-8">

--- a/ui/src/components/Flag/Preview/index.tsx
+++ b/ui/src/components/Flag/Preview/index.tsx
@@ -33,7 +33,7 @@ const Preview: React.FC<Props> = (props) => (
         </span>
         <span className="ml-6 text-sm text-grey-600 transition-colors duration-500 dark:text-grey-100">
             Flagged by {props.flag.user.firstName} {props.flag.user.lastName},{' '}
-            {Helpers.formatDate(props.flag.createdAt)}
+            <time suppressHydrationWarning>{Helpers.formatDate(props.flag.createdAt)}</time>
         </span>
     </Components.Link>
 );

--- a/ui/src/components/PageSubTitle/index.tsx
+++ b/ui/src/components/PageSubTitle/index.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 type Props = {
     text: string;
     className?: string;
+    suppressHydrationWarning?: boolean;
 };
 
 const PageSubTitle: React.FC<Props> = (props): React.ReactElement => (
@@ -10,6 +11,7 @@ const PageSubTitle: React.FC<Props> = (props): React.ReactElement => (
         className={`mx-auto mb-8 block font-montserrat text-3xl font-bold text-grey-900 transition-colors duration-500 dark:text-grey-100 ${
             props.className ?? ''
         }`}
+        suppressHydrationWarning={props.suppressHydrationWarning}
     >
         {props.text}
     </h2>

--- a/ui/src/components/Publication/BookmarkedPublications/index.tsx
+++ b/ui/src/components/Publication/BookmarkedPublications/index.tsx
@@ -36,11 +36,17 @@ const BookmarkedPublications: React.FC<Props> = (props): React.ReactElement => {
                             </span>
                             {props.publication.publishedDate ? (
                                 <span className="text-xs leading-3 text-grey-600 transition-colors duration-500 dark:text-grey-100 ">
-                                    Published: {Helpers.formatDate(props.publication.publishedDate)}
+                                    Published:{' '}
+                                    <time suppressHydrationWarning>
+                                        {Helpers.formatDate(props.publication.publishedDate)}
+                                    </time>
                                 </span>
                             ) : (
                                 <span className="text-xs leading-3 text-grey-600 transition-colors duration-500 dark:text-grey-100 ">
-                                    Last updated: {Helpers.formatDate(props.publication.updatedAt)}
+                                    Last updated:{' '}
+                                    <time suppressHydrationWarning>
+                                        {Helpers.formatDate(props.publication.updatedAt)}
+                                    </time>
                                 </span>
                             )}
                         </div>

--- a/ui/src/components/Publication/Creation/LinkedItems/LinkedPublicationRow.tsx
+++ b/ui/src/components/Publication/Creation/LinkedItems/LinkedPublicationRow.tsx
@@ -27,9 +27,12 @@ const LinkedPublicationRow: React.FC<Props> = (props): React.ReactElement => {
                         {props.linkedPublication.title}
                     </p>
                     <div className="flex items-center space-x-2">
-                        <span className="text-xs text-grey-700 transition-colors duration-500 dark:text-white-100">
+                        <time
+                            className="text-xs text-grey-700 transition-colors duration-500 dark:text-white-100"
+                            suppressHydrationWarning
+                        >
                             {Helpers.formatDate(props.linkedPublication.publishedDate)},
-                        </span>
+                        </time>
                         <span className="text-sm text-grey-700 transition-colors duration-500 dark:text-white-100">
                             {props.linkedPublication.authorFirstName[0]}. {props.linkedPublication.authorLastName}
                         </span>

--- a/ui/src/components/Publication/Creation/LinkedItems/LinkedPublicationsCombobox.tsx
+++ b/ui/src/components/Publication/Creation/LinkedItems/LinkedPublicationsCombobox.tsx
@@ -133,8 +133,11 @@ const LinkedPublicationsCombobox: React.FC<LinkedPublicationsComboboxProps> = (p
                                     <p className="text-grey-800">{publicationVersion.title}</p>
                                     <div className="flex items-center space-x-2">
                                         <span className="text-xs text-grey-700">
-                                            {publicationVersion.publishedDate &&
-                                                Helpers.formatDate(publicationVersion.publishedDate)}
+                                            {publicationVersion.publishedDate && (
+                                                <time suppressHydrationWarning>
+                                                    {Helpers.formatDate(publicationVersion.publishedDate)}
+                                                </time>
+                                            )}
                                             ,
                                         </span>
                                         <span className="text-sm text-grey-700">

--- a/ui/src/components/Publication/SidebarCard/Actions/index.tsx
+++ b/ui/src/components/Publication/SidebarCard/Actions/index.tsx
@@ -12,6 +12,8 @@ import * as Assets from '@assets';
 import * as Types from '@types';
 import * as api from '@api';
 
+import axios from 'axios';
+
 type ActionProps = {
     publicationVersion: Interfaces.PublicationVersion;
 };
@@ -68,7 +70,11 @@ const Actions: React.FC<ActionProps> = (props): React.ReactElement => {
             }
         } catch (err) {
             const { message } = err as Interfaces.JSONResponseError;
-            setError(message);
+            setError(
+                axios.isAxiosError(err) && typeof err.response?.data?.message === 'string'
+                    ? err.response.data.message
+                    : message
+            );
         }
         setSubmitting(false);
     };

--- a/ui/src/components/Publication/SimpleResult/index.tsx
+++ b/ui/src/components/Publication/SimpleResult/index.tsx
@@ -42,11 +42,17 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
                     </span>
                     {props.publicationVersion.publishedDate ? (
                         <span className="text-xs leading-3 text-grey-600 transition-colors duration-500 dark:text-grey-100 ">
-                            Published: {Helpers.formatDate(props.publicationVersion.publishedDate)}
+                            Published:{' '}
+                            <time suppressHydrationWarning>
+                                {Helpers.formatDate(props.publicationVersion.publishedDate)}
+                            </time>
                         </span>
                     ) : (
                         <span className="text-xs leading-3 text-grey-600 transition-colors duration-500 dark:text-grey-100 ">
-                            Last updated: {Helpers.formatDate(props.publicationVersion.updatedAt)}
+                            Last updated:{' '}
+                            <time suppressHydrationWarning>
+                                {Helpers.formatDate(props.publicationVersion.updatedAt)}
+                            </time>
                         </span>
                     )}
                 </div>

--- a/ui/src/pages/blog/[slug].tsx
+++ b/ui/src/pages/blog/[slug].tsx
@@ -177,7 +177,8 @@ type Props = {
 
 const IndividualBlogPage: NextPage<Props> = (props) => {
     const router = useRouter();
-    const { title, author, content, publishedDate } = props.blog.fields;
+    const { title, author, content } = props.blog.fields;
+    const [publishedDate, setPublishedDate] = React.useState(String(props.blog.fields.publishedDate));
 
     const { canGoBack } = router.query as { canGoBack: string };
 
@@ -186,6 +187,13 @@ const IndividualBlogPage: NextPage<Props> = (props) => {
     }, [content]);
 
     const pageTitle = `${title} - ${Config.urls.base.title}`;
+
+    // This is required to ensure that we don't encounter hydration errors when we format the published
+    // date on the client. Normally we use suppressHydrationWarning but that only works one level down,
+    // and we're passing the value to a subcomponent.
+    React.useEffect(() => {
+        setPublishedDate(Helpers.formatDate(props.blog.fields.publishedDate));
+    }, [props.blog.fields.publishedDate]);
 
     return (
         <>
@@ -211,7 +219,7 @@ const IndividualBlogPage: NextPage<Props> = (props) => {
                             <Components.PageTitle text={title} className="!mb-4" />
                             <Components.PageSubTitle
                                 className="text-base font-medium"
-                                text={`Written by ${author} on ${Helpers.formatDate(publishedDate)}`}
+                                text={`Written by ${author} on ${publishedDate}`}
                             />
                             <div className="dark:text-white-50">
                                 {documentToReactComponents(content, renderOptions)}

--- a/ui/src/pages/blog/[slug].tsx
+++ b/ui/src/pages/blog/[slug].tsx
@@ -177,8 +177,7 @@ type Props = {
 
 const IndividualBlogPage: NextPage<Props> = (props) => {
     const router = useRouter();
-    const { title, author, content } = props.blog.fields;
-    const [publishedDate, setPublishedDate] = React.useState(String(props.blog.fields.publishedDate));
+    const { title, author, content, publishedDate } = props.blog.fields;
 
     const { canGoBack } = router.query as { canGoBack: string };
 
@@ -187,13 +186,6 @@ const IndividualBlogPage: NextPage<Props> = (props) => {
     }, [content]);
 
     const pageTitle = `${title} - ${Config.urls.base.title}`;
-
-    // This is required to ensure that we don't encounter hydration errors when we format the published
-    // date on the client. Normally we use suppressHydrationWarning but that only works one level down,
-    // and we're passing the value to a subcomponent.
-    React.useEffect(() => {
-        setPublishedDate(Helpers.formatDate(props.blog.fields.publishedDate));
-    }, [props.blog.fields.publishedDate]);
 
     return (
         <>
@@ -219,7 +211,8 @@ const IndividualBlogPage: NextPage<Props> = (props) => {
                             <Components.PageTitle text={title} className="!mb-4" />
                             <Components.PageSubTitle
                                 className="text-base font-medium"
-                                text={`Written by ${author} on ${publishedDate}`}
+                                text={`Written by ${author} on ${Helpers.formatDate(publishedDate)}`}
+                                suppressHydrationWarning
                             />
                             <div className="dark:text-white-50">
                                 {documentToReactComponents(content, renderOptions)}

--- a/ui/src/pages/publications/[id]/flag/[flagId]/index.tsx
+++ b/ui/src/pages/publications/[id]/flag/[flagId]/index.tsx
@@ -230,7 +230,10 @@ const FlagThread: Next.NextPage<Props> = (props): JSX.Element => {
 
                                     <p className="text-grey-700 transition-colors duration-500 dark:text-grey-100">
                                         This publication was red flagged on{' '}
-                                        <span className="italic">{Helpers.formatDate(data.createdAt)}</span>, by{' '}
+                                        <time className="italic" suppressHydrationWarning>
+                                            {Helpers.formatDate(data.createdAt)}
+                                        </time>
+                                        , by{' '}
                                         <Components.Link
                                             href={`${Config.urls.viewUser.path}/${data.user.id}`}
                                             className="text-teal-500 underline"


### PR DESCRIPTION
The purpose of this PR was to display an informative error message when the user attempts to create a flag that they have already created one of the same type for on the current publication. The API was already sending a message but the UI was not set up to display it.

I ran into a hydration error while working on this so made some adjustments to prevent these wherever we are using dates/times formatted with toLocaleString().

---

### Acceptance Criteria:

As per [OC-633](https://jiscdev.atlassian.net/browse/OC-633).

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

E2E:
<img width="125" alt="Screenshot 2023-10-17 111949" src="https://github.com/JiscSD/octopus/assets/132363734/39d10f92-17c7-4193-8213-ab71feb3ac73">

UI:
<img width="283" alt="Screenshot 2023-10-16 160636" src="https://github.com/JiscSD/octopus/assets/132363734/417ab025-65cc-4f75-9aa1-f2f058f92b26">

API:
<img width="164" alt="Screenshot 2023-10-16 161202" src="https://github.com/JiscSD/octopus/assets/132363734/772a0214-9a2f-4515-bc15-47b85c030522">

---

### Screenshots:

<img width="403" alt="Screenshot 2023-10-17 112923" src="https://github.com/JiscSD/octopus/assets/132363734/3e8614ca-e46a-42b2-adf2-b37e68d209c8">


[OC-633]: https://jiscdev.atlassian.net/browse/OC-633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ