### PR TITLE
OC-751: Display parent publications on child research problems

### DIFF
--- a/e2e/tests/PageModel.ts
+++ b/e2e/tests/PageModel.ts
@@ -84,7 +84,7 @@ export const PageModel = {
             // content
             '#main-text >> text=How has life on earth evolved?',
             // problems above this
-            'text=Research problems above this in the hierarchy',
+            'text=Publications above this in the hierarchy',
             // problems below this
             'text=Research problems below this in the hierarchy',
             // funders

--- a/ui/src/pages/publications/[id]/versions/[versionId].tsx
+++ b/ui/src/pages/publications/[id]/versions/[versionId].tsx
@@ -205,19 +205,15 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
 
     const peerReviews = linkedFrom.filter((link) => link.type === 'PEER_REVIEW') || [];
 
-    // problems this publication is linked to
-    const parentProblems = linkedTo.filter((link) => link.type === 'PROBLEM') || [];
-
     // problems linked from this publication
     const childProblems = linkedFrom.filter((link) => link.type === 'PROBLEM') || [];
-
     const isBookmarkButtonVisible = user && publicationVersion?.currentStatus === 'LIVE';
 
     const list = [];
 
     const showReferences = Boolean(references?.length);
     const showChildProblems = Boolean(childProblems?.length);
-    const showParentProblems = Boolean(parentProblems?.length);
+    const showParentPublications = Boolean(linkedTo?.length);
     const showTopics = Boolean(publicationVersion?.topics?.length);
     const showPeerReviews = Boolean(peerReviews?.length);
     const showEthicalStatement =
@@ -225,7 +221,8 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
     const showRedFlags = !!flags.length;
 
     if (showReferences) list.push({ title: 'References', href: 'references' });
-    if (showChildProblems || showParentProblems) list.push({ title: 'Linked problems', href: 'problems' });
+    if (showChildProblems || showParentPublications)
+        list.push({ title: 'Linked publications', href: 'linked-publications' });
     if (showTopics) list.push({ title: 'Linked topics', href: 'topics' });
     if (showPeerReviews) list.push({ title: 'Peer reviews', href: 'peer-reviews' });
     if (showEthicalStatement) list.push({ title: 'Ethical statement', href: 'ethical-statement' });
@@ -732,17 +729,17 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                         </Components.ContentSection>
                     )}
 
-                    {(showParentProblems || showChildProblems) && (
-                        <div id="problems">
+                    {(showParentPublications || showChildProblems) && (
+                        <div id="linked-publications">
                             {/* Parent problems */}
-                            {showParentProblems && (
+                            {showParentPublications && (
                                 <Components.ContentSection
-                                    id="problems-linked-to"
-                                    title="Research problems above this in the hierarchy"
+                                    id="publications-linked-to"
+                                    title="Publications above this in the hierarchy"
                                     hasBreak
                                 >
                                     <Components.List ordered={false}>
-                                        {parentProblems.map((link) => (
+                                        {linkedTo.map((link) => (
                                             <Components.ListItem
                                                 key={link.id}
                                                 className="flex items-center font-semibold leading-3"

--- a/ui/src/pages/publications/[id]/versions/[versionId].tsx
+++ b/ui/src/pages/publications/[id]/versions/[versionId].tsx
@@ -205,15 +205,19 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
 
     const peerReviews = linkedFrom.filter((link) => link.type === 'PEER_REVIEW') || [];
 
-    // problems linked from this publication
-    const childProblems = linkedFrom.filter((link) => link.type === 'PROBLEM') || [];
+    // Publications this publication is linked to (only shown on problems)
+    const parentPublications = publicationVersion?.publication.type === 'PROBLEM' ? linkedTo : [];
+
+    // Problems linked from this publication (shown on any type)
+    const childProblems = linkedFrom.filter((link) => link.type === 'PROBLEM');
+
     const isBookmarkButtonVisible = user && publicationVersion?.currentStatus === 'LIVE';
 
     const list = [];
 
     const showReferences = Boolean(references?.length);
-    const showChildProblems = Boolean(childProblems?.length);
-    const showParentPublications = Boolean(linkedTo?.length);
+    const showChildProblems = Boolean(childProblems.length);
+    const showParentPublications = Boolean(parentPublications.length);
     const showTopics = Boolean(publicationVersion?.topics?.length);
     const showPeerReviews = Boolean(peerReviews?.length);
     const showEthicalStatement =
@@ -731,7 +735,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
 
                     {(showParentPublications || showChildProblems) && (
                         <div id="linked-publications">
-                            {/* Parent problems */}
+                            {/* Parent publications */}
                             {showParentPublications && (
                                 <Components.ContentSection
                                     id="publications-linked-to"
@@ -739,7 +743,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                                     hasBreak
                                 >
                                     <Components.List ordered={false}>
-                                        {linkedTo.map((link) => (
+                                        {parentPublications.map((link) => (
                                             <Components.ListItem
                                                 key={link.id}
                                                 className="flex items-center font-semibold leading-3"


### PR DESCRIPTION
The purpose of this PR was to display parent publications of all types, not just other problems, while viewing a research problem. Before this, if a problem was linked to a non-problem publication, that wasn't shown anywhere on the page when viewing it.

---

### Acceptance Criteria:

- On research problems the “Research problems above this in the hierarchy” is renamed to “Publications above this in the hierarchy”.
  - This section includes any publication type of publication (excluding topics) that sit above it in the hierarchy.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

E2E:
<img width="128" alt="Screenshot 2023-12-21 101244" src="https://github.com/JiscSD/octopus/assets/132363734/1c5aca97-7a1d-4498-8537-151fcdffd3bd">

UI:
<img width="266" alt="Screenshot 2023-12-21 101755" src="https://github.com/JiscSD/octopus/assets/132363734/965065fa-5213-4c9e-bfc8-829f0d2d015c">
