### PR TITLE
OC-747: Change account page draft being edited wording to imply activity

### DIFF
--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -42,7 +42,6 @@ const completeLinkedItemsTab = async (page: Page, linkedPubSearchTerm: string, l
     await page.keyboard.type(linkedPubSearchTerm);
     await page.locator(`[role="option"]:has-text("${linkedPubTitle}")`).click();
     await page.locator(PageModel.publish.linkedItems.addLink).click();
-    await page.waitForResponse((response) => response.url().includes('/links?direct=true') && response.ok());
     await expect(page.locator(PageModel.publish.linkedItems.deletePublicationLink)).toBeVisible();
 
     await page.locator(PageModel.publish.nextButton).click();
@@ -816,7 +815,6 @@ const checkPublicationOnAccountPage = async (
         case 'pending your approval':
             await expect(publicationContainer).toContainText('(Author)');
             await expect(publicationContainer).toContainText('Status: Pending your approval');
-            await expect(publicationContainer.locator(PageModel.myProfile.viewDraftButton)).toBeVisible();
             break;
         case 'approved':
             await expect(publicationContainer).toContainText('Status: Ready to publish');
@@ -825,12 +823,12 @@ const checkPublicationOnAccountPage = async (
             await expect(publicationContainer).toContainText('1 published version');
             await expect(publicationContainer).toContainText('New draft not created');
             await expect(publicationContainer.locator(PageModel.myProfile.createDraftVersionButton)).toBeVisible();
-            await expect(publicationContainer).toContainText('Published on: ');
+            await expect(publicationContainer).toContainText('Published on ');
             await expect(publicationContainer.locator(PageModel.myProfile.viewButton)).toBeVisible();
             break;
         case 'published':
             await expect(publicationContainer.locator(PageModel.myProfile.createDraftVersionButton)).toBeVisible();
-            await expect(publicationContainer).toContainText('Published on: ');
+            await expect(publicationContainer).toContainText('Published on ');
             await expect(publicationContainer.locator(PageModel.myProfile.viewButton)).toBeVisible();
             break;
         case 'own new version':
@@ -838,13 +836,13 @@ const checkPublicationOnAccountPage = async (
             break;
         case "coauthor's new version":
             await expect(publicationContainer).toContainText(
-                'Someone else has created a new draft version, and you do not yet have access to it'
+                'Someone else is working on a new draft version, and you do not yet have access to it'
             );
             break;
         case "coauthor's unlocked draft":
             await expect(publicationContainer).toContainText('Status: Editing in progress');
             await expect(publicationContainer).toContainText(
-                `${Helpers.user2.shortName} has created a new draft version`
+                `${Helpers.user2.shortName} is working on a new draft version`
             );
             break;
     }
@@ -1480,7 +1478,7 @@ test.describe('Publication flow + co-authors', () => {
         await checkPublicationOnAccountPage(page2, { id: publicationId }, 'pending your approval', true);
 
         // Approve publication
-        await page2.getByTestId(publicationContainerTestId).locator(PageModel.myProfile.viewDraftButton).click();
+        await page2.goto(Helpers.UI_BASE + '/publications/' + publicationId);
         await approvePublication(page2);
 
         // Check details as co-author

--- a/ui/src/components/Publication/SimpleResult/index.tsx
+++ b/ui/src/components/Publication/SimpleResult/index.tsx
@@ -158,47 +158,45 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
                 {draftVersion ? (
                     <div className="flex h-full flex-col justify-between">
                         <p>
-                            Last updated:{' '}
+                            Last updated on{' '}
                             <time suppressHydrationWarning>{Helpers.formatDate(draftVersion.updatedAt)}</time>
                         </p>
                         <p className="flex-grow pb-5">
                             Status: {Helpers.getPublicationStatusByAuthor(draftVersion, props.user)}
                         </p>
-                        {['DRAFT', 'LOCKED'].includes(draftVersion.currentStatus) ? (
-                            props.user.id === draftVersion.user.id ? (
-                                <Components.Button
-                                    href={`/publications/${props.publication.id}/edit?step=0`}
-                                    endIcon={<OutlineIcons.PencilSquareIcon className="h-4" />}
-                                    title="Edit Draft"
-                                    className="mt-5 w-fit bg-green-600 px-3 text-white-50 children:border-none children:text-white-50"
-                                />
-                            ) : (
-                                <>
-                                    <p>
-                                        <Components.Link
-                                            href={`${Config.urls.viewUser.path}/${draftVersion.user.id}`}
-                                            className="underline"
-                                        >
-                                            {draftVersion.user.firstName.substring(0, 1)}. {draftVersion.user.lastName}
-                                        </Components.Link>{' '}
-                                        has created a new draft version
-                                    </p>
-                                    {isAuthorOnLatestLive && requestControl}
-                                </>
-                            )
-                        ) : (
+                        {props.user.id !== draftVersion.user.id ? (
+                            <>
+                                <p>
+                                    <Components.Link
+                                        href={`${Config.urls.viewUser.path}/${draftVersion.user.id}`}
+                                        className="underline"
+                                    >
+                                        {draftVersion.user.firstName.substring(0, 1)}. {draftVersion.user.lastName}
+                                    </Components.Link>{' '}
+                                    is working on a new draft version
+                                </p>
+                                {isAuthorOnLatestLive && requestControl}
+                            </>
+                        ) : draftVersion.currentStatus === 'LOCKED' ? (
                             <Components.Button
                                 href={`/publications/${props.publication.id}`}
                                 endIcon={<OutlineIcons.EyeIcon className="h-4" />}
                                 title="View Draft"
                                 className="mt-5 bg-green-600 px-3 text-white-50 children:border-none children:text-white-50"
                             />
+                        ) : (
+                            <Components.Button
+                                href={`/publications/${props.publication.id}/edit?step=0`}
+                                endIcon={<OutlineIcons.PencilSquareIcon className="h-4" />}
+                                title="Edit Draft"
+                                className="mt-5 w-fit bg-green-600 px-3 text-white-50 children:border-none children:text-white-50"
+                            />
                         )}
                     </div>
                 ) : isAuthorOnLatestLive ? (
                     draftExistsWithoutPermission ? (
                         <div className="flex h-full flex-col justify-between">
-                            <p>Someone else has created a new draft version, and you do not yet have access to it.</p>
+                            <p>Someone else is working on a new draft version, and you do not yet have access to it.</p>
                             {requestControl}
                         </div>
                     ) : (
@@ -225,7 +223,7 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
                     <>
                         <div className="flex-grow">
                             <p>
-                                Published on:{' '}
+                                Published on{' '}
                                 <time suppressHydrationWarning>
                                     {latestLiveVersion.publishedDate &&
                                         Helpers.formatDate(latestLiveVersion.publishedDate)}

--- a/ui/src/components/Publication/SimpleResult/index.tsx
+++ b/ui/src/components/Publication/SimpleResult/index.tsx
@@ -182,7 +182,7 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
                                 href={`/publications/${props.publication.id}`}
                                 endIcon={<OutlineIcons.EyeIcon className="h-4" />}
                                 title="View Draft"
-                                className="mt-5 bg-green-600 px-3 text-white-50 children:border-none children:text-white-50"
+                                className="mt-5 w-fit bg-green-600 px-3 text-white-50 children:border-none children:text-white-50"
                             />
                         ) : (
                             <Components.Button


### PR DESCRIPTION
The purpose of this PR was to adjust some text on the my account page to stop implying that the current author is not actively working on the publication.

Also contains a slight tweak to the logic where:
- user is corresponding author
- publication is locked and awaiting approval
- button shown is changed from edit draft to view draft

And accompanying changes to end to end tests to ensure all still pass.

---

### Acceptance Criteria:

1. If a new draft has been created, co-authors on the latest live version who haven’t confirmed involvement in the new draft version see the message “Someone else has is working on a new draft version, and you do not yet have access to it.” (instead of “Someone else has created a new draft version, and you do not yet have access to it.”)
2. If a new draft version has been created and is currently unlocked for editing, co-authors who have confirmed involvement in the new draft version see the message: “<Corresponding author> is working on a new draft version.” 
3. On the account page, the publication date text on live versions now reads “Published on <Date>” (without the colon)
4. On the account page, the last updated text on draft versions now reads “Last updated on <Date>”, (without the colon, and with “on”) 

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

E2E:
<img width="122" alt="Screenshot 2023-12-14 094753" src="https://github.com/JiscSD/octopus/assets/132363734/19fe2b0c-5cdd-429a-81b1-dbfe3ac299d5">

UI:
<img width="262" alt="Screenshot 2023-12-14 094800" src="https://github.com/JiscSD/octopus/assets/132363734/f9d989d4-c249-47b1-929a-4e89b7236482">

