### PR TITLE
OC-735 Email co-authors when corresponding authorship is transferred

### DIFF
--- a/api/src/components/event/controller.ts
+++ b/api/src/components/event/controller.ts
@@ -2,13 +2,13 @@ import * as I from 'interface';
 import * as eventService from 'event/service';
 
 export const dailyEventCheck = async (): Promise<void> => {
-    const dummyEvents = await eventService.getByTypes(['DUMMY']);
+    const dummyEvents = await eventService.getMany({ type: 'DUMMY' });
 
     if (dummyEvents.length) {
         await eventService.processDummyEvents(dummyEvents as I.DummyEvent[]);
     }
 
-    const requestControlEvents = await eventService.getByTypes(['REQUEST_CONTROL']);
+    const requestControlEvents = await eventService.getMany({ type: 'REQUEST_CONTROL' });
 
     if (requestControlEvents.length) {
         await eventService.processRequestControlEvents(requestControlEvents as I.RequestControlEvent[]);

--- a/api/src/components/publicationVersion/controller.ts
+++ b/api/src/components/publicationVersion/controller.ts
@@ -520,7 +520,8 @@ export const requestControl = async (
         }
 
         // check if this user already requested control over this version
-        const requestControlEvents = await eventService.getByTypes(['REQUEST_CONTROL'], {
+        const requestControlEvents = await eventService.getMany({
+            type: 'REQUEST_CONTROL',
             data: {
                 equals: {
                     requesterId: event.user.id,
@@ -638,6 +639,35 @@ export const approveControlRequest = async (
                 url: `${process.env.BASE_URL}/publications/${publicationVersion.versionOf}/versions/latest`
             }
         });
+
+        // notify the rest of requesters that their control request has been dismissed
+        const otherRequests = (await eventService.getMany({
+            type: 'REQUEST_CONTROL',
+            id: {
+                not: requestControlEvent.id
+            },
+            data: {
+                path: ['publicationVersion', 'id'],
+                equals: publicationVersion.id
+            }
+        })) as I.RequestControlEvent[];
+
+        if (otherRequests.length) {
+            for (const request of otherRequests) {
+                const supersededRequester = await userService.get(request.data.requesterId, true);
+
+                console.log({ supersededRequester });
+
+                if (supersededRequester) {
+                    // send email to the superseded requester
+                    await email.controlRequestSuperseded({
+                        newCorrespondingAuthorFullName: `${requester.firstName} ${requester.lastName}`,
+                        publicationVersionTitle: publicationVersion.title || '',
+                        requesterEmail: supersededRequester.email || ''
+                    });
+                }
+            }
+        }
 
         // delete all pending request control events for this publication version
         await eventService.deleteMany({

--- a/api/src/components/publicationVersion/controller.ts
+++ b/api/src/components/publicationVersion/controller.ts
@@ -656,8 +656,6 @@ export const approveControlRequest = async (
             for (const request of otherRequests) {
                 const supersededRequester = await userService.get(request.data.requesterId, true);
 
-                console.log({ supersededRequester });
-
                 if (supersededRequester) {
                     // send email to the superseded requester
                     await email.controlRequestSuperseded({

--- a/api/src/components/user/controller.ts
+++ b/api/src/components/user/controller.ts
@@ -84,7 +84,8 @@ export const getUserControlRequests = async (event: I.AuthenticatedAPIRequest<un
     const requesterId = event.user.id;
 
     try {
-        const userControlRequests = await eventService.getByTypes(['REQUEST_CONTROL'], {
+        const userControlRequests = await eventService.getMany({
+            type: 'REQUEST_CONTROL',
             data: {
                 path: ['requesterId'],
                 equals: requesterId

--- a/api/src/lib/email.ts
+++ b/api/src/lib/email.ts
@@ -897,3 +897,31 @@ export const removeCorrespondingAuthor = async (options: RemoveCorrespondingAuth
         subject
     });
 };
+
+type ControlRequestSupersededOptions = {
+    requesterEmail: string;
+    newCorrespondingAuthorFullName: string;
+    publicationVersionTitle: string;
+};
+
+export const controlRequestSuperseded = async (options: ControlRequestSupersededOptions): Promise<void> => {
+    const subject = `${options.newCorrespondingAuthorFullName} has been approved as the new corresponding author.`;
+
+    const html = `
+                <p>${options.newCorrespondingAuthorFullName} is now the corresponding author for the following publication on Octopus:</p>
+                <br>
+                <p style="text-align: center"><strong><i>${options.publicationVersionTitle}</i></strong></p>
+                <br>
+                <p>Your request to take over corresponding authorship of this publication has been invalidated by this change. If you would still like to take over corresponding authorship, please discuss this with ${options.newCorrespondingAuthorFullName} or raise a new request.</p>
+            </p>
+            `;
+
+    const text = `${options.newCorrespondingAuthorFullName} is now the corresponding author for the following publication on Octopus: ${options.publicationVersionTitle}. Your request to take over corresponding authorship of this publication has been invalidated by this change. If you would still like to take over corresponding authorship, please discuss this with ${options.newCorrespondingAuthorFullName} or raise a new request.`;
+
+    await send({
+        html: standardHTMLEmailTemplate(subject, html, 'Another author has taken over as corresponding author'),
+        text,
+        to: options.requesterEmail,
+        subject
+    });
+};


### PR DESCRIPTION
The purpose of this PR was to add a new notification for superseded co-authors when publication version ownership is transferred.

---

### Acceptance Criteria:

As per [OC-735](https://jiscdev.atlassian.net/browse/OC-735)

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:
<img width="740" alt="image" src="https://github.com/JiscSD/octopus/assets/48569671/037f8988-ed14-4fdf-b4d3-ccb849082371">

---

### Screenshots:


[OC-735]: https://jiscdev.atlassian.net/browse/OC-735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ