### PR TITLE
OC-724 Investigate & fix github actions/api tests failing

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -22,6 +22,7 @@ RUN mkdir /root/.aws && echo '[octopus-docker]\naws_access_key_id=setkey\naws_se
 RUN mkdir -p /app
 WORKDIR /app
 COPY package.json /app
+COPY package-lock.json /app
 
 # Only npm install if we're not using act or GH Actions (where we cache)
 # ARG RUNNER


### PR DESCRIPTION
The purpose of this PR was to fix api tests not running on Github Actions.

It seems in the /api/Dockerfile we just copied package.json and run "npm i" when creating a new docker image. That means we ended up installing different dependencies versions locally vs Github actions and typescript was throwing a Type Error in /lib/sqs.ts

---

### Acceptance Criteria:

- API tests running without issues on Github Actions

---

### Checklist:

- [x] Local manual testing conducted

---

### Tests:

---

### Screenshots:
