### PR TITLE
OC-742: Ensure all edits affect "Last Updated" on account page

### DIFF
--- a/api/src/components/coauthor/service.ts
+++ b/api/src/components/coauthor/service.ts
@@ -1,5 +1,6 @@
 import * as client from 'lib/client';
 import * as I from 'lib/interface';
+import * as publicationVersionService from 'publicationVersion/service';
 import { createId } from '@paralleldrive/cuid2';
 import { Prisma } from '@prisma/client';
 
@@ -48,13 +49,8 @@ export const update = async (id: string, data: Prisma.CoAuthorsUpdateInput) => {
         data
     });
 
-    await client.prisma.publicationVersion.update({
-        where: {
-            id: updateCoAuthor.publicationVersionId
-        },
-        data: {
-            updatedAt: new Date().toISOString()
-        }
+    await publicationVersionService.update(updateCoAuthor.publicationVersionId, {
+        updatedAt: new Date().toISOString()
     });
 
     return updateCoAuthor;
@@ -89,13 +85,8 @@ export const updateAll = async (publicationVersionId: string, authors: I.CoAutho
         )
     );
 
-    await client.prisma.publicationVersion.update({
-        where: {
-            id: publicationVersionId
-        },
-        data: {
-            updatedAt: new Date().toISOString()
-        }
+    await publicationVersionService.update(publicationVersionId, {
+        updatedAt: new Date().toISOString()
     });
 
     return update;
@@ -115,14 +106,12 @@ export const deleteCoAuthor = async (id: string) => {
             id
         }
     });
-    await client.prisma.publicationVersion.update({
-        where: {
-            id: coAuthor?.publicationVersionId
-        },
-        data: {
+
+    if (coAuthor) {
+        await publicationVersionService.update(coAuthor.publicationVersionId, {
             updatedAt: new Date().toISOString()
-        }
-    });
+        });
+    }
 
     return deleteCoAuthor;
 };
@@ -134,13 +123,8 @@ export const deleteCoAuthorByEmail = async (publicationVersionId: string, email:
         }
     });
 
-    await client.prisma.publicationVersion.update({
-        where: {
-            id: publicationVersionId
-        },
-        data: {
-            updatedAt: new Date().toISOString()
-        }
+    await publicationVersionService.update(publicationVersionId, {
+        updatedAt: new Date().toISOString()
     });
 
     return deleteCoAuthor;
@@ -157,13 +141,8 @@ export const linkUser = async (userId: string, publicationVersionId: string, ema
             linkedUser: userId
         }
     });
-    await client.prisma.publicationVersion.update({
-        where: {
-            id: publicationVersionId
-        },
-        data: {
-            updatedAt: new Date().toISOString()
-        }
+    await publicationVersionService.update(publicationVersionId, {
+        updatedAt: new Date().toISOString()
     });
 
     return update;
@@ -177,13 +156,8 @@ export const removeFromPublicationVersion = async (publicationVersionId: string,
             code
         }
     });
-    await client.prisma.publicationVersion.update({
-        where: {
-            id: publicationVersionId
-        },
-        data: {
-            updatedAt: new Date().toISOString()
-        }
+    await publicationVersionService.update(publicationVersionId, {
+        updatedAt: new Date().toISOString()
     });
 
     return removeCoAuthor;
@@ -199,13 +173,8 @@ export const updateConfirmation = async (publicationVersionId: string, userId: s
             confirmedCoAuthor: confirm
         }
     });
-    await client.prisma.publicationVersion.update({
-        where: {
-            id: publicationVersionId
-        },
-        data: {
-            updatedAt: new Date().toISOString()
-        }
+    await publicationVersionService.update(publicationVersionId, {
+        updatedAt: new Date().toISOString()
     });
 
     return updateCoAuthor;
@@ -233,13 +202,8 @@ export const resetCoAuthors = async (publicationVersionId: string) => {
             code: createId()
         }
     });
-    await client.prisma.publicationVersion.update({
-        where: {
-            id: publicationVersionId
-        },
-        data: {
-            updatedAt: new Date().toISOString()
-        }
+    await publicationVersionService.update(publicationVersionId, {
+        updatedAt: new Date().toISOString()
     });
 
     return resetCoAuthors;
@@ -270,13 +234,8 @@ export const updateRequestApprovalStatus = async (publicationVersionId: string, 
             approvalRequested: true
         }
     });
-    await client.prisma.publicationVersion.update({
-        where: {
-            id: publicationVersionId
-        },
-        data: {
-            updatedAt: new Date().toISOString()
-        }
+    await publicationVersionService.update(publicationVersionId, {
+        updatedAt: new Date().toISOString()
     });
 
     return coAuthors;
@@ -294,13 +253,8 @@ export const createCorrespondingAuthor = async (publicationVersion: I.Publicatio
             confirmedCoAuthor: true
         }
     });
-    await client.prisma.publicationVersion.update({
-        where: {
-            id: publicationVersion.id
-        },
-        data: {
-            updatedAt: new Date().toISOString()
-        }
+    await publicationVersionService.update(publicationVersion.id, {
+        updatedAt: new Date().toISOString()
     });
 
     return create;

--- a/api/src/components/coauthor/service.ts
+++ b/api/src/components/coauthor/service.ts
@@ -40,13 +40,25 @@ export const getAllByPublicationVersion = async (publicationVersionId: string) =
     return coAuthors;
 };
 
-export const update = (id: string, data: Prisma.CoAuthorsUpdateInput) =>
-    client.prisma.coAuthors.update({
+export const update = async (id: string, data: Prisma.CoAuthorsUpdateInput) => {
+    const updateCoAuthor = await client.prisma.coAuthors.update({
         where: {
             id
         },
         data
     });
+
+    await client.prisma.publicationVersion.update({
+        where: {
+            id: updateCoAuthor.publicationVersionId
+        },
+        data: {
+            updatedAt: new Date().toISOString()
+        }
+    });
+
+    return updateCoAuthor;
+};
 
 /**
  *
@@ -77,25 +89,62 @@ export const updateAll = async (publicationVersionId: string, authors: I.CoAutho
         )
     );
 
+    await client.prisma.publicationVersion.update({
+        where: {
+            id: publicationVersionId
+        },
+        data: {
+            updatedAt: new Date().toISOString()
+        }
+    });
+
     return update;
 };
 
 export const deleteCoAuthor = async (id: string) => {
+    const coAuthor = await client.prisma.coAuthors.findFirst({
+        where: {
+            id
+        },
+        select: {
+            publicationVersionId: true
+        }
+    });
     const deleteCoAuthor = await client.prisma.coAuthors.delete({
         where: {
             id
+        }
+    });
+    await client.prisma.publicationVersion.update({
+        where: {
+            id: coAuthor?.publicationVersionId
+        },
+        data: {
+            updatedAt: new Date().toISOString()
         }
     });
 
     return deleteCoAuthor;
 };
 
-export const deleteCoAuthorByEmail = (publicationVersionId: string, email: string) =>
-    client.prisma.coAuthors.delete({
+export const deleteCoAuthorByEmail = async (publicationVersionId: string, email: string) => {
+    const deleteCoAuthor = await client.prisma.coAuthors.delete({
         where: {
             publicationVersionId_email: { publicationVersionId, email }
         }
     });
+
+    await client.prisma.publicationVersion.update({
+        where: {
+            id: publicationVersionId
+        },
+        data: {
+            updatedAt: new Date().toISOString()
+        }
+    });
+
+    return deleteCoAuthor;
+};
 
 export const linkUser = async (userId: string, publicationVersionId: string, email: string, code: string) => {
     const update = await client.prisma.coAuthors.updateMany({
@@ -108,18 +157,37 @@ export const linkUser = async (userId: string, publicationVersionId: string, ema
             linkedUser: userId
         }
     });
+    await client.prisma.publicationVersion.update({
+        where: {
+            id: publicationVersionId
+        },
+        data: {
+            updatedAt: new Date().toISOString()
+        }
+    });
 
     return update;
 };
 
-export const removeFromPublicationVersion = async (publicationVersionId: string, email: string, code: string) =>
-    client.prisma.coAuthors.deleteMany({
+export const removeFromPublicationVersion = async (publicationVersionId: string, email: string, code: string) => {
+    const removeCoAuthor = client.prisma.coAuthors.deleteMany({
         where: {
             publicationVersionId,
             email,
             code
         }
     });
+    await client.prisma.publicationVersion.update({
+        where: {
+            id: publicationVersionId
+        },
+        data: {
+            updatedAt: new Date().toISOString()
+        }
+    });
+
+    return removeCoAuthor;
+};
 
 export const updateConfirmation = async (publicationVersionId: string, userId: string, confirm: boolean) => {
     const updateCoAuthor = await client.prisma.coAuthors.updateMany({
@@ -131,6 +199,14 @@ export const updateConfirmation = async (publicationVersionId: string, userId: s
             confirmedCoAuthor: confirm
         }
     });
+    await client.prisma.publicationVersion.update({
+        where: {
+            id: publicationVersionId
+        },
+        data: {
+            updatedAt: new Date().toISOString()
+        }
+    });
 
     return updateCoAuthor;
 };
@@ -139,6 +215,9 @@ export const resetCoAuthors = async (publicationVersionId: string) => {
     const publicationVersion = await client.prisma.publicationVersion.findFirst({
         where: {
             id: publicationVersionId
+        },
+        select: {
+            createdBy: true
         }
     });
 
@@ -152,6 +231,14 @@ export const resetCoAuthors = async (publicationVersionId: string) => {
         data: {
             confirmedCoAuthor: false,
             code: createId()
+        }
+    });
+    await client.prisma.publicationVersion.update({
+        where: {
+            id: publicationVersionId
+        },
+        data: {
+            updatedAt: new Date().toISOString()
         }
     });
 
@@ -183,12 +270,20 @@ export const updateRequestApprovalStatus = async (publicationVersionId: string, 
             approvalRequested: true
         }
     });
+    await client.prisma.publicationVersion.update({
+        where: {
+            id: publicationVersionId
+        },
+        data: {
+            updatedAt: new Date().toISOString()
+        }
+    });
 
     return coAuthors;
 };
 
-export const createCorrespondingAuthor = (publicationVersion: I.PublicationVersion) =>
-    client.prisma.coAuthors.create({
+export const createCorrespondingAuthor = async (publicationVersion: I.PublicationVersion) => {
+    const create = client.prisma.coAuthors.create({
         data: {
             email: publicationVersion.user.email || '',
             publicationVersionId: publicationVersion.id || '',
@@ -199,3 +294,14 @@ export const createCorrespondingAuthor = (publicationVersion: I.PublicationVersi
             confirmedCoAuthor: true
         }
     });
+    await client.prisma.publicationVersion.update({
+        where: {
+            id: publicationVersion.id
+        },
+        data: {
+            updatedAt: new Date().toISOString()
+        }
+    });
+
+    return create;
+};

--- a/api/src/components/funder/service.ts
+++ b/api/src/components/funder/service.ts
@@ -12,6 +12,14 @@ export const create = async (publicationVersionId: string, data: I.CreateFunderR
             link: data.link
         }
     });
+    await client.prisma.publicationVersion.update({
+        where: {
+            id: publicationVersionId
+        },
+        data: {
+            updatedAt: new Date().toISOString()
+        }
+    });
 
     return funder;
 };
@@ -21,6 +29,14 @@ export const destroy = async (publicationVersionId: string, funderId: string) =>
         where: {
             publicationVersionId,
             id: funderId
+        }
+    });
+    await client.prisma.publicationVersion.update({
+        where: {
+            id: publicationVersionId
+        },
+        data: {
+            updatedAt: new Date().toISOString()
         }
     });
 

--- a/api/src/components/funder/service.ts
+++ b/api/src/components/funder/service.ts
@@ -1,5 +1,6 @@
 import * as client from 'lib/client';
 import * as I from 'interface';
+import * as publicationVersionService from 'publicationVersion/service';
 
 export const create = async (publicationVersionId: string, data: I.CreateFunderRequestBody) => {
     const funder = await client.prisma.funders.create({
@@ -12,13 +13,8 @@ export const create = async (publicationVersionId: string, data: I.CreateFunderR
             link: data.link
         }
     });
-    await client.prisma.publicationVersion.update({
-        where: {
-            id: publicationVersionId
-        },
-        data: {
-            updatedAt: new Date().toISOString()
-        }
+    await publicationVersionService.update(publicationVersionId, {
+        updatedAt: new Date().toISOString()
     });
 
     return funder;
@@ -31,13 +27,8 @@ export const destroy = async (publicationVersionId: string, funderId: string) =>
             id: funderId
         }
     });
-    await client.prisma.publicationVersion.update({
-        where: {
-            id: publicationVersionId
-        },
-        data: {
-            updatedAt: new Date().toISOString()
-        }
+    await publicationVersionService.update(publicationVersionId, {
+        updatedAt: new Date().toISOString()
     });
 
     return funder;

--- a/api/src/components/link/service.ts
+++ b/api/src/components/link/service.ts
@@ -8,6 +8,16 @@ export const create = async (fromPublicationId: string, toPublicationId: string)
         }
     });
 
+    await client.prisma.publicationVersion.updateMany({
+        where: {
+            versionOf: fromPublicationId,
+            isLatestVersion: true
+        },
+        data: {
+            updatedAt: new Date().toISOString()
+        }
+    });
+
     return link;
 };
 
@@ -23,9 +33,30 @@ export const doesLinkExist = async (fromPublicationId: string, toPublicationId: 
 };
 
 export const deleteLink = async (id: string) => {
+    const link = await client.prisma.links.findFirst({
+        where: {
+            id
+        },
+        select: {
+            publicationFromRef: {
+                select: {
+                    id: true
+                }
+            }
+        }
+    });
     const deletedLink = await client.prisma.links.delete({
         where: {
             id
+        }
+    });
+    await client.prisma.publicationVersion.updateMany({
+        where: {
+            versionOf: link?.publicationFromRef.id,
+            isLatestVersion: true
+        },
+        data: {
+            updatedAt: new Date().toISOString()
         }
     });
 

--- a/api/src/components/link/service.ts
+++ b/api/src/components/link/service.ts
@@ -9,13 +9,7 @@ export const create = async (fromPublicationId: string, toPublicationId: string)
         }
     });
 
-    const latestVersionFrom = await client.prisma.publicationVersion.findFirst({
-        where: {
-            versionOf: fromPublicationId,
-            isLatestVersion: true
-        },
-        select: { id: true }
-    });
+    const latestVersionFrom = await publicationVersionService.get(fromPublicationId, 'latest');
 
     if (latestVersionFrom) {
         await publicationVersionService.update(latestVersionFrom.id, {
@@ -50,20 +44,20 @@ export const deleteLink = async (id: string) => {
             }
         }
     });
-    const latestVersionFrom = await client.prisma.publicationVersion.findFirst({
-        where: { versionOf: link?.publicationFromRef.id, isLatestVersion: true },
-        select: { id: true }
-    });
     const deletedLink = await client.prisma.links.delete({
         where: {
             id
         }
     });
 
-    if (latestVersionFrom) {
-        await publicationVersionService.update(latestVersionFrom?.id, {
-            updatedAt: new Date().toISOString()
-        });
+    if (link) {
+        const latestVersionFrom = await publicationVersionService.get(link.publicationFromRef.id, 'latest');
+
+        if (latestVersionFrom) {
+            await publicationVersionService.update(latestVersionFrom.id, {
+                updatedAt: new Date().toISOString()
+            });
+        }
     }
 
     return deletedLink;

--- a/api/src/components/publicationVersion/service.ts
+++ b/api/src/components/publicationVersion/service.ts
@@ -230,7 +230,8 @@ export const update = (id: string, data: Prisma.PublicationVersionUpdateInput) =
         where: {
             id
         },
-        data,
+        // Make sure updatedAt changes - only changing relations will not cause this otherwise.
+        data: { ...data, updatedAt: new Date().toISOString() },
         include: {
             publication: {
                 select: {

--- a/api/src/components/reference/service.ts
+++ b/api/src/components/reference/service.ts
@@ -16,7 +16,18 @@ export const updateAll = async (publicationVersionId: string, data: I.UpdateRefe
         }
     });
 
-    return await client.prisma.references.createMany({
+    const create = await client.prisma.references.createMany({
         data
     });
+
+    await client.prisma.publicationVersion.update({
+        where: {
+            id: publicationVersionId
+        },
+        data: {
+            updatedAt: new Date().toISOString()
+        }
+    });
+
+    return create;
 };

--- a/api/src/components/reference/service.ts
+++ b/api/src/components/reference/service.ts
@@ -1,5 +1,6 @@
 import * as client from 'lib/client';
 import * as I from 'interface';
+import * as publicationVersionService from 'publicationVersion/service';
 
 export const getAllByPublicationVersion = async (publicationVersionId: string) => {
     return await client.prisma.references.findMany({
@@ -20,14 +21,7 @@ export const updateAll = async (publicationVersionId: string, data: I.UpdateRefe
         data
     });
 
-    await client.prisma.publicationVersion.update({
-        where: {
-            id: publicationVersionId
-        },
-        data: {
-            updatedAt: new Date().toISOString()
-        }
-    });
+    await publicationVersionService.update(publicationVersionId, { updatedAt: new Date().toISOString() });
 
     return create;
 };

--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -2233,24 +2233,24 @@ test.describe('Publication flow + co-authors', () => {
         await page.locator(PageModel.publish.versionsAccordionButton).waitFor();
 
         // switch between versions
-        await page.click(PageModel.publish.versionsAccordionButton);
-        await expect(page.locator('#versions-accordion p:has-text("Version 3: Currently viewed")')).toBeVisible();
+        const versionsAccordion = await page.locator(PageModel.publish.versionsAccordion);
+        await expect(versionsAccordion.locator('p:has-text("Version 3: Currently viewed")')).toBeVisible();
         expect(page.url()).toContain('/versions/latest');
 
         // switch to v2
-        await page.locator('#versions-accordion a').first().click();
+        await versionsAccordion.locator('a:has-text("Version 2")').click();
         await page.waitForURL('**/versions/2');
-        await expect(page.locator('#versions-accordion a:has-text("Version 3: Draft")')).toBeVisible();
-        await expect(page.locator('#versions-accordion p:has-text("Version 2: Currently viewed")')).toBeVisible();
+        await expect(versionsAccordion.locator('a:has-text("Version 3: Draft")')).toBeVisible();
+        await expect(versionsAccordion.locator('p:has-text("Version 2: Currently viewed")')).toBeVisible();
 
         // switch to v1
-        await page.locator('#versions-accordion a').nth(1).click();
+        await versionsAccordion.locator('a:has-text("Version 1")').click();
         await page.waitForURL('**/versions/1');
-        await expect(page.locator('#versions-accordion a:has-text("Version 3: Draft")')).toBeVisible();
-        await expect(page.locator('#versions-accordion p:has-text("Version 1: Currently viewed")')).toBeVisible();
+        await expect(versionsAccordion.locator('a:has-text("Version 3: Draft")')).toBeVisible();
+        await expect(versionsAccordion.locator('p:has-text("Version 1: Currently viewed")')).toBeVisible();
 
         // switch back to v3
-        await page.locator('#versions-accordion a').first().click();
+        await versionsAccordion.locator('a:has-text("Version 3")').click();
         await page.waitForURL('**/versions/3');
 
         // go back to edit page
@@ -2322,8 +2322,6 @@ test.describe('Publication flow + co-authors', () => {
 
         // wait to be redirected to the edit page
         await page.waitForURL('**/edit?**');
-
-        // go back to preview page
         await page.click(PageModel.publish.previewButton);
         await page.waitForURL('**/versions/latest');
 

--- a/e2e/tests/PageModel.ts
+++ b/e2e/tests/PageModel.ts
@@ -220,6 +220,7 @@ export const PageModel = {
             manualAffiliationLink: 'input[placeholder="Link"]',
             affiliationDetails: 'textarea[placeholder="Enter any details"]'
         },
+        versionsAccordion: 'aside >> #versions-accordion',
         versionsAccordionButton: 'aside button[title="Versions"]'
     },
     coauthorApprove: {},


### PR DESCRIPTION
The purpose of this PR was to make sure that all actions a user would understand to be "updating a publication (version)" update the updatedAt field on the publication version model in the database. Then when this is surfaced in the application it will match up to the actions they have taken.

---

### Acceptance Criteria:

The following items should affect the last updated date of publications on the account page:

1. Edits to the publication version
2. All related entities
3. Funder information
4. Affiliations changes (co author and corresponding author)
5. Co-author approval
6. Co-author changing their mind
7. Co-author denying involvement
8. Co-author being added or removed
9. Publication being locked or unlocked
10. Transfers of corresponding authorship

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

API:
<img width="160" alt="Screenshot 2023-12-20 094900" src="https://github.com/JiscSD/octopus/assets/132363734/50478809-b84a-4482-963c-70f76257794a">

E2E:
<img width="138" alt="Screenshot 2023-12-20 094202" src="https://github.com/JiscSD/octopus/assets/132363734/242fef98-a476-467f-99f8-a7aa04f9347e">
