### PR TITLE
OC-734 Add new promo video to Octopus

### DIFF
--- a/ui/src/components/Video/HTML/index.tsx
+++ b/ui/src/components/Video/HTML/index.tsx
@@ -6,8 +6,9 @@ type Props = {
     title?: string;
     showCaption: boolean;
     controls: boolean;
+    controlsList?: string;
     poster?: string;
-    width?: number;
+    width?: number | string;
     className?: string;
 };
 
@@ -20,6 +21,7 @@ const HTML: React.FC<Props> = (props): React.ReactElement => (
     >
         <video
             controls={props.controls}
+            controlsList={props.controlsList}
             width={props.width}
             poster={props.poster}
             preload="none"

--- a/ui/src/pages/about.tsx
+++ b/ui/src/pages/about.tsx
@@ -3,11 +3,9 @@ import { NextPage } from 'next';
 import Head from 'next/head';
 import * as OutlineIcons from '@heroicons/react/24/outline';
 import * as Framer from 'framer-motion';
-
 import * as Components from '@components';
 import * as Layouts from '@layouts';
 import * as Config from '@config';
-import * as Types from '@types';
 
 type CardItemProps = {
     title: string;
@@ -145,6 +143,17 @@ const About: NextPage = (): React.ReactElement => (
                         />
                     </div>
                 </div>
+            </PageSection>
+            <PageSection>
+                <Components.HTMLVideo
+                    width="100%"
+                    title="An introduction to Octopus"
+                    showCaption
+                    controls
+                    controlsList="nodownload"
+                    srcMp4="https://octopus-promo-video.s3.eu-west-1.amazonaws.com/Jisc+-+Octopus+Animation.mp4"
+                    poster="https://octopus-promo-video.s3.eu-west-1.amazonaws.com/octopus-promo-video-poster.jpg"
+                />
             </PageSection>
             <PageSection>
                 <div className="mx-auto block lg:w-9/12 xl:w-10/12 2xl:w-7/12">


### PR DESCRIPTION
The purpose of this PR was to add the new octopus promo video under /about page
Poster/thumbnail was confirmed with PO

---

### Acceptance Criteria:

Per [OC-734](https://jiscdev.atlassian.net/browse/OC-734)

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

---

### Screenshots:
![image](https://github.com/JiscSD/octopus/assets/48569671/a5a68d63-45e5-42df-a178-d0a5ccc10819)



[OC-734]: https://jiscdev.atlassian.net/browse/OC-734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ