### PR TITLE
OC-740 Filtering the account page

### DIFF
--- a/api/src/components/user/controller.ts
+++ b/api/src/components/user/controller.ts
@@ -39,6 +39,14 @@ export const get = async (
 export const getPublications = async (
     event: I.OptionalAuthenticatedAPIRequest<undefined, I.UserPublicationsFilters, I.GetUserParameters>
 ): Promise<I.JSONResponse> => {
+    const versionStatusArray = event.queryStringParameters?.versionStatus?.split(',') || [];
+
+    if (versionStatusArray && !versionStatusArray.every((status) => I.PublicationStatusEnum[status])) {
+        return response.json(400, {
+            message: "Invalid version status provided. Valid values include 'DRAFT', 'LIVE', 'LOCKED"
+        });
+    }
+
     try {
         const isAccountOwner = Boolean(event.user?.id === event.pathParameters.id);
 
@@ -51,7 +59,8 @@ export const getPublications = async (
         const userPublications = await userService.getPublications(
             event.pathParameters.id,
             event.queryStringParameters,
-            isAccountOwner
+            isAccountOwner,
+            versionStatusArray.length ? (versionStatusArray as I.PublicationStatusEnum[]) : undefined
         );
 
         return response.json(200, userPublications);

--- a/api/src/components/user/controller.ts
+++ b/api/src/components/user/controller.ts
@@ -39,9 +39,10 @@ export const get = async (
 export const getPublications = async (
     event: I.OptionalAuthenticatedAPIRequest<undefined, I.UserPublicationsFilters, I.GetUserParameters>
 ): Promise<I.JSONResponse> => {
-    const versionStatusArray = event.queryStringParameters?.versionStatus?.split(',') || [];
+    const versionStatus = event.queryStringParameters?.versionStatus;
+    const versionStatusArray = versionStatus ? versionStatus.split(',') : [];
 
-    if (versionStatusArray && !versionStatusArray.every((status) => I.PublicationStatusEnum[status])) {
+    if (versionStatusArray.length && versionStatusArray.some((status) => !I.PublicationStatusEnum[status])) {
         return response.json(400, {
             message: "Invalid version status provided. Valid values include 'DRAFT', 'LIVE', 'LOCKED"
         });

--- a/api/src/components/user/schema/getPublications.ts
+++ b/api/src/components/user/schema/getPublications.ts
@@ -12,6 +12,10 @@ const getPublicationsSchema: I.JSONSchemaType<I.UserPublicationsFilters> = {
             type: 'number',
             minimum: 1,
             default: 10
+        },
+        versionStatus: {
+            type: 'string',
+            nullable: true
         }
     },
     required: []

--- a/api/src/components/user/service.ts
+++ b/api/src/components/user/service.ts
@@ -132,7 +132,12 @@ export const get = async (id: string, isAccountOwner = false) => {
     return user;
 };
 
-export const getPublications = async (id: string, params: I.UserPublicationsFilters, isAccountOwner: boolean) => {
+export const getPublications = async (
+    id: string,
+    params: I.UserPublicationsFilters,
+    isAccountOwner: boolean,
+    versionStatusArray?: I.PublicationStatusEnum[]
+) => {
     const { offset, limit } = params;
 
     const where: Prisma.PublicationWhereInput = {
@@ -156,7 +161,19 @@ export const getPublications = async (id: string, params: I.UserPublicationsFilt
                 }
             }
         ],
-        ...(!isAccountOwner && { versions: { some: { isLatestLiveVersion: true } } })
+        ...(isAccountOwner
+            ? versionStatusArray
+                ? {
+                      versions: {
+                          every: {
+                              currentStatus: {
+                                  in: versionStatusArray
+                              }
+                          }
+                      }
+                  }
+                : {}
+            : { versions: { some: { isLatestLiveVersion: true } } })
     };
 
     const userPublications = await client.prisma.publication.findMany({

--- a/api/src/components/user/service.ts
+++ b/api/src/components/user/service.ts
@@ -165,7 +165,7 @@ export const getPublications = async (
             ? versionStatusArray
                 ? {
                       versions: {
-                          every: {
+                          some: {
                               currentStatus: {
                                   in: versionStatusArray
                               }

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -669,11 +669,11 @@ export interface UpdateAffiliationsBody {
 export interface UserPublicationsFilters {
     offset: number;
     limit: number;
+    versionStatus?: string;
 }
 
 export interface SendApprovalReminderPathParams {
     id: string;
-
     coauthor: string;
 }
 

--- a/e2e/tests/LoggedIn/profile.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/profile.e2e.spec.ts
@@ -19,8 +19,8 @@ test.describe('Live author page', () => {
 
         // go to "Live author page" page
         await page.locator(PageModel.header.usernameButton).click();
-        await page.locator(PageModel.header.myProfileButton).click();
-        await page.locator(PageModel.myProfile.liveAuthorPageButton).click();
+        await page.locator(PageModel.header.myAccountButton).click();
+        await page.locator(PageModel.myAccount.liveAuthorPageButton).click();
     });
 
     test.afterAll(async () => {

--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -796,7 +796,7 @@ const checkPublicationOnAccountPage = async (
 ) => {
     if (navigate) {
         await page.locator(PageModel.header.usernameButton).click();
-        await page.locator(PageModel.header.myProfileButton).click();
+        await page.locator(PageModel.header.myAccountButton).click();
     }
     const publicationContainer = await page.getByTestId('publication-' + publicationDetails.id);
     switch (state) {
@@ -806,17 +806,17 @@ const checkPublicationOnAccountPage = async (
             await expect(publicationContainer).toContainText('0 published versions');
             await expect(publicationContainer).toContainText('(Corresponding Author)');
             await expect(publicationContainer).toContainText('Status: Draft');
-            await expect(publicationContainer.locator(PageModel.myProfile.editDraftButton)).toBeVisible();
+            await expect(publicationContainer.locator(PageModel.myAccount.editDraftButton)).toBeVisible();
             await expect(publicationContainer).toContainText('Never published');
             break;
         case 'pending coauthor approval':
             await expect(publicationContainer).toContainText('Status: Pending author approval');
-            await expect(publicationContainer.locator(PageModel.myProfile.viewDraftButton)).toBeVisible();
+            await expect(publicationContainer.locator(PageModel.myAccount.viewDraftButton)).toBeVisible();
             break;
         case 'pending your approval':
             await expect(publicationContainer).toContainText('(Author)');
             await expect(publicationContainer).toContainText('Status: Pending your approval');
-            await expect(publicationContainer.locator(PageModel.myProfile.viewDraftButton)).toBeVisible();
+            await expect(publicationContainer.locator(PageModel.myAccount.viewDraftButton)).toBeVisible();
             break;
         case 'approved':
             await expect(publicationContainer).toContainText('Status: Ready to publish');
@@ -824,14 +824,14 @@ const checkPublicationOnAccountPage = async (
         case 'published once':
             await expect(publicationContainer).toContainText('1 published version');
             await expect(publicationContainer).toContainText('New draft not created');
-            await expect(publicationContainer.locator(PageModel.myProfile.createDraftVersionButton)).toBeVisible();
+            await expect(publicationContainer.locator(PageModel.myAccount.createDraftVersionButton)).toBeVisible();
             await expect(publicationContainer).toContainText('Published on: ');
-            await expect(publicationContainer.locator(PageModel.myProfile.viewButton)).toBeVisible();
+            await expect(publicationContainer.locator(PageModel.myAccount.viewButton)).toBeVisible();
             break;
         case 'published':
-            await expect(publicationContainer.locator(PageModel.myProfile.createDraftVersionButton)).toBeVisible();
+            await expect(publicationContainer.locator(PageModel.myAccount.createDraftVersionButton)).toBeVisible();
             await expect(publicationContainer).toContainText('Published on: ');
-            await expect(publicationContainer.locator(PageModel.myProfile.viewButton)).toBeVisible();
+            await expect(publicationContainer.locator(PageModel.myAccount.viewButton)).toBeVisible();
             break;
         case 'own new version':
             await expect(publicationContainer).toContainText('(Corresponding Author)');
@@ -1452,7 +1452,7 @@ test.describe('Publication flow + co-authors', () => {
         );
 
         // Edit draft
-        await page.getByTestId(publicationContainerTestId).locator(PageModel.myProfile.editDraftButton).click();
+        await page.getByTestId(publicationContainerTestId).locator(PageModel.myAccount.editDraftButton).click();
         await completeKeyInformationTab(page);
         await completeAffiliationsTab(page, true);
         await completeLinkedItemsTab(
@@ -1480,7 +1480,7 @@ test.describe('Publication flow + co-authors', () => {
         await checkPublicationOnAccountPage(page2, { id: publicationId }, 'pending your approval', true);
 
         // Approve publication
-        await page2.getByTestId(publicationContainerTestId).locator(PageModel.myProfile.viewDraftButton).click();
+        await page2.getByTestId(publicationContainerTestId).locator(PageModel.myAccount.viewDraftButton).click();
         await approvePublication(page2);
 
         // Check details as co-author
@@ -1491,7 +1491,7 @@ test.describe('Publication flow + co-authors', () => {
         await checkPublicationOnAccountPage(page, { id: publicationId }, 'approved');
 
         // Publish
-        await page.getByTestId(publicationContainerTestId).locator(PageModel.myProfile.viewDraftButton).click();
+        await page.getByTestId(publicationContainerTestId).locator(PageModel.myAccount.viewDraftButton).click();
         await page.locator(PageModel.publish.publishButton).click();
         await Promise.all([page.waitForNavigation(), page.locator('button[aria-label="Yes"]').click()]);
 
@@ -1502,7 +1502,7 @@ test.describe('Publication flow + co-authors', () => {
         await page2.reload();
         await page2
             .getByTestId(publicationContainerTestId)
-            .locator(PageModel.myProfile.createDraftVersionButton)
+            .locator(PageModel.myAccount.createDraftVersionButton)
             .click();
         await page2.waitForResponse(
             (response) => response.request().method() === 'POST' && response.url().includes('/publication-versions')
@@ -1517,7 +1517,7 @@ test.describe('Publication flow + co-authors', () => {
         await checkPublicationOnAccountPage(page, { id: publicationId }, "coauthor's new version", false);
 
         // Request approval on new version
-        await page2.getByTestId(publicationContainerTestId).locator(PageModel.myProfile.editDraftButton).click();
+        await page2.getByTestId(publicationContainerTestId).locator(PageModel.myAccount.editDraftButton).click();
         await expect(page2.locator(PageModel.publish.requestApprovalButton)).toBeEnabled();
         await page2.locator(PageModel.publish.requestApprovalButton).click();
         await page2.locator(PageModel.publish.confirmRequestApproval).click();
@@ -2158,7 +2158,7 @@ test.describe('Publication flow + co-authors', () => {
         await checkPublicationOnAccountPage(page, { id: publicationId }, 'published once', true);
 
         // create new version
-        await page.getByTestId(publicationTestId).locator(PageModel.myProfile.createDraftVersionButton).click();
+        await page.getByTestId(publicationTestId).locator(PageModel.myAccount.createDraftVersionButton).click();
         await page.waitForResponse(
             (response) => response.request().method() === 'POST' && response.url().includes('/publication-versions')
         );
@@ -2209,7 +2209,7 @@ test.describe('Publication flow + co-authors', () => {
         await checkPublicationOnAccountPage(page, { id: publicationId }, 'published', true);
 
         // create new version
-        await page.getByTestId(publicationTestId).locator(PageModel.myProfile.createDraftVersionButton).click();
+        await page.getByTestId(publicationTestId).locator(PageModel.myAccount.createDraftVersionButton).click();
         await page.waitForResponse(
             (response) => response.request().method() === 'POST' && response.url().includes('/publication-versions')
         );
@@ -2315,7 +2315,7 @@ test.describe('Publication flow + co-authors', () => {
         await checkPublicationOnAccountPage(page, { id: publicationId }, 'published once', true);
 
         // create new version
-        await page.getByTestId(publicationTestId).locator(PageModel.myProfile.createDraftVersionButton).click();
+        await page.getByTestId(publicationTestId).locator(PageModel.myAccount.createDraftVersionButton).click();
         await page.waitForResponse(
             (response) => response.request().method() === 'POST' && response.url().includes('/publication-versions')
         );

--- a/e2e/tests/LoggedIn/z_account.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/z_account.e2e.spec.ts
@@ -1,0 +1,99 @@
+import * as Helpers from '../helpers';
+import { BrowserContext, expect, Page, test } from '@playwright/test';
+import { PageModel } from '../PageModel';
+
+/**
+ * These tests should run after publishing so that users have some LIVE and DRAFT publications
+ */
+
+test.describe('My account page', () => {
+    let context: BrowserContext;
+    let page: Page;
+
+    test.beforeAll(async ({ browser }) => {
+        context = await browser.newContext();
+        page = await context.newPage();
+        // navigate to homepage
+        await page.goto(Helpers.UI_BASE, { waitUntil: 'domcontentloaded' });
+
+        // login
+        await Helpers.login(page, browser);
+        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(`${Helpers.user1.fullName}`);
+
+        // go to '/account' page
+        await page.goto(`${Helpers.UI_BASE}/account`);
+    });
+
+    test.afterAll(async () => {
+        await page.close();
+    });
+
+    test('My account page filters are enabled by default', async () => {
+        await expect(page.locator(`h1:has-text("${Helpers.user1.fullName}")`)).toBeVisible();
+
+        const includeLiveVersion = page.locator('input#include-live-version');
+        const includeDraftVersion = page.locator('input#include-draft-version');
+
+        await expect(includeLiveVersion).toBeVisible();
+        await expect(includeDraftVersion).toBeVisible();
+
+        expect(await includeLiveVersion.isChecked()).toBe(true);
+        expect(await includeDraftVersion.isChecked()).toBe(true);
+    });
+
+    test('My account page shows publications with LIVE and DRAFT versions by default', async () => {
+        // check that there are publications with the message: 'Never published'
+        await expect(page.getByText('Never published').first()).toBeVisible();
+
+        // check that there are publications with LIVE versions
+        await expect(page.getByText('1 published version').first()).toBeVisible();
+    });
+
+    test('My account page only shows publications with a LIVE version when DRAFT checkbox is unchecked', async () => {
+        // check that there are publications with the message: 'Never published'
+        await expect(page.getByText('Never published').first()).toBeVisible();
+
+        // uncheck DRAFT
+        const includeLiveVersion = page.locator('input#include-draft-version');
+        await includeLiveVersion.uncheck();
+        await page.waitForResponse((response) => response.url().includes('&versionStatus=LIVE') && response.ok());
+
+        // check there's no publication with the message: 'Never published'
+        await expect(page.getByText('Never published').first()).not.toBeVisible();
+    });
+
+    test('My account page only shows publications with a DRAFT version when LIVE checkbox is unchecked', async () => {
+        // reset filters
+        await page.reload();
+
+        // check that there are publications with the button 'Create Draft Version'
+        await expect(page.locator('button[title="Create Draft Version"]').first()).toBeVisible();
+
+        // uncheck LIVE
+        const includeLiveVersion = page.locator('input#include-live-version');
+        await includeLiveVersion.uncheck();
+        await page.waitForResponse(
+            (response) => response.url().includes('&versionStatus=DRAFT,LOCKED') && response.ok()
+        );
+
+        // check there's no button 'Create Draft Version' anymore
+        await expect(page.locator('button[title="Create Draft Version"]').first()).not.toBeVisible();
+    });
+
+    test('My account page displays publications with DRAFT and LIVE versions when both filters are unchecked', async () => {
+        // reset filters
+        await page.reload();
+
+        // uncheck LIVE
+        const includeLiveVersion = page.locator('input#include-live-version');
+        await includeLiveVersion.uncheck();
+        await page.waitForResponse(
+            (response) => response.url().includes('&versionStatus=DRAFT,LOCKED') && response.ok()
+        );
+
+        // uncheck DRAFT
+        const includeDraftVersion = page.locator('input#include-draft-version');
+        await includeDraftVersion.uncheck();
+        await page.waitForResponse((response) => response.url().includes('/publications?limit=') && response.ok());
+    });
+});

--- a/e2e/tests/PageModel.ts
+++ b/e2e/tests/PageModel.ts
@@ -8,7 +8,7 @@ export const PageModel = {
         publishButton: 'ul a:has-text("Publish")',
         myBookmarksButton: 'a[href="/my-bookmarks"]',
         myPublicationsButton: 'a[href="/account"]',
-        myProfileButton: 'a:has-text("My Account")'
+        myAccountButton: 'a:has-text("My Account")'
     },
     footer: {
         links: [
@@ -133,7 +133,7 @@ export const PageModel = {
         rejectCookies: '#onetrust-reject-all-handler'
     },
     confirmEmail: {},
-    myProfile: {
+    myAccount: {
         liveAuthorPageButton: 'a:has-text("View my public author page")',
         publicationHeader: 'h2:has-text("Publications")',
         editDraftButton: 'a:has-text("Edit Draft")',

--- a/ui/src/pages/account.tsx
+++ b/ui/src/pages/account.tsx
@@ -219,7 +219,6 @@ const Account: Types.NextPage<Props> = (props): React.ReactElement => {
                         <div className="flex flex-wrap gap-4 sm:gap-12">
                             <label htmlFor="include-live-version" className="flex cursor-pointer items-center gap-2">
                                 <input
-                                    required
                                     id="include-live-version"
                                     name="LIVE"
                                     type="checkbox"
@@ -240,7 +239,6 @@ const Account: Types.NextPage<Props> = (props): React.ReactElement => {
 
                             <label htmlFor="include-draft-version" className="flex cursor-pointer items-center gap-2">
                                 <input
-                                    required
                                     id="include-draft-version"
                                     name="DRAFT"
                                     type="checkbox"

--- a/ui/src/pages/account.tsx
+++ b/ui/src/pages/account.tsx
@@ -19,6 +19,7 @@ import * as Framer from 'framer-motion';
 
 export const getServerSideProps: Types.GetServerSideProps = Helpers.withServerSession(async (context, currentUser) => {
     const token = Helpers.getJWT(context);
+    const versionStatus = context.query.versionStatus;
 
     /**
      * @TODO - /user/{id}/publications now returns paginated results
@@ -69,6 +70,7 @@ const Account: Types.NextPage<Props> = (props): React.ReactElement => {
     const { setUser } = Stores.useAuthStore();
     const [revokeAccessError, setRevokeAccessError] = useState<string | null>(null);
     const [isRevokingAccess, setIsRevokingAccess] = useState(false);
+
     const { data: controlRequests = [] } = useSWR<Interfaces.ControlRequest[]>(
         `${Config.endpoints.users}/me/control-requests`,
         null,

--- a/ui/src/pages/account.tsx
+++ b/ui/src/pages/account.tsx
@@ -213,14 +213,11 @@ const Account: Types.NextPage<Props> = (props): React.ReactElement => {
                     </h2>
 
                     <fieldset className="mb-8">
-                        <legend className="mb-2 text-xs font-semibold text-grey-800 transition-colors dark:text-white-50">
+                        <legend className="mb-2 text-sm text-grey-800 transition-colors dark:text-white-50">
                             Include publications with:
                         </legend>
                         <div className="flex flex-wrap gap-4 sm:gap-12">
-                            <label
-                                htmlFor="include-live-version"
-                                className="flex cursor-pointer items-center gap-4 text-sm"
-                            >
+                            <label htmlFor="include-live-version" className="flex cursor-pointer items-center gap-2">
                                 <input
                                     required
                                     id="include-live-version"
@@ -234,17 +231,14 @@ const Account: Types.NextPage<Props> = (props): React.ReactElement => {
                                                 : versionStatusArray.filter((status) => status !== 'LIVE')
                                         )
                                     }
-                                    className="cursor-pointer rounded-sm border-teal-500 bg-white-50 outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400"
+                                    className="cursor-pointer rounded border-teal-500 bg-white-50 outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400"
                                 />
                                 <span className="text-grey-800 transition-colors dark:text-white-50">
                                     A live version
                                 </span>
                             </label>
 
-                            <label
-                                htmlFor="include-draft-version"
-                                className="flex cursor-pointer items-center gap-4 text-sm"
-                            >
+                            <label htmlFor="include-draft-version" className="flex cursor-pointer items-center gap-2">
                                 <input
                                     required
                                     id="include-draft-version"
@@ -260,7 +254,7 @@ const Account: Types.NextPage<Props> = (props): React.ReactElement => {
                                                   )
                                         )
                                     }
-                                    className="cursor-pointer rounded-sm border-teal-500 bg-white-50 outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400"
+                                    className="cursor-pointer rounded border-teal-500 bg-white-50 outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400"
                                 />
                                 <span className="text-grey-800 transition-colors dark:text-white-50">
                                     A draft version


### PR DESCRIPTION
The purpose of this PR was to add filters for DRAFT/LIVE versions on `/account` page

---

### Acceptance Criteria:

As per [OC-740](https://jiscdev.atlassian.net/browse/OC-740)

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

<img width="744" alt="image" src="https://github.com/JiscSD/octopus/assets/48569671/fc5d3ebe-746b-4a1c-a3fa-d2ec81fb84f0">


---

### Screenshots:

![image](https://github.com/JiscSD/octopus/assets/48569671/cb56541b-9ce9-46e4-be53-416b4219e094)


[OC-740]: https://jiscdev.atlassian.net/browse/OC-740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ