### PR TITLE
OC-727 Adding new versions from version switch dropdown

### DIFF
--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -2322,6 +2322,8 @@ test.describe('Publication flow + co-authors', () => {
 
         // wait to be redirected to the edit page
         await page.waitForURL('**/edit?**');
+
+        // go back to preview page
         await page.click(PageModel.publish.previewButton);
         await page.waitForURL('**/versions/latest');
 
@@ -2366,6 +2368,99 @@ test.describe('Publication flow + co-authors', () => {
         await page3.waitForURL('**/edit?**');
         await page3.waitForLoadState('networkidle');
         await expect(page3.locator('aside button:has-text("Key information")').first()).toBeVisible();
+    });
+
+    test('Authors can create/edit and request control over new version from "Versions" dropdown', async ({
+        browser
+    }) => {
+        const context = await browser.newContext();
+        const page = await context.newPage();
+
+        await page.goto(Helpers.UI_BASE);
+        await Helpers.login(page, browser);
+        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
+
+        // create v1
+        await createPublication(page, problemPublication2.title, 'PROBLEM');
+        await completeKeyInformationTab(page);
+        await completeAffiliationsTab(page, false);
+        await completeLinkedItemsTab(
+            page,
+            'living organisms',
+            'How do living organisms function, survive, reproduce and evolve?'
+        );
+        await completeMainTextTab(page, 'main text', 'aa', referencesList, 'description', 'key, words');
+        await completeConflictOfInterestTab(page, false);
+        await completeFundersTab(
+            page,
+            '01rv9gx86',
+            'funder name',
+            'funder city',
+            'https://funder.com',
+            'extra details'
+        );
+
+        // invite a co-author
+        await page.locator('aside button:has-text("Co-authors")').first().click();
+        await addCoAuthor(page, Helpers.user2);
+
+        // request approvals for v1
+        await page.locator(PageModel.publish.requestApprovalButton).click();
+        await page.locator(PageModel.publish.confirmRequestApproval).click();
+        await page.locator(`h1:has-text("${problemPublication2.title}")`).first().waitFor({ state: 'visible' });
+        await page.locator(`h1:has-text("${problemPublication2.title}")`).waitFor(); // wait for redirect
+
+        // confirm co-author invitation
+        await confirmCoAuthorInvitation(browser, Helpers.user2);
+
+        // publish v1
+        await page.reload();
+        await page.locator(PageModel.publish.publishButtonTracker).click();
+        await page.locator(PageModel.publish.confirmPublishButtonTracker).click();
+        await page.locator('aside a:has-text("Create New Version")').waitFor();
+        await expect(page.locator('aside a:has-text("Create New Version")')).toBeVisible();
+
+        const publicationUrl = page.url();
+
+        // login as co-author
+        const context2 = await browser.newContext();
+        const page2 = await context2.newPage();
+        await page2.goto(Helpers.UI_BASE);
+        await Helpers.login(page2, browser, Helpers.user2);
+        await expect(page2.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user2.fullName);
+        await page2.goto(publicationUrl);
+        await page2.locator('aside button[title="Versions"]').waitFor();
+
+        // create v2 from 'Versions' dropdown
+        await expect(page2.locator('aside button[title="Versions"]')).toBeVisible();
+        await expect(page2.locator('aside a:has-text("Create New Version")')).toBeVisible();
+        await page2.locator('aside a:has-text("Create New Version")').click();
+
+        // wait to be redirected to the edit page
+        await page2.waitForURL('**/edit?**');
+
+        // go back to preview page
+        await page2.click(PageModel.publish.previewButton);
+        await page2.waitForURL('**/versions/latest');
+
+        // check co-author has option to 'Edit Draft' from 'Versions' dropdown
+        await expect(page2.locator('a:has-text("Edit Draft")')).toBeVisible();
+        await page2.close();
+
+        // check previous corresponding author can 'Take over editing' from the 'Versions' dropdown
+        await page.reload();
+        await page.locator('aside button[title="Versions"]').waitFor();
+        await expect(page.locator('aside button[title="Versions"]')).toBeVisible();
+        await expect(page.locator('aside a:has-text("Take over editing")')).toBeVisible();
+
+        await page.locator('aside a:has-text("Take over editing")').click();
+        await page.locator('button[title="Request Control"]').click();
+        await page.waitForResponse(
+            (response) => response.url().includes('/publication-versions/latest/request-control') && response.ok()
+        );
+        await page.getByText('You have requested control over this publication version.').waitFor();
+        await expect(page.getByText('You have requested control over this publication version.')).toBeVisible();
+        await page.close();
     });
 });
 

--- a/ui/src/components/Publication/ActionBar/index.tsx
+++ b/ui/src/components/Publication/ActionBar/index.tsx
@@ -57,7 +57,7 @@ const ActionBar: React.FC<Props> = (props) => {
                             <p className="pb-1">This publication is locked for approval.</p>
                             <Components.Link
                                 className="inline w-fit rounded text-teal-600 underline outline-0 focus:ring-2 focus:ring-yellow-400 dark:text-teal-200 dark:decoration-teal-200"
-                                href={`${Config.urls.viewPublication.path}/${props.publicationVersion.publication.id}/edit?step=4`}
+                                href={`${Config.urls.viewPublication.path}/${props.publicationVersion.publication.id}/edit?step=0`}
                                 title="Edit publication"
                                 onClick={async (e) => {
                                     e.preventDefault();

--- a/ui/src/components/Publication/SimpleResult/index.tsx
+++ b/ui/src/components/Publication/SimpleResult/index.tsx
@@ -1,29 +1,24 @@
 import React from 'react';
-import axios from 'axios';
 import * as OutlineIcons from '@heroicons/react/24/outline';
 import * as Interfaces from '@interfaces';
 import * as Helpers from '@helpers';
 import * as Components from '@components';
-import * as api from '@api';
 import * as Config from '@config';
-import * as Contexts from '@contexts';
-import * as SWRConfig from 'swr';
-import * as FaIcons from 'react-icons/fa';
-import { useRouter } from 'next/router';
+import * as Hooks from '@hooks';
 
 type Props = {
     publication: Interfaces.Publication;
     user: Interfaces.User;
-    canCreateNewVersion?: boolean;
-    canEditNewVersion?: boolean;
     controlRequests: Interfaces.ControlRequest[];
 };
 
 const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
-    const confirmation = Contexts.useConfirmationModal();
-    const router = useRouter();
-    const [error, setError] = React.useState('');
-    const [loading, setLoading] = React.useState(false);
+    const { handleCreateNewVersion, loadingNewVersion, newVersionError } = Hooks.useCreateNewVersion(
+        props.publication.id
+    );
+    const { handleControlRequest, loadingControlRequest, controlRequestError } = Hooks.useControlRequest(
+        props.publication.id
+    );
 
     const latestLiveVersion = props.publication.versions.find((version) => version.isLatestLiveVersion);
     const isAuthorOnLatestLive =
@@ -36,64 +31,6 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
     const draftExistsWithoutPermission = !draftExistsWithPermission && !latestLiveVersion?.isLatestVersion;
     const hasAlreadyRequestedControl = props.controlRequests.some(
         (request) => request.data.publicationVersion.versionOf === props.publication.id
-    );
-
-    const handleCreateNewVersion = React.useCallback(
-        async (e: React.MouseEvent<Element, MouseEvent>) => {
-            setError('');
-            setLoading(true);
-
-            try {
-                // create new version
-                await api.post(
-                    `${Config.endpoints.publications}/${props.publication.id}/publication-versions`,
-                    {},
-                    Helpers.getJWT()
-                );
-
-                // redirect user to the edit page
-                await router.push(`/publications/${props.publication.id}/edit?step=0`);
-            } catch (error) {
-                console.log(error);
-                setError(axios.isAxiosError(error) ? error.response?.data?.message : (error as Error).message);
-            }
-
-            setLoading(false);
-        },
-        [props.publication.id, router]
-    );
-
-    const handleTakeOverEditing = React.useCallback(
-        async (e: React.MouseEvent<Element, MouseEvent>) => {
-            const confirmed = await confirmation(
-                'Take over editing',
-                'This action will remove the current corresponding author and allow you to make edits instead. Are you sure you want to do this?',
-                <FaIcons.FaEdit className="h-8 w-8 text-grey-600" />,
-                'Request Control'
-            );
-
-            if (confirmed) {
-                setError('');
-                setLoading(true);
-
-                try {
-                    // request control over this version
-                    await api.get(
-                        `${Config.endpoints.publications}/${props.publication.id}/publication-versions/latest/request-control`,
-                        Helpers.getJWT()
-                    );
-
-                    // re-fetch control requests for this user
-                    await SWRConfig.mutate(`${Config.endpoints.users}/me/control-requests`);
-                } catch (error) {
-                    console.log(error);
-                    setError(axios.isAxiosError(error) ? error.response?.data?.message : (error as Error).message);
-                }
-
-                setLoading(false);
-            }
-        },
-        [confirmation, props.publication.id]
     );
 
     const divider = <span className="border-b border-grey-300 pt-4 dark:border-teal-500 sm:border-r sm:pb-4" />;
@@ -109,11 +46,11 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
         />
     ) : (
         <>
-            {error && <Components.Alert severity="ERROR" title={error} className="mt-4" />}
+            {controlRequestError && <Components.Alert severity="ERROR" title={controlRequestError} className="mt-4" />}
             <Components.Button
-                disabled={loading}
+                disabled={loadingControlRequest}
                 title="Take over editing"
-                onClick={handleTakeOverEditing}
+                onClick={handleControlRequest}
                 endIcon={<OutlineIcons.PencilSquareIcon className="h-4" />}
                 className="mt-5 w-fit bg-green-600 px-3 text-white-50 children:border-none children:text-white-50"
             />
@@ -204,9 +141,11 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
                     ) : (
                         <>
                             <p className="flex-grow pb-5">New draft not created</p>
-                            {error && <Components.Alert severity="ERROR" title={error} className="mt-4" />}
+                            {newVersionError && (
+                                <Components.Alert severity="ERROR" title={newVersionError} className="mt-4" />
+                            )}
                             <Components.Button
-                                disabled={loading}
+                                disabled={loadingNewVersion}
                                 title="Create Draft Version"
                                 onClick={handleCreateNewVersion}
                                 endIcon={<OutlineIcons.PencilSquareIcon className="h-4" />}

--- a/ui/src/components/Publication/VersionsAccordion/VersionsAccordion.tsx
+++ b/ui/src/components/Publication/VersionsAccordion/VersionsAccordion.tsx
@@ -1,17 +1,45 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import * as OutlineIcons from '@heroicons/react/24/outline';
 import * as Interfaces from '@interfaces';
 import * as Types from '@types';
 import * as Components from '@components';
+import * as Stores from '@stores';
 import * as Framer from 'framer-motion';
+import * as Hooks from '@hooks';
+import * as Config from '@config';
 
 type Props = {
     versions: Types.PartialPublicationVersion[];
     selectedVersion: Interfaces.PublicationVersion;
+    controlRequests: Interfaces.ControlRequest[];
+    onServerError: (errorMessage: string) => void;
+    onUnlockPublication: () => Promise<void>;
 };
 
 const VersionsAccordion: React.FC<Props> = (props) => {
-    const [expanded, setExpanded] = useState(false);
+    const [expanded, setExpanded] = useState(true);
+    const { user } = Stores.useAuthStore();
+    const { handleControlRequest, controlRequestError } = Hooks.useControlRequest(props.selectedVersion.versionOf);
+    const { handleCreateNewVersion, loadingNewVersion, newVersionError } = Hooks.useCreateNewVersion(
+        props.selectedVersion.versionOf
+    );
+
+    useEffect(() => props.onServerError(controlRequestError), [controlRequestError, props]);
+    useEffect(() => props.onServerError(newVersionError), [newVersionError, props]);
+
+    const isAuthorOnLatestLiveVersion = props.versions.some(
+        (version) => version.isLatestLiveVersion && version.coAuthors.some((author) => author.linkedUser === user?.id)
+    );
+    const latestVersion = props.versions.find((version) => version.isLatestVersion);
+    const canCreateNewVersion = isAuthorOnLatestLiveVersion && (latestVersion?.isLatestLiveVersion || false);
+    const canRequestControl =
+        isAuthorOnLatestLiveVersion && !canCreateNewVersion && latestVersion?.createdBy !== user?.id;
+    const hasAlreadyRequestedControl = props.controlRequests.some(
+        (request) => request.data.publicationVersion.versionOf === props.selectedVersion.versionOf
+    );
+    const canEditDraft = Boolean(
+        latestVersion && !latestVersion.isLatestLiveVersion && latestVersion.createdBy === user?.id
+    );
 
     return (
         <Framer.AnimatePresence>
@@ -49,6 +77,59 @@ const VersionsAccordion: React.FC<Props> = (props) => {
                             exit={{ height: 0 }}
                         >
                             <div className="space-y-3 px-6 py-4">
+                                {canEditDraft &&
+                                    (latestVersion?.currentStatus === 'LOCKED' ? (
+                                        <Components.Link
+                                            title="Edit Draft"
+                                            className="flex w-fit rounded border-transparent text-sm font-semibold text-teal-600 outline-0 transition-colors duration-500 hover:underline focus:overflow-hidden focus:ring-2 focus:ring-yellow-400 dark:text-teal-400"
+                                            href={`${Config.urls.viewPublication.path}/${props.selectedVersion.versionOf}/edit?step=0`}
+                                            onClick={async (e) => {
+                                                e.preventDefault();
+                                                await props.onUnlockPublication();
+                                            }}
+                                        >
+                                            Edit Draft &nbsp;
+                                            <OutlineIcons.PencilSquareIcon className="inline w-4" />
+                                        </Components.Link>
+                                    ) : (
+                                        <Components.Link
+                                            title="Edit Draft"
+                                            className="flex w-fit rounded border-transparent text-sm font-semibold text-teal-600 outline-0 transition-colors duration-500 hover:underline focus:overflow-hidden focus:ring-2 focus:ring-yellow-400 dark:text-teal-400"
+                                            href={`${Config.urls.viewPublication.path}/${props.selectedVersion.versionOf}/edit?step=0`}
+                                        >
+                                            Edit Draft &nbsp;
+                                            <OutlineIcons.PencilSquareIcon className="inline w-4" />
+                                        </Components.Link>
+                                    ))}
+                                {canCreateNewVersion && (
+                                    <Components.Link
+                                        title="Create new version"
+                                        className="flex w-fit rounded border-transparent text-sm font-semibold text-teal-600 outline-0 transition-colors duration-500 hover:underline focus:overflow-hidden focus:ring-2 focus:ring-yellow-400 dark:text-teal-400"
+                                        href="#"
+                                        onClick={handleCreateNewVersion}
+                                    >
+                                        Create new version &nbsp;
+                                        <OutlineIcons.PencilSquareIcon className="inline w-4" />
+                                    </Components.Link>
+                                )}
+                                {canRequestControl && !hasAlreadyRequestedControl && (
+                                    <Components.Link
+                                        title="Take over editing"
+                                        className="flex w-fit rounded border-transparent text-sm font-semibold text-teal-600 outline-0 transition-colors duration-500 hover:underline focus:overflow-hidden focus:ring-2 focus:ring-yellow-400 dark:text-teal-400"
+                                        href="#"
+                                        onClick={handleControlRequest}
+                                    >
+                                        Take over editing&nbsp;
+                                        <OutlineIcons.PencilSquareIcon className="inline w-4" />
+                                    </Components.Link>
+                                )}
+
+                                {isAuthorOnLatestLiveVersion && !latestVersion && (
+                                    <p className="text-sm font-semibold text-grey-800 transition-colors duration-500 dark:text-grey-100">
+                                        Version {props.versions.length + 1}: Currently being edited
+                                    </p>
+                                )}
+
                                 {props.versions
                                     .sort((version1, version2) => version2.versionNumber - version1.versionNumber)
                                     .map((version) =>

--- a/ui/src/components/Publication/VersionsAccordion/VersionsAccordion.tsx
+++ b/ui/src/components/Publication/VersionsAccordion/VersionsAccordion.tsx
@@ -104,7 +104,7 @@ const VersionsAccordion: React.FC<Props> = (props) => {
                                 {canCreateNewVersion && (
                                     <Components.Link
                                         title="Create new version"
-                                        className="flex w-fit rounded border-transparent text-sm font-semibold text-teal-600 outline-0 transition-colors duration-500 hover:underline focus:overflow-hidden focus:ring-2 focus:ring-yellow-400 dark:text-teal-400"
+                                        className="flex w-fit rounded border-transparent text-sm font-semibold capitalize text-teal-600 outline-0 transition-colors duration-500 hover:underline focus:overflow-hidden focus:ring-2 focus:ring-yellow-400 dark:text-teal-400"
                                         href="#"
                                         onClick={handleCreateNewVersion}
                                     >

--- a/ui/src/components/Publication/VersionsAccordion/VersionsAccordion.tsx
+++ b/ui/src/components/Publication/VersionsAccordion/VersionsAccordion.tsx
@@ -101,6 +101,7 @@ const VersionsAccordion: React.FC<Props> = (props) => {
                                             <OutlineIcons.PencilSquareIcon className="inline w-4" />
                                         </Components.Link>
                                     ))}
+
                                 {canCreateNewVersion && (
                                     <Components.Link
                                         title="Create new version"
@@ -112,6 +113,7 @@ const VersionsAccordion: React.FC<Props> = (props) => {
                                         <OutlineIcons.PencilSquareIcon className="inline w-4" />
                                     </Components.Link>
                                 )}
+
                                 {canRequestControl && !hasAlreadyRequestedControl && (
                                     <Components.Link
                                         title="Take over editing"
@@ -119,7 +121,7 @@ const VersionsAccordion: React.FC<Props> = (props) => {
                                         href="#"
                                         onClick={handleControlRequest}
                                     >
-                                        Take over editing&nbsp;
+                                        Take over editing &nbsp;
                                         <OutlineIcons.PencilSquareIcon className="inline w-4" />
                                     </Components.Link>
                                 )}

--- a/ui/src/hooks/index.ts
+++ b/ui/src/hooks/index.ts
@@ -1,3 +1,5 @@
 export { default as useMediaQuery } from './useMediaQuery';
 export { default as useAuthCheck } from './useAuthCheck';
 export { default as useMatomoNext } from './useMatomoNext';
+export { default as useControlRequest } from './useControlRequest';
+export { default as useCreateNewVersion } from './useCreateNewVersion';

--- a/ui/src/hooks/useControlRequest.tsx
+++ b/ui/src/hooks/useControlRequest.tsx
@@ -1,0 +1,57 @@
+import React, { useCallback, useState } from 'react';
+import axios from 'axios';
+import * as Config from '@config';
+import * as Contexts from '@contexts';
+import * as SWRConfig from 'swr';
+import * as FaIcons from 'react-icons/fa';
+import * as api from '@api';
+import * as Helpers from '@helpers';
+
+const useControlRequest = (publicationId: string) => {
+    const confirmation = Contexts.useConfirmationModal();
+    const [loadingControlRequest, setLoadingControlRequest] = useState(false);
+    const [controlRequestError, setControlRequestError] = useState('');
+
+    const handleControlRequest = useCallback(
+        async (e: React.MouseEvent<Element, MouseEvent>) => {
+            if (loadingControlRequest) {
+                return;
+            }
+
+            const confirmed = await confirmation(
+                'Take over editing',
+                'This action will remove the current corresponding author and allow you to make edits instead. Are you sure you want to do this?',
+                <FaIcons.FaEdit className="h-8 w-8 text-grey-600" />,
+                'Request Control'
+            );
+
+            if (confirmed) {
+                setControlRequestError('');
+                setLoadingControlRequest(true);
+
+                try {
+                    // create new version
+                    await api.get(
+                        `${Config.endpoints.publications}/${publicationId}/publication-versions/latest/request-control`,
+                        Helpers.getJWT()
+                    );
+
+                    // re-fetch control requests for this user
+                    await SWRConfig.mutate(`${Config.endpoints.users}/me/control-requests`);
+                } catch (error) {
+                    console.log(error);
+                    setControlRequestError(
+                        axios.isAxiosError(error) ? error.response?.data?.message : (error as Error).message
+                    );
+                }
+
+                setLoadingControlRequest(false);
+            }
+        },
+        [confirmation, loadingControlRequest, publicationId]
+    );
+
+    return { handleControlRequest, loadingControlRequest, controlRequestError };
+};
+
+export default useControlRequest;

--- a/ui/src/hooks/useCreateNewVersion.ts
+++ b/ui/src/hooks/useCreateNewVersion.ts
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import * as Config from '@config';
+import * as api from '@api';
+import * as Helpers from '@helpers';
+import { useRouter } from 'next/router';
+
+const useCreateNewVersion = (publicationId: string) => {
+    const router = useRouter();
+    const [loadingNewVersion, setLoadingNewVersion] = useState(false);
+    const [newVersionError, setNewVersionError] = useState('');
+
+    const handleCreateNewVersion = React.useCallback(
+        async (e: React.MouseEvent<Element, MouseEvent>) => {
+            if (loadingNewVersion) {
+                return;
+            }
+
+            setNewVersionError('');
+            setLoadingNewVersion(true);
+
+            try {
+                // create new version
+                await api.post(
+                    `${Config.endpoints.publications}/${publicationId}/publication-versions`,
+                    {},
+                    Helpers.getJWT()
+                );
+
+                // redirect user to the edit page
+                await router.push(`/publications/${publicationId}/edit?step=0`);
+            } catch (error) {
+                console.log(error);
+                setNewVersionError(
+                    axios.isAxiosError(error) ? error.response?.data?.message : (error as Error).message
+                );
+            }
+
+            setLoadingNewVersion(false);
+        },
+        [loadingNewVersion, publicationId, router]
+    );
+
+    return { handleCreateNewVersion, loadingNewVersion, newVersionError };
+};
+
+export default useCreateNewVersion;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -339,4 +339,6 @@ export type PartialPublicationVersion = Pick<
     | 'publishedDate'
     | 'isLatestLiveVersion'
     | 'isLatestVersion'
+    | 'coAuthors'
+    | 'currentStatus'
 >;

--- a/ui/src/pages/publications/[id]/versions/[versionId].tsx
+++ b/ui/src/pages/publications/[id]/versions/[versionId].tsx
@@ -1,14 +1,9 @@
-/**
- * This page is a temporary copy of /publications/[id] page and will be only available on local and int stages until we release versioning work on prod
- * If trying to access this page on prod, the user will be redirected back to the /publications/[id]
- */
 import React, { useEffect, useMemo } from 'react';
 import parse from 'html-react-parser';
 import Head from 'next/head';
 import useSWR from 'swr';
 import axios from 'axios';
 import * as Framer from 'framer-motion';
-
 import * as OutlineIcons from '@heroicons/react/24/outline';
 import * as api from '@api';
 import * as Components from '@components';
@@ -65,10 +60,20 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
             .then((res) => ({ publicationVersion: res.data, versionRequestError: null }))
             .catch((error) => {
                 console.log(error);
-                const status = error.response.status;
-                const message = error.response.data.message;
 
-                return { publicationVersion: null, versionRequestError: { status, message } };
+                // check if the api responded with an error
+                // if the api is not reachable, trying to access error.response.status will throw an error
+                if (axios.isAxiosError(error)) {
+                    const status = error.response?.status as number;
+                    const message = error.response?.data.message as string;
+
+                    return { publicationVersion: null, versionRequestError: { status, message } };
+                }
+
+                return {
+                    publicationVersion: null,
+                    versionRequestError: { status: 500, message: 'Unknown Server error' }
+                };
             }),
         api
             .get(`${Config.endpoints.bookmarks}?type=PUBLICATION&entityId=${requestedId}`, token)
@@ -148,6 +153,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
     const [approvalError, setApprovalError] = React.useState('');
     const [serverError, setServerError] = React.useState('');
     const [isEditingAffiliations, setIsEditingAffiliations] = React.useState(false);
+    const [isUnlocking, setIsUnlocking] = React.useState(false);
 
     useEffect(() => {
         setBookmarkId(props.bookmarkId);
@@ -186,9 +192,15 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
             versions: Types.PartialPublicationVersion[];
         }
     >(
-        publicationVersion?.versionNumber === 1 && publicationVersion.isLatestVersion
-            ? null // don't fetch data if there is only one version available
-            : `${Config.endpoints.publications}/${props.publicationId}?fields=id,type,versions(id,doi,versionOf,versionNumber,createdBy,publishedDate,isLatestLiveVersion,isLatestVersion)`
+        `${Config.endpoints.publications}/${props.publicationId}?fields=id,type,versions(id,doi,currentStatus,versionOf,versionNumber,createdBy,publishedDate,isLatestLiveVersion,isLatestVersion,coAuthors)`
+    );
+
+    const { data: controlRequests = [], isLoading: isLoadingControlRequests } = useSWR<Interfaces.ControlRequest[]>(
+        user ? `${Config.endpoints.users}/me/control-requests` : null
+    );
+
+    const hasAlreadyRequestedControl = controlRequests.some(
+        (request) => request.data.publicationVersion.versionOf === props.publicationId
     );
 
     const peerReviews = linkedFrom.filter((link) => link.type === 'PEER_REVIEW') || [];
@@ -199,10 +211,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
     // problems linked from this publication
     const childProblems = linkedFrom.filter((link) => link.type === 'PROBLEM') || [];
 
-    const isBookmarkButtonVisible = useMemo(
-        () => user && publicationVersion?.currentStatus === 'LIVE',
-        [publicationVersion, user]
-    );
+    const isBookmarkButtonVisible = user && publicationVersion?.currentStatus === 'LIVE';
 
     const list = [];
 
@@ -214,7 +223,6 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
     const showEthicalStatement =
         publicationVersion?.publication.type === 'DATA' && Boolean(publicationVersion.ethicalStatement);
     const showRedFlags = !!flags.length;
-    const showVersionsAccordion = publication && publication.versions.length > 1;
 
     if (showReferences) list.push({ title: 'References', href: 'references' });
     if (showChildProblems || showParentProblems) list.push({ title: 'Linked problems', href: 'problems' });
@@ -337,6 +345,10 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
     }, [confirmation, publicationVersion?.id, router]);
 
     const handleUnlock = async () => {
+        if (isUnlocking) {
+            return;
+        }
+
         const confirmed = await confirmation(
             'Are you sure you want to cancel and unlock?',
             'Unlocking this publication for editing will invalidate all existing author approvals. Authors will be invited to approve your new changes once you have finished editing',
@@ -346,6 +358,8 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
         );
 
         if (confirmed) {
+            setIsUnlocking(true);
+
             try {
                 await api.put(
                     `${Config.endpoints.publicationVersions}/${publicationVersion?.id}/status/DRAFT`,
@@ -353,11 +367,15 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                     Helpers.getJWT()
                 );
 
-                router.push(`${Config.urls.viewPublication.path}/${publicationVersion?.publication.id}/edit?step=4`);
+                await router.push(
+                    `${Config.urls.viewPublication.path}/${publicationVersion?.publication.id}/edit?step=0`
+                );
             } catch (err) {
                 const unlockError = err as Interfaces.JSONResponseError;
                 setServerError(unlockError.message);
             }
+
+            setIsUnlocking(false);
         }
     };
 
@@ -516,7 +534,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                                     <Components.Link
                                         openNew={false}
                                         title="Edit publication"
-                                        href={`${Config.urls.viewPublication.path}/${publicationVersion.publication.id}/edit?step=4`}
+                                        href={`${Config.urls.viewPublication.path}/${publicationVersion.publication.id}/edit?step=0`}
                                         className="mt-2 flex w-fit items-center space-x-2 text-sm text-white-50 underline"
                                     >
                                         <OutlineIcons.PencilSquareIcon className="w-4" />
@@ -525,6 +543,14 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                                 </Components.Alert>
                             )}
                         </>
+                    )}
+
+                    {hasAlreadyRequestedControl && (
+                        <Components.Alert
+                            severity="INFO"
+                            title="You have requested control over this publication version."
+                            className="mb-4"
+                        />
                     )}
 
                     {showApprovalsTracker && (
@@ -541,7 +567,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                         />
                     )}
 
-                    {serverError && <Components.Alert severity="ERROR" title={serverError} />}
+                    {serverError && <Components.Alert severity="ERROR" className="mb-4" title={serverError} />}
 
                     {showApprovalsTracker && (
                         <div className="pb-16">
@@ -658,14 +684,18 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                         </Framer.AnimatePresence>
 
                         <div className="block lg:hidden">
-                            {showVersionsAccordion && (
+                            {publication && !isLoadingControlRequests && (
                                 <div className="my-8">
                                     <Components.VersionsAccordion
                                         versions={publication.versions}
                                         selectedVersion={publicationVersion}
+                                        controlRequests={controlRequests}
+                                        onServerError={setServerError}
+                                        onUnlockPublication={handleUnlock}
                                     />
                                 </div>
                             )}
+
                             {publicationVersion && (
                                 <SidebarCard
                                     publicationVersion={publicationVersion}
@@ -938,10 +968,13 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                 </section>
                 <aside className="relative hidden lg:col-span-4 lg:block xl:col-span-3">
                     <div className="sticky top-12 space-y-8">
-                        {showVersionsAccordion && (
+                        {publication && !isLoadingControlRequests && (
                             <Components.VersionsAccordion
                                 versions={publication.versions}
                                 selectedVersion={publicationVersion}
+                                controlRequests={controlRequests}
+                                onServerError={setServerError}
+                                onUnlockPublication={handleUnlock}
                             />
                         )}
                         <SidebarCard


### PR DESCRIPTION
_Note! This branch needs to be rebased with main after #541  is being merged_

The purpose of this PR was to provide options for create/edit draft versions from 'Versions' dropdown on the publication page. And also provide option for co-authors to request control over the new version

---

### Acceptance Criteria:

As per [OC-727](https://jiscdev.atlassian.net/browse/OC-727)

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added

---

### Tests:

<img width="614" alt="image" src="https://github.com/JiscSD/octopus/assets/48569671/c5181acd-a5a9-478a-8487-95d5f4bab32e">


---

### Screenshots:

![image](https://github.com/JiscSD/octopus/assets/48569671/1a044664-0390-427d-8972-322632f3f92e)
![image](https://github.com/JiscSD/octopus/assets/48569671/cc30ae7c-4577-4e5c-befa-ef65194c3163)
![image](https://github.com/JiscSD/octopus/assets/48569671/825fdc4b-3c56-4b5a-affc-7f20dc5c9250)
![image](https://github.com/JiscSD/octopus/assets/48569671/061b41ee-920e-42a2-90db-687abfa2992a)


[OC-727]: https://jiscdev.atlassian.net/browse/OC-727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ