### PR TITLE
OC-392 Switching between displayed version

### DIFF
--- a/api/src/components/publication/__tests__/getPublication.test.ts
+++ b/api/src/components/publication/__tests__/getPublication.test.ts
@@ -31,5 +31,23 @@ describe('View publications + versions', () => {
         expect(getPublication.status).toEqual(403);
     });
 
-    test.todo('Any user can see a LIVE publication');
+    test('Any user can see LIVE publication versions', async () => {
+        const getPublication = await testUtils.agent.get('/publications/publication-problem-live');
+
+        expect(getPublication.status).toEqual(200);
+        expect(getPublication.body.versions.every((version) => version.currentStatus === 'LIVE')).toEqual(true);
+    });
+
+    test('GET publication endpoint supports partial response query', async () => {
+        const getPublication = await testUtils.agent.get(
+            '/publications/publication-problem-live?fields=id,type,versions(id,title)'
+        );
+
+        expect(getPublication.status).toEqual(200);
+
+        expect(Object.keys(getPublication.body).length).toEqual(3);
+        expect(Object.keys(getPublication.body).every((key) => ['id', 'type', 'versions'].includes(key)));
+        expect(Object.keys(getPublication.body.versions[0]).length).toEqual(2);
+        expect(Object.keys(getPublication.body.versions[0]).every((key) => ['id', 'title'].includes(key)));
+    });
 });

--- a/api/src/components/publication/controller.ts
+++ b/api/src/components/publication/controller.ts
@@ -7,10 +7,11 @@ import * as publicationService from 'publication/service';
 import * as publicationVersionService from 'publicationVersion/service';
 
 export const get = async (
-    event: I.APIRequest<undefined, undefined, I.GetPublicationPathParams>
+    event: I.APIRequest<undefined, I.GetPublicatonQueryParams, I.GetPublicationPathParams>
 ): Promise<I.JSONResponse> => {
     try {
         const publication = await publicationService.get(event.pathParameters.id);
+        const fields = event.queryStringParameters?.fields;
 
         if (!publication) {
             return response.json(404, {
@@ -30,7 +31,7 @@ export const get = async (
             return response.json(403, { message: "You don't have permissions to view this publication." });
         }
 
-        return response.json(200, publication);
+        return response.json(200, fields ? helpers.buildPartialResponse(fields, publication) : publication);
     } catch (err) {
         console.log(err);
 

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -112,6 +112,10 @@ export interface GetPublicationPathParams {
     id: string;
 }
 
+export interface GetPublicatonQueryParams {
+    fields?: string;
+}
+
 export interface GetPublicationLinksPathParams {
     id: string;
 }

--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -732,6 +732,39 @@ test.describe('Publication flow', () => {
         // remove initial corresponding author
         await removeCoAuthor(page, Helpers.user1);
 
+        // preview the the new version
+        await page.locator(PageModel.publish.previewButton).click();
+        await page.locator(`h1:has-text("${newTitle}")`).first().waitFor({ state: 'visible' });
+
+        // check v3 DRAFT
+        await checkPublication(page, { ...problemPublication, title: newTitle }, [Helpers.user2]);
+        await page.locator(PageModel.publish.versionsAccordionButton).waitFor();
+
+        // switch between versions
+        await page.click(PageModel.publish.versionsAccordionButton);
+        await expect(page.locator('#versions-accordion p:has-text("Version 3: Currently viewed")')).toBeVisible();
+        expect(page.url()).toContain('/versions/latest');
+
+        // switch to v2
+        await page.locator('#versions-accordion a').first().click();
+        await page.waitForURL('**/versions/2');
+        await expect(page.locator('#versions-accordion a:has-text("Version 3: Draft")')).toBeVisible();
+        await expect(page.locator('#versions-accordion p:has-text("Version 2: Currently viewed")')).toBeVisible();
+
+        // switch to v1
+        await page.locator('#versions-accordion a').nth(1).click();
+        await page.waitForURL('**/versions/1');
+        await expect(page.locator('#versions-accordion a:has-text("Version 3: Draft")')).toBeVisible();
+        await expect(page.locator('#versions-accordion p:has-text("Version 1: Currently viewed")')).toBeVisible();
+
+        // switch back to v3
+        await page.locator('#versions-accordion a').first().click();
+        await page.waitForURL('**/versions/3');
+
+        // go back to edit page
+        await page.locator(PageModel.publish.draftEditButton).click();
+        await page.waitForURL('**/edit?**');
+
         // check publish button is now enabled
         await expect(page.locator(PageModel.publish.publishButton)).toBeEnabled();
 

--- a/e2e/tests/PageModel.ts
+++ b/e2e/tests/PageModel.ts
@@ -215,7 +215,8 @@ export const PageModel = {
             manualAffiliationCity: 'input[placeholder="City"]',
             manualAffiliationLink: 'input[placeholder="Link"]',
             affiliationDetails: 'textarea[placeholder="Enter any details"]'
-        }
+        },
+        versionsAccordionButton: 'aside button[title="Versions"]'
     },
     coauthorApprove: {},
     coauthorDeny: {},

--- a/ui/src/components/Publication/VersionsAccordion/VersionsAccordion.tsx
+++ b/ui/src/components/Publication/VersionsAccordion/VersionsAccordion.tsx
@@ -1,0 +1,100 @@
+import React, { useState } from 'react';
+import * as OutlineIcons from '@heroicons/react/24/outline';
+import * as Interfaces from '@interfaces';
+import * as Types from '@types';
+import * as Components from '@components';
+import * as Framer from 'framer-motion';
+
+type Props = {
+    versions: Types.PartialPublicationVersion[];
+    selectedVersion: Interfaces.PublicationVersion;
+};
+
+const VersionsAccordion: React.FC<Props> = (props) => {
+    const [expanded, setExpanded] = useState(false);
+
+    return (
+        <Framer.AnimatePresence>
+            <Framer.motion.div
+                id="versions-accordion"
+                key="versions-accordion"
+                className="border-grey rounded shadow transition-colors duration-500 dark:bg-grey-900"
+                initial={{ opacity: 0, height: 0 }}
+                animate={{ opacity: 1, height: 'auto' }}
+            >
+                <Components.Button
+                    title="Versions"
+                    className={`w-full justify-between bg-grey-50 px-6 py-1 font-inter transition-all duration-300 children:border-0 dark:bg-grey-700 ${
+                        expanded ? 'rounded-none rounded-t' : ''
+                    }`}
+                    endIcon={
+                        <OutlineIcons.ChevronDownIcon
+                            className={`w-4 transition-transform duration-300 dark:text-white-50 ${
+                                expanded ? 'rotate-180' : 'rotate-0'
+                            }`}
+                        />
+                    }
+                    onClick={() => setExpanded((prevState) => !prevState)}
+                >
+                    Versions
+                </Components.Button>
+
+                <Framer.AnimatePresence>
+                    {expanded && (
+                        <Framer.motion.div
+                            key="versions-accordion-items"
+                            className="overflow-hidden"
+                            initial={{ height: 0 }}
+                            animate={{ height: 'auto' }}
+                            exit={{ height: 0 }}
+                        >
+                            <div className="space-y-3 px-6 py-4">
+                                {props.versions
+                                    .sort((version1, version2) => version2.versionNumber - version1.versionNumber)
+                                    .map((version) =>
+                                        version.id === props.selectedVersion.id ? (
+                                            <p
+                                                key={version.id}
+                                                className="text-sm font-semibold text-grey-800 transition-colors duration-500 dark:text-grey-100"
+                                            >
+                                                Version {version.versionNumber}: Currently viewed
+                                            </p>
+                                        ) : (
+                                            <Components.Link
+                                                key={version.id}
+                                                className="flex w-fit rounded border-transparent text-sm font-medium text-teal-600 outline-0 transition-colors duration-500 hover:underline focus:overflow-hidden focus:ring-2 focus:ring-yellow-400 dark:text-teal-400"
+                                                href={`/publications/${version.versionOf}/versions/${version.versionNumber}`}
+                                            >
+                                                Version {version.versionNumber}:{' '}
+                                                {version.publishedDate
+                                                    ? new Date(version.publishedDate).toLocaleDateString()
+                                                    : 'Draft'}
+                                            </Components.Link>
+                                        )
+                                    )}
+                            </div>
+                        </Framer.motion.div>
+                    )}
+                </Framer.AnimatePresence>
+            </Framer.motion.div>
+
+            <Framer.AnimatePresence>
+                {/** API will only return versions that the current user has permission to see */}
+                {props.versions.length !== props.selectedVersion.versionNumber && (
+                    <Framer.motion.p
+                        key="info"
+                        className="text-sm leading-relaxed dark:text-white-50"
+                        initial={{ opacity: 0, height: 0, marginTop: 0 }}
+                        animate={{ opacity: 1, height: 'auto', marginTop: 16 }}
+                        exit={{ opacity: 0, height: 0, marginTop: 0 }}
+                    >
+                        <OutlineIcons.ExclamationCircleIcon className="inline w-6 stroke-2 align-bottom text-red-600 dark:text-red-500" />{' '}
+                        A newer version of this publication exists
+                    </Framer.motion.p>
+                )}
+            </Framer.AnimatePresence>
+        </Framer.AnimatePresence>
+    );
+};
+
+export default VersionsAccordion;

--- a/ui/src/components/index.tsx
+++ b/ui/src/components/index.tsx
@@ -94,3 +94,4 @@ export { default as EditAffiliationsModal } from './EditAffiliationsModal';
 export { default as BlogCard } from './BlogCard';
 export { default as Maintenance } from './Maintenance';
 export { default as ModalBarLoader } from './ModalBarLoader';
+export { default as VersionsAccordion } from './Publication/VersionsAccordion/VersionsAccordion';

--- a/ui/src/lib/interfaces.ts
+++ b/ui/src/lib/interfaces.ts
@@ -100,41 +100,11 @@ export interface PublicationVersion {
     topics: BaseTopic[];
 }
 
-export interface PublicationWithVersions extends CorePublication {
-    versions: PublicationVersion[];
-}
-
-// The form of publication generally expected by the UI, with versionable data merged into the object.
 export interface Publication extends CorePublication {
-    versionId: string;
-    versionNumber: number;
-    isLatestVersion: boolean;
-    isLatestLiveVersion: boolean;
-    title: string;
-    description: string;
-    keywords: string[];
-    createdBy: string;
-    createdAt: string;
-    updatedAt: string;
-    currentStatus: Types.PublicationStatuses;
-    publishedDate: string;
-    licence: Types.LicenceType;
-    content: string;
-    language: Types.Languages;
-    ethicalStatement: string;
-    ethicalStatementFreeText: string | null;
-    publicationStatus: PublicationStatus[];
-    user: User;
-    conflictOfInterestStatus: boolean | undefined;
-    conflictOfInterestText: string | null;
-    dataAccessStatement: string | null;
-    dataPermissionsStatement: string | null;
-    dataPermissionsStatementProvidedBy: string | null;
-    selfDeclaration: boolean;
-    coAuthors: CoAuthor[];
-    funders: Funder[];
-    fundersStatement: string | null;
-    references: Reference[];
+    linkedTo: LinkedToPublication[];
+    linkedFrom: LinkedFromPublication[];
+    publicationFlags: Flag[];
+    versions: PublicationVersion[];
 }
 
 export interface LinkedPublication {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -328,3 +328,15 @@ export type BlogFields = {
     slug: Contentful.EntryFields.Text;
     publishedDate: Contentful.EntryFields.Date;
 };
+
+export type PartialPublicationVersion = Pick<
+    Interfaces.PublicationVersion,
+    | 'id'
+    | 'doi'
+    | 'versionOf'
+    | 'versionNumber'
+    | 'createdBy'
+    | 'publishedDate'
+    | 'isLatestLiveVersion'
+    | 'isLatestVersion'
+>;


### PR DESCRIPTION
The purpose of this PR was to add a version switch accordion on the publication page

---

### Acceptance Criteria:

As per [OC-392](https://jiscdev.atlassian.net/browse/OC-392)

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added

---

### Tests:

<img width="1468" alt="image" src="https://github.com/JiscSD/octopus/assets/48569671/ae2c2dfc-be65-43f5-a398-cea7bcaf51a0">
<img width="886" alt="image" src="https://github.com/JiscSD/octopus/assets/48569671/cbabf923-d10d-4577-9aa0-9c3753e6151b">


---

### Screenshots:

![image](https://github.com/JiscSD/octopus/assets/48569671/b68de6bc-1528-4274-99a7-daeda5d14897)

![image](https://github.com/JiscSD/octopus/assets/48569671/3b74a858-190b-4f64-b205-3969c0baa83b)


[OC-392]: https://jiscdev.atlassian.net/browse/OC-392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ