### PR TITLE
OC-721: Require login before checking whether a user has permission to view a draft

### DIFF
--- a/api/src/components/publicationVersion/controller.ts
+++ b/api/src/components/publicationVersion/controller.ts
@@ -34,9 +34,8 @@ export const get = async (
             return response.json(200, publicationVersion);
         }
 
-        return response.json(404, {
-            message:
-                'Publication version is either not found, or you do not have permissions to view it in its current state.'
+        return response.json(403, {
+            message: 'You do not have permission to view this publication version.'
         });
     } catch (err) {
         console.log(err);

--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -1997,7 +1997,7 @@ test.describe('Publication flow + co-authors', () => {
             page.waitForResponse(
                 (response) =>
                     response.request().method() === 'GET' &&
-                    response.url().includes(`/publication-versions/latest`) &&
+                    response.url().includes(`/publication-versions/`) &&
                     response.ok()
             )
         ]);

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -189,7 +189,7 @@ export const clickFirstPublication = async (page: Page): Promise<void> => {
     await firstPublication.click();
 
     // expect URL to contain publication path
-    await expect(page).toHaveURL(`${UI_BASE}${firstPublicationPath}`);
+    await expect(page).toHaveURL(`${UI_BASE}${firstPublicationPath}/versions/latest`);
 };
 
 export const testDateInput = async (page: Page, dateFromInput: Locator, dateToInput: Locator): Promise<void> => {

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosResponse } from 'axios';
+import axios, { AxiosResponse, AxiosRequestConfig } from 'axios';
 
 import * as Interfaces from '@interfaces';
 import * as Config from '@config';
@@ -22,14 +22,29 @@ const api = axios.create({
     baseURL
 });
 
-export const get = async (url: string, token: string | undefined): Promise<AxiosResponse> => {
+export const get = async (
+    url: string,
+    token: string | undefined,
+    config?: AxiosRequestConfig
+): Promise<AxiosResponse> => {
     const headers = {
-        headers: {
-            Authorization: `Bearer ${token}`
-        }
+        Authorization: `Bearer ${token}`
     };
 
-    const response = await api.get(url, token ? headers : undefined);
+    const response = await api.get(
+        url,
+        config
+            ? {
+                  ...config,
+                  ...(token && { headers: {
+                    ...config.headers,
+                    ...headers
+                  } })
+              }
+            : token
+            ? { headers }
+            : undefined
+    );
     return response;
 };
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -36,10 +36,12 @@ export const get = async (
         config
             ? {
                   ...config,
-                  ...(token && { headers: {
-                    ...config.headers,
-                    ...headers
-                  } })
+                  ...(token && {
+                      headers: {
+                          ...config.headers,
+                          ...headers
+                      }
+                  })
               }
             : token
             ? { headers }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosResponse, AxiosRequestConfig } from 'axios';
+import axios, { AxiosResponse } from 'axios';
 
 import * as Interfaces from '@interfaces';
 import * as Config from '@config';
@@ -22,31 +22,14 @@ const api = axios.create({
     baseURL
 });
 
-export const get = async (
-    url: string,
-    token: string | undefined,
-    config?: AxiosRequestConfig
-): Promise<AxiosResponse> => {
+export const get = async (url: string, token: string | undefined): Promise<AxiosResponse> => {
     const headers = {
-        Authorization: `Bearer ${token}`
+        headers: {
+            Authorization: `Bearer ${token}`
+        }
     };
 
-    const response = await api.get(
-        url,
-        config
-            ? {
-                  ...config,
-                  ...(token && {
-                      headers: {
-                          ...config.headers,
-                          ...headers
-                      }
-                  })
-              }
-            : token
-            ? { headers }
-            : undefined
-    );
+    const response = await api.get(url, token ? headers : undefined);
     return response;
 };
 

--- a/ui/src/pages/publications/[id]/versions/[versionId].tsx
+++ b/ui/src/pages/publications/[id]/versions/[versionId].tsx
@@ -6,7 +6,7 @@ import React, { useEffect, useMemo } from 'react';
 import parse from 'html-react-parser';
 import Head from 'next/head';
 import useSWR from 'swr';
-import axios from 'axios';
+import axios, { AxiosResponse } from 'axios';
 
 import * as OutlineIcons from '@heroicons/react/24/outline';
 import * as api from '@api';
@@ -64,15 +64,18 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
 
     // fetch data concurrently
     const promises: [
-        Promise<Interfaces.PublicationVersion | void>,
+        Promise<AxiosResponse<Interfaces.PublicationVersion> | void>,
         Promise<Interfaces.BookmarkedEntityData[] | void>,
         Promise<Interfaces.PublicationWithLinks | void>,
         Promise<Interfaces.Flag[] | void>,
         Promise<Interfaces.BaseTopic[] | void>
     ] = [
         api
-            .get(`${Config.endpoints.publications}/${requestedId}/publication-versions/${versionId}`, token)
-            .then((res) => res.data)
+            .get(`${Config.endpoints.publications}/${requestedId}/publication-versions/latest`, token, {
+                // We need to know the return code of this request if it is 403/404 so we can redirect,
+                // so this stops it from being caught and not checkable in the following code.
+                validateStatus: (status) => [403, 404].includes(status) || (status >= 200 && status < 300)
+            })
             .catch((error) => console.log(error)),
         api
             .get(`${Config.endpoints.bookmarks}?type=PUBLICATION&entityId=${requestedId}`, token)
@@ -93,12 +96,32 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
     ];
 
     const [
-        publicationVersion,
+        publicationVersionResponse,
         bookmarks = [],
         directLinks = { publication: null, linkedTo: [], linkedFrom: [] },
         flags = [],
         topics = []
     ] = await Promise.all(promises);
+
+    if (publicationVersionResponse) {
+        // If anonymous user doesn't have access, redirect to login.
+        if (!token && publicationVersionResponse.status === 403) {
+            return {
+                redirect: {
+                    destination: `${Config.urls.orcidLogin.path}&state=${encodeURIComponent(context.resolvedUrl)}`,
+                    permanent: false
+                }
+            };
+        }
+        // If logged in user doesn't have access or version is not found, return notFound.
+        if ((token && publicationVersionResponse.status === 403) || publicationVersionResponse.status === 404) {
+            return {
+                notFound: true
+            };
+        }
+    }
+
+    const publicationVersion = publicationVersionResponse?.data;
 
     if (!publicationVersion) {
         return {

--- a/ui/src/pages/publications/[id]/versions/[versionId].tsx
+++ b/ui/src/pages/publications/[id]/versions/[versionId].tsx
@@ -6,7 +6,7 @@ import React, { useEffect, useMemo } from 'react';
 import parse from 'html-react-parser';
 import Head from 'next/head';
 import useSWR from 'swr';
-import axios, { AxiosResponse } from 'axios';
+import axios from 'axios';
 
 import * as OutlineIcons from '@heroicons/react/24/outline';
 import * as api from '@api';
@@ -64,19 +64,25 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
 
     // fetch data concurrently
     const promises: [
-        Promise<AxiosResponse<Interfaces.PublicationVersion> | void>,
+        Promise<
+            | { publicationVersion: Interfaces.PublicationVersion; versionRequestError: null }
+            | { publicationVersion: null; versionRequestError: { status: number; message: string } }
+        >,
         Promise<Interfaces.BookmarkedEntityData[] | void>,
         Promise<Interfaces.PublicationWithLinks | void>,
         Promise<Interfaces.Flag[] | void>,
         Promise<Interfaces.BaseTopic[] | void>
     ] = [
         api
-            .get(`${Config.endpoints.publications}/${requestedId}/publication-versions/latest`, token, {
-                // We need to know the return code of this request if it is 403/404 so we can redirect,
-                // so this stops it from being caught and not checkable in the following code.
-                validateStatus: (status) => [403, 404].includes(status) || (status >= 200 && status < 300)
-            })
-            .catch((error) => console.log(error)),
+            .get(`${Config.endpoints.publications}/${requestedId}/publication-versions/${versionId}`, token)
+            .then((res) => ({ publicationVersion: res.data, versionRequestError: null }))
+            .catch((error) => {
+                console.log(error);
+                const status = error.response.status;
+                const message = error.response.data.message;
+
+                return { publicationVersion: null, versionRequestError: { status, message } };
+            }),
         api
             .get(`${Config.endpoints.bookmarks}?type=PUBLICATION&entityId=${requestedId}`, token)
             .then((res) => res.data)
@@ -96,16 +102,20 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
     ];
 
     const [
-        publicationVersionResponse,
+        { publicationVersion, versionRequestError },
         bookmarks = [],
         directLinks = { publication: null, linkedTo: [], linkedFrom: [] },
         flags = [],
         topics = []
     ] = await Promise.all(promises);
 
-    if (publicationVersionResponse) {
-        // If anonymous user doesn't have access, redirect to login.
-        if (!token && publicationVersionResponse.status === 403) {
+    if (versionRequestError) {
+        const status = versionRequestError.status;
+        if (status === 404 || (token && status === 403)) {
+            return {
+                notFound: true
+            };
+        } else if (status === 403) {
             return {
                 redirect: {
                     destination: `${Config.urls.orcidLogin.path}&state=${encodeURIComponent(context.resolvedUrl)}`,
@@ -113,34 +123,26 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
                 }
             };
         }
-        // If logged in user doesn't have access or version is not found, return notFound.
-        if ((token && publicationVersionResponse.status === 403) || publicationVersionResponse.status === 404) {
-            return {
-                notFound: true
-            };
-        }
     }
 
-    const publicationVersion = publicationVersionResponse?.data;
-
-    if (!publicationVersion) {
+    if (publicationVersion) {
+        return {
+            props: {
+                publicationVersion,
+                userToken: token || '',
+                bookmarkId: bookmarks.length ? bookmarks[0].id : null,
+                publicationId: publicationVersion.publication.id,
+                protectedPage: ['LOCKED', 'DRAFT'].includes(publicationVersion.currentStatus),
+                directLinks,
+                flags,
+                topics
+            }
+        };
+    } else {
         return {
             notFound: true
         };
     }
-
-    return {
-        props: {
-            publicationVersion,
-            userToken: token || '',
-            bookmarkId: bookmarks.length ? bookmarks[0].id : null,
-            publicationId: publicationVersion.publication.id,
-            protectedPage: ['LOCKED', 'DRAFT'].includes(publicationVersion.currentStatus),
-            directLinks,
-            flags,
-            topics
-        }
-    };
 };
 
 type Props = {


### PR DESCRIPTION
The purpose of this PR was to redirect anonymous users to login when they attempt to view a publication that exists only in draft/locked status. This required a small API change so that we can determine from the API response status whether the publication exists in one of these states, or doesn't exist at all (which up to now both returned 404 status).

Also made a couple of end to end test tweaks as some of them were failing due to some recent versioning changes.

---

### Acceptance Criteria:

- When a user is not logged in and navigates directly to a draft publication, they should be redirected to the ORCiD log in, and directed back to the publication page.
  - If the user has permission to view it, they see the draft publication page as normal
  - If the user does not have permission to view it, they see a 404

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

API:
<img width="161" alt="Screenshot 2023-11-06 142613" src="https://github.com/JiscSD/octopus/assets/132363734/bdbeddff-4700-4399-ad2e-f7e1bc31bea2">

UI:
<img width="260" alt="Screenshot 2023-11-06 141912" src="https://github.com/JiscSD/octopus/assets/132363734/70875a2d-2bff-44e9-8ecf-bbbdbb374f2e">

E2E:
<img width="125" alt="Screenshot 2023-11-06 142605" src="https://github.com/JiscSD/octopus/assets/132363734/5d4adc3b-5e52-42a9-9bc3-683df19becf7">