### PR TITLE
OC-737: Move "A newer version of this publication exists" message

### DIFF
--- a/ui/src/components/Publication/VersionsAccordion/VersionsAccordion.tsx
+++ b/ui/src/components/Publication/VersionsAccordion/VersionsAccordion.tsx
@@ -77,22 +77,6 @@ const VersionsAccordion: React.FC<Props> = (props) => {
                     )}
                 </Framer.AnimatePresence>
             </Framer.motion.div>
-
-            <Framer.AnimatePresence>
-                {/** API will only return versions that the current user has permission to see */}
-                {props.versions.length !== props.selectedVersion.versionNumber && (
-                    <Framer.motion.p
-                        key="info"
-                        className="text-sm leading-relaxed dark:text-white-50"
-                        initial={{ opacity: 0, height: 0, marginTop: 0 }}
-                        animate={{ opacity: 1, height: 'auto', marginTop: 16 }}
-                        exit={{ opacity: 0, height: 0, marginTop: 0 }}
-                    >
-                        <OutlineIcons.ExclamationCircleIcon className="inline w-6 stroke-2 align-bottom text-red-600 dark:text-red-500" />{' '}
-                        A newer version of this publication exists
-                    </Framer.motion.p>
-                )}
-            </Framer.AnimatePresence>
         </Framer.AnimatePresence>
     );
 };

--- a/ui/src/pages/publications/[id]/versions/[versionId].tsx
+++ b/ui/src/pages/publications/[id]/versions/[versionId].tsx
@@ -7,6 +7,7 @@ import parse from 'html-react-parser';
 import Head from 'next/head';
 import useSWR from 'swr';
 import axios from 'axios';
+import * as Framer from 'framer-motion';
 
 import * as OutlineIcons from '@heroicons/react/24/outline';
 import * as api from '@api';
@@ -641,6 +642,20 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                                 </div>
                             ))}
                         </div>
+                        <Framer.AnimatePresence>
+                            {/** API will only return versions that the current user has permission to see */}
+                            {publication && publication.versions.length !== publicationVersion.versionNumber && (
+                                <Framer.motion.p
+                                    className="mb-4 text-sm leading-relaxed dark:text-white-50"
+                                    initial={{ opacity: 0, height: 0, marginTop: 0 }}
+                                    animate={{ opacity: 1, height: 'auto', marginTop: 16 }}
+                                    exit={{ opacity: 0, height: 0, marginTop: 0 }}
+                                >
+                                    <OutlineIcons.ExclamationCircleIcon className="inline w-6 stroke-2 align-bottom text-red-600 dark:text-red-500" />{' '}
+                                    A newer version of this publication exists
+                                </Framer.motion.p>
+                            )}
+                        </Framer.AnimatePresence>
 
                         <div className="block lg:hidden">
                             {showVersionsAccordion && (


### PR DESCRIPTION
The purpose of this PR was to put the aforementioned message in a more prominent place.

---

### Acceptance Criteria:

- If a version of the publication that is not the latest live version, the message “A newer version of this publication exists” and the corresponding warning icon are displayed below the author list 

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
<img width="262" alt="Screenshot 2023-11-30 090329" src="https://github.com/JiscSD/octopus/assets/132363734/c6262b5a-ec3b-465d-a9d7-dd684a21ad5e">

E2E
<img width="122" alt="Screenshot 2023-11-30 101626" src="https://github.com/JiscSD/octopus/assets/132363734/8a85a17a-e3ab-415f-8311-a483f80721de">

---

### Screenshots:
<img width="259" alt="Screenshot 2023-11-30 102216" src="https://github.com/JiscSD/octopus/assets/132363734/be0c8ecc-d120-4f4d-b13f-ac3164ea2730">
