### PR TITLE
OC-723: Create This Publication button stays enabled after being hit

### DIFF
--- a/ui/src/pages/create.tsx
+++ b/ui/src/pages/create.tsx
@@ -41,8 +41,10 @@ const Create: Types.NextPage<PageProps> = (props): React.ReactElement => {
     const [publicationType, setPublicationType] = React.useState(props.publicationType ?? 'PROBLEM');
     const [confirmed, setConfirmed] = React.useState(false);
     const [error, setError] = React.useState<string | null>(null);
+    const [createPublicationLoading, setCreatePublicationLoading] = React.useState(false);
 
     const createPublication = async () => {
+        setCreatePublicationLoading(true);
         setError(null);
 
         try {
@@ -74,6 +76,7 @@ const Create: Types.NextPage<PageProps> = (props): React.ReactElement => {
         } catch (err) {
             const { message } = err as Interfaces.JSONResponseError;
             setError(message);
+            setCreatePublicationLoading(false);
         }
     };
 
@@ -213,7 +216,7 @@ const Create: Types.NextPage<PageProps> = (props): React.ReactElement => {
                     </label>
                     <Components.Button
                         title="Create this publication"
-                        disabled={!publicationType || !title.length || !confirmed}
+                        disabled={!publicationType || !title.length || !confirmed || createPublicationLoading}
                         onClick={createPublication}
                         endIcon={
                             <OutlineIcons.ArrowSmallRightIcon className="h-4 w-4 text-teal-500 transition-colors duration-500 dark:text-white-50" />


### PR DESCRIPTION
The purpose of this PR was to disable the button after it has been hit and while the back end request is processing, so that we don't allow users to create multiple publications with the same title if they quickly hit the button multiple times before the page redirects.

---

### Acceptance Criteria:

The "Create This Publication" button is disabled while the back end request is processing.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
<img width="263" alt="Screenshot 2023-11-09 130755" src="https://github.com/JiscSD/octopus/assets/132363734/dc4aa1da-ab51-4e00-8018-c00eea7ca687">

E2E
<img width="129" alt="Screenshot 2023-11-09 135607" src="https://github.com/JiscSD/octopus/assets/132363734/9cfdf736-219b-4e2d-835d-cdc8b913b788">

