### PR TITLE
OC-717: Bookmark button visible while in DRAFT

### DIFF
--- a/ui/src/pages/publications/[id]/index.tsx
+++ b/ui/src/pages/publications/[id]/index.tsx
@@ -184,7 +184,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
 
     const user = Stores.useAuthStore((state: Types.AuthStoreType) => state.user);
     const isBookmarkButtonVisible = useMemo(() => {
-        if (!user || !publicationVersion || (publicationVersion && publicationVersion.currentStatus !== 'LIVE')) {
+        if (user && publicationVersion?.currentStatus === 'LIVE') {
             return false;
         } else {
             return true;

--- a/ui/src/pages/publications/[id]/index.tsx
+++ b/ui/src/pages/publications/[id]/index.tsx
@@ -183,13 +183,10 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
     const childProblems = linkedFrom.filter((link) => link.type === 'PROBLEM') || [];
 
     const user = Stores.useAuthStore((state: Types.AuthStoreType) => state.user);
-    const isBookmarkButtonVisible = useMemo(() => {
-        if (user && publicationVersion?.currentStatus === 'LIVE') {
-            return false;
-        } else {
-            return true;
-        }
-    }, [publicationVersion, user]);
+    const isBookmarkButtonVisible = useMemo(
+        () => user && publicationVersion?.currentStatus === 'LIVE',
+        [publicationVersion, user]
+    );
 
     const list = [];
 

--- a/ui/src/pages/publications/[id]/index.tsx
+++ b/ui/src/pages/publications/[id]/index.tsx
@@ -184,7 +184,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
 
     const user = Stores.useAuthStore((state: Types.AuthStoreType) => state.user);
     const isBookmarkButtonVisible = useMemo(() => {
-        if (!user || !publicationVersion) {
+        if (!user || !publicationVersion || (publicationVersion && publicationVersion.currentStatus !== 'LIVE')) {
             return false;
         } else {
             return true;

--- a/ui/src/pages/publications/[id]/versions/[versionId].tsx
+++ b/ui/src/pages/publications/[id]/versions/[versionId].tsx
@@ -190,7 +190,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
 
     const user = Stores.useAuthStore((state: Types.AuthStoreType) => state.user);
     const isBookmarkButtonVisible = useMemo(() => {
-        if (!user || !publicationVersion) {
+        if (!user || !publicationVersion || (publicationVersion && publicationVersion.currentStatus !== 'LIVE')) {
             return false;
         } else {
             return true;

--- a/ui/src/pages/publications/[id]/versions/[versionId].tsx
+++ b/ui/src/pages/publications/[id]/versions/[versionId].tsx
@@ -189,13 +189,10 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
     const childProblems = linkedFrom.filter((link) => link.type === 'PROBLEM') || [];
 
     const user = Stores.useAuthStore((state: Types.AuthStoreType) => state.user);
-    const isBookmarkButtonVisible = useMemo(() => {
-        if (!user || !publicationVersion || (publicationVersion && publicationVersion.currentStatus !== 'LIVE')) {
-            return false;
-        } else {
-            return true;
-        }
-    }, [publicationVersion, user]);
+    const isBookmarkButtonVisible = useMemo(
+        () => user && publicationVersion?.currentStatus === 'LIVE',
+        [publicationVersion, user]
+    );
 
     const list = [];
 


### PR DESCRIPTION
The purpose of this PR was to stop the bookmark button when a draft/locked publication is being viewed.

---

### Acceptance Criteria:

- We can allow users to bookmark their own LIVE publications, but the bookmark button should be hidden in DRAFT (and LOCKED).

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
<img width="271" alt="Screenshot 2023-11-09 100931" src="https://github.com/JiscSD/octopus/assets/132363734/65b30d20-1f54-45bc-8f35-3b1d1d067586">

E2E
<img width="127" alt="Screenshot 2023-11-09 105756" src="https://github.com/JiscSD/octopus/assets/132363734/1fd678cf-2482-4f43-a9ea-238eb030602b">

---

### Screenshots:

This shows a draft publication being viewed without the bookmark button.
<img width="964" alt="Screenshot 2023-11-09 112800" src="https://github.com/JiscSD/octopus/assets/132363734/288abbf6-0431-4f50-a2e4-47ef54d2574d">
