### PR TITLE
OC-726 Some users are unable to load affiliations

### DIFF
--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -1096,7 +1096,10 @@ export const mapOrcidAffiliationSummary = (
     organization: summary.organization,
     createdAt: summary['created-date'].value,
     updatedAt: summary['last-modified-date'].value,
-    source: { name: summary.source['source-name'].value, orcid: summary.source['source-orcid'].path },
+    source: {
+        name: summary.source['source-name'].value,
+        orcid: summary.source['source-orcid']?.path || summary.source['source-client-id']?.path || ''
+    },
     url: summary.url ? summary.url.value : undefined
 });
 

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -731,12 +731,16 @@ export interface OrcidAffiliationSummary {
         value: number;
     };
     source: {
-        'source-orcid': {
+        'source-orcid'?: {
             uri: string;
             path: string;
             host: string;
         };
-        'source-client-id'?: string;
+        'source-client-id'?: {
+            uri: string;
+            path: string;
+            host: string;
+        };
         'source-name': {
             value: string;
         };


### PR DESCRIPTION
The purpose of this PR was to fix affiliations mapping when those affiliations were added by trusted organisations and not by the user himself. It seems the "source" values come under "source-orcid" when the affiliation is added by the user himself, but if the affiliation was added by an organisation, the "source" values come as "source-client-id". 

---

### Acceptance Criteria:

As per [OC-726](https://jiscdev.atlassian.net/browse/OC-726)

---

### Checklist:

- [ ] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

---

### Screenshots:


[OC-726]: https://jiscdev.atlassian.net/browse/OC-726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ