### PR TITLE
OC-728 Research culture report homepage link

### DIFF
--- a/ui/src/components/Nav/index.tsx
+++ b/ui/src/components/Nav/index.tsx
@@ -67,7 +67,7 @@ const Nav: React.FC = (): React.ReactElement => {
                         value: Config.urls.about.path
                     },
                     {
-                        label: 'Report',
+                        label: 'Research Culture Report',
                         value: Config.urls.researchCultureReport.path
                     },
                     {

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -18,8 +18,8 @@ const Home: Types.NextPage = (props): React.ReactElement => {
                 <link rel="canonical" href={Config.urls.home.canonical} />
             </Head>
             <Layouts.Standard fixedHeader={false}>
-                <section className="container mx-auto px-8 py-8 lg:py-24">
-                    <div className="mx-auto block lg:w-9/12 xl:w-10/12 2xl:w-7/12">
+                <section className="container mx-auto px-8 pt-8 lg:pt-24">
+                    <div className="mx-auto block lg:w-9/12 xl:w-10/12 2xl:max-w-5xl">
                         <h1 className="mb-8 block text-center font-montserrat text-2xl font-black !leading-tight tracking-tight text-grey-700 transition-colors duration-500 dark:text-white-50 lg:text-5xl ">
                             Free, fast and fair: the global primary research record where researchers publish their work
                             in full detail
@@ -62,7 +62,29 @@ const Home: Types.NextPage = (props): React.ReactElement => {
                         </div>
                     </div>
                 </section>
-                <section className="container mx-auto px-8 py-16 2xl:py-28 ">
+                <section className="container mx-auto px-8 py-20 text-center">
+                    <h2 className="mb-8 font-montserrat text-xl font-semibold text-grey-800 transition-colors duration-500 dark:text-white-100 lg:text-3xl">
+                        Research Culture Report
+                    </h2>
+                    <p className="mx-auto mb-6 text-center font-montserrat text-base font-medium leading-relaxed text-grey-700 transition-colors duration-500 dark:text-grey-100 lg:w-8/12 lg:text-lg">
+                        Researchers at the University of Bristol have recently conducted an investigation into the
+                        current state of the research culture. They found academic researchers demoralised by a culture
+                        that disincentivises sharing and collaboration, encourages questionable research practices, and
+                        increases the risk of bias. These findings underline the need for a platform such as Octopus.
+                        Their results are detailed in the report &quot;A snapshot of the academic research culture in
+                        2023 and how it might be improved&quot;.
+                    </p>
+
+                    <Components.Link
+                        href={Config.urls.researchCultureReport.path}
+                        className="mx-auto flex w-full items-center justify-between rounded-lg bg-teal-700 p-4 font-medium text-white-50 outline-0 transition-colors duration-300 hover:bg-teal-600 focus:ring-2 focus:ring-yellow-400 dark:bg-teal-600 dark:hover:bg-teal-600 sm:w-auto sm:w-fit"
+                    >
+                        <span className="w-full text-center font-montserrat text-sm leading-none tracking-wide">
+                            Learn more
+                        </span>
+                    </Components.Link>
+                </section>
+                <section className="container mx-auto px-8">
                     <div className="grid grid-cols-1 gap-8 lg:grid-cols-2 lg:gap-12 2xl:grid-cols-3">
                         <Components.ActionCard
                             title="Publish your work"


### PR DESCRIPTION
The purpose of this PR was to add a link to the Research Culture Report page on the homepage and also to update the link text into the nav bar from 'Report' to 'Research Culture Report'

---

### Acceptance Criteria:

As per [OC-728](https://jiscdev.atlassian.net/browse/OC-728)

---

### Checklist:

- [ ] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

---

### Screenshots:
<img width="1426" alt="image" src="https://github.com/JiscSD/octopus/assets/48569671/31be8cf7-588f-4a73-a62c-bc1d53fb3d5b">


[OC-728]: https://jiscdev.atlassian.net/browse/OC-728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ