### PR TITLE
OC-736 Notify old corresponding author of automatic replacement

### DIFF
--- a/api/src/components/event/service.ts
+++ b/api/src/components/event/service.ts
@@ -132,6 +132,13 @@ export const processRequestControlEvents = async (requestControlEvents: I.Reques
                     true // is automatically approved
                 );
 
+                // notify old corresponding author they've been removed
+                await email.removeCorrespondingAuthor({
+                    newCorrespondingAuthorFullName: `${requester.firstName} ${requester.lastName}`,
+                    oldCorrespondingAuthorEmail: publicationVersion.user.email || '',
+                    publicationVersionTitle: publicationVersion.title || ''
+                });
+
                 // delete all pending requests for this publication version
                 await deleteMany({
                     type: 'REQUEST_CONTROL',

--- a/api/src/lib/email.ts
+++ b/api/src/lib/email.ts
@@ -870,3 +870,32 @@ export const approveControlRequest = async (
         subject
     });
 };
+
+type RemoveCorrespondingAuthorOptions = {
+    oldCorrespondingAuthorEmail: string;
+    newCorrespondingAuthorFullName: string;
+    publicationVersionTitle: string;
+};
+
+export const removeCorrespondingAuthor = async (options: RemoveCorrespondingAuthorOptions): Promise<void> => {
+    const subject =
+        'Another author has taken over editing and correspondence responsibility for one of your publications.';
+
+    const html = `
+                <p>${options.newCorrespondingAuthorFullName} had made a request to take over as corresponding author on <strong><i>${options.publicationVersionTitle}</i></strong>.</p>
+                <br/>
+                <p>As two weeks have passed since this request was made without any confirmation or rejection, corresponding authorship has automatically been passed to them. You will no longer be able to make edits to this publication yourself.</p>
+                <br/>
+                <p>Please discuss with the current corresponding author if you feel there may have been a mistake.</p>
+            </p>
+            `;
+
+    const text = `${options.newCorrespondingAuthorFullName} had made a request to take over as corresponding author on '${options.publicationVersionTitle}'. As two weeks have passed since this request was made without any confirmation or rejection, corresponding authorship has automatically been passed to them. You will no longer be able to make edits to this publication yourself. Please discuss with the current corresponding author if you feel there may have been a mistake.`;
+
+    await send({
+        html: standardHTMLEmailTemplate(subject, html, 'Corresponding author status has been transferred.'),
+        text,
+        to: options.oldCorrespondingAuthorEmail,
+        subject
+    });
+};

--- a/api/src/lib/email.ts
+++ b/api/src/lib/email.ts
@@ -882,9 +882,7 @@ export const removeCorrespondingAuthor = async (options: RemoveCorrespondingAuth
         'Another author has taken over editing and correspondence responsibility for one of your publications.';
 
     const html = `
-                <p>${options.newCorrespondingAuthorFullName} had made a request to take over as corresponding author on <strong><i>${options.publicationVersionTitle}</i></strong>.</p>
-                <br/>
-                <p>As two weeks have passed since this request was made without any confirmation or rejection, corresponding authorship has automatically been passed to them. You will no longer be able to make edits to this publication yourself.</p>
+                <p>${options.newCorrespondingAuthorFullName} had made a request to take over as corresponding author on <strong><i>${options.publicationVersionTitle}</i></strong>. As two weeks have passed since this request was made without any confirmation or rejection, corresponding authorship has automatically been passed to them. You will no longer be able to make edits to this publication yourself.</p>
                 <br/>
                 <p>Please discuss with the current corresponding author if you feel there may have been a mistake.</p>
             </p>


### PR DESCRIPTION
The purpose of this PR was to add notification that's being sent to old corresponding author when the ownership over a publication version is automatically transferred.

---

### Acceptance Criteria:

---

### Checklist:

- [ ] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

---

### Screenshots:
![image](https://github.com/JiscSD/octopus/assets/48569671/c94d00b1-0335-4332-999e-9358879a2323)
