### PR TITLE
Make sure all containers restart automatically

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
 
   localstack:
     image: localstack/localstack:${LOCALSTACK_IMAGE_VERSION:-latest}
+    restart: always
     ports:
       - "4510-4559:4510-4559"
       - "4566:4566"
@@ -42,6 +43,7 @@ services:
 
   opensearch-node1: # This is also the hostname of the container within the Docker network (i.e. https://opensearch-node1/)
     image: opensearchproject/opensearch:2.7.0
+    restart: always
     container_name: opensearch-node1
     environment:
       - cluster.name=opensearch-cluster # Name the cluster
@@ -71,6 +73,7 @@ services:
 
   opensearch-dashboards:
     image: opensearchproject/opensearch-dashboards:2.7.0
+    restart: always
     container_name: opensearch-dashboards
     depends_on:
       - opensearch-node1


### PR DESCRIPTION
I noticed a small thing after I recreated my docker containers - 3 of them don't start automatically when the docker service starts. Since they come as a group it makes sense for either all of them to start together or none. I added the restart = always setting to these three so that the group will always start up together.
