### PR TITLE
OC-488 Disable bookmarking god problem and 2nd level LOC items

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -25,6 +25,7 @@
         "createVersionedDOIs": "ts-node -r tsconfig-paths/register prisma/createVersionedDOIs.ts",
         "updateLinksStatus": "ts-node -r tsconfig-paths/register prisma/updateLinksStatus.ts",
         "insertDummyEvent": "ts-node -r tsconfig-paths/register prisma/insertDummyEvent.ts",
+        "deleteHighLevelTopicBookmarks": "ts-node -r tsconfig-paths/register prisma/deleteHighLevelTopicBookmarks.ts",
         "format:check": "npx prettier --check src/",
         "format:write": "npx prettier --write src/",
         "lint:check": "eslint src/",

--- a/api/prisma/deleteHighLevelTopicBookmarks.ts
+++ b/api/prisma/deleteHighLevelTopicBookmarks.ts
@@ -1,0 +1,70 @@
+import * as client from 'lib/client';
+import * as topicService from 'topic/service';
+
+const deleteHighLevelTopicBookmarks = async (): Promise<number> => {
+    const topicBookmarks = await client.prisma.bookmark.findMany({
+        where: {
+            type: 'TOPIC'
+        },
+        select: {
+            id: true,
+            entityId: true
+        }
+    });
+
+    let deletedBookmarksCount = 0;
+
+    const processedEntityIds: string[] = [];
+
+    for (const bookmark of topicBookmarks) {
+        // continue if the bookmarks against this topic were already processed
+        if (processedEntityIds.includes(bookmark.entityId)) {
+            continue;
+        }
+
+        // get the topic
+        const topic = await topicService.get(bookmark.entityId);
+
+        if (!topic) {
+            continue;
+        }
+
+        // check if this is the god topic
+        if (!topic.parents.length) {
+            // delete all bookmarks against this topic
+            const deletedBookmarks = await client.prisma.bookmark.deleteMany({
+                where: {
+                    entityId: bookmark.entityId
+                }
+            });
+
+            deletedBookmarksCount += deletedBookmarks.count;
+        }
+
+        // check if the parent of this topic is the god topic
+        if (topic.parents.length === 1) {
+            const parentTopic = await topicService.get(topic.parents[0].id);
+
+            if (parentTopic && !parentTopic.parents.length) {
+                // delete all bookmarks against this topic
+                const deletedBookmarks = await client.prisma.bookmark.deleteMany({
+                    where: {
+                        entityId: bookmark.entityId
+                    }
+                });
+
+                deletedBookmarksCount += deletedBookmarks.count;
+            }
+        }
+
+        processedEntityIds.push(bookmark.entityId);
+    }
+
+    return deletedBookmarksCount;
+};
+
+deleteHighLevelTopicBookmarks()
+    .then((deletedBookmarksCount) =>
+        console.log(`Successfully deleted ${deletedBookmarksCount} bookmarks against high level topics.`)
+    )
+    .catch((error) => console.log(error));

--- a/api/prisma/seeds/topicsDevSeedData.ts
+++ b/api/prisma/seeds/topicsDevSeedData.ts
@@ -24,7 +24,15 @@ const topicSeeds: Prisma.TopicCreateInput[] = [
                 },
                 {
                     id: 'test-topic-1b',
-                    title: 'Test sub-topic B'
+                    title: 'Test sub-topic B',
+                    children: {
+                        create: [
+                            {
+                                id: 'test-topic-1b-1',
+                                title: 'Test sub-topic B 1'
+                            }
+                        ]
+                    }
                 }
             ]
         }

--- a/api/src/components/bookmark/__tests__/createBookmark.test.ts
+++ b/api/src/components/bookmark/__tests__/createBookmark.test.ts
@@ -1,7 +1,7 @@
 import * as testUtils from 'lib/testUtils';
 
 describe('Create a bookmark', () => {
-    beforeEach(async () => {
+    beforeAll(async () => {
         await testUtils.clearDB();
         await testUtils.testSeed();
     });
@@ -9,7 +9,7 @@ describe('Create a bookmark', () => {
     test('Create a bookmark', async () => {
         const bookmark = await testUtils.agent.post('/bookmarks').query({ apiKey: '000000003' }).send({
             type: 'TOPIC',
-            entityId: 'test-topic-1'
+            entityId: 'test-topic-1b-1'
         });
 
         expect(bookmark.status).toEqual(201);
@@ -25,9 +25,9 @@ describe('Create a bookmark', () => {
     });
 
     test('Cannot create a bookmark where one already exists', async () => {
-        const bookmark = await testUtils.agent.post('/bookmarks').query({ apiKey: '987654321' }).send({
+        const bookmark = await testUtils.agent.post('/bookmarks').query({ apiKey: '000000003' }).send({
             type: 'TOPIC',
-            entityId: 'test-topic-1'
+            entityId: 'test-topic-1b-1'
         });
 
         expect(bookmark.status).toEqual(400);
@@ -46,6 +46,24 @@ describe('Create a bookmark', () => {
         const bookmark = await testUtils.agent.post('/bookmarks').query({ apiKey: '000000003' }).send({
             type: 'PUBLICATION',
             entityId: 'publication-problem-draft'
+        });
+
+        expect(bookmark.status).toEqual(403);
+    });
+
+    test('Cannot create a bookmark against the god topic', async () => {
+        const bookmark = await testUtils.agent.post('/bookmarks').query({ apiKey: '000000003' }).send({
+            type: 'TOPIC',
+            entityId: 'test-topic-1'
+        });
+
+        expect(bookmark.status).toEqual(403);
+    });
+
+    test('Cannot create a bookmark against the first level topics under the god topic', async () => {
+        const bookmark = await testUtils.agent.post('/bookmarks').query({ apiKey: '000000003' }).send({
+            type: 'TOPIC',
+            entityId: 'test-topic-1b'
         });
 
         expect(bookmark.status).toEqual(403);

--- a/api/src/components/bookmark/controller.ts
+++ b/api/src/components/bookmark/controller.ts
@@ -42,6 +42,22 @@ export const create = async (
                     });
                 }
 
+                // check if it's god topic
+                if (!topic.parents.length) {
+                    return response.json(403, { message: 'Bookmarking against the high level topics is not allowed.' });
+                }
+
+                // check if the parent of this topic is the god topic
+                if (topic.parents.length === 1) {
+                    const parentTopic = await topicService.get(topic.parents[0].id);
+
+                    if (!parentTopic?.parents.length) {
+                        return response.json(403, {
+                            message: 'Bookmarking against the high level topics is not allowed.'
+                        });
+                    }
+                }
+
                 break;
             }
 

--- a/api/src/components/bookmark/controller.ts
+++ b/api/src/components/bookmark/controller.ts
@@ -44,7 +44,7 @@ export const create = async (
 
                 // check if it's god topic
                 if (!topic.parents.length) {
-                    return response.json(403, { message: 'Bookmarking against the high level topics is not allowed.' });
+                    return response.json(403, { message: 'Bookmarking against high level topics is not allowed.' });
                 }
 
                 // check if the parent of this topic is the god topic
@@ -53,7 +53,7 @@ export const create = async (
 
                     if (!parentTopic?.parents.length) {
                         return response.json(403, {
-                            message: 'Bookmarking against the high level topics is not allowed.'
+                            message: 'Bookmarking against high level topics is not allowed.'
                         });
                     }
                 }

--- a/e2e/tests/LoggedIn/topic.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/topic.e2e.spec.ts
@@ -7,12 +7,14 @@ test.describe.configure({ mode: 'serial' });
 // Recreate parameter controls the behaviour when a bookmark already exists.
 // If true, it will remove and recreate it; if false, it will leave it.
 const ensureBookmarkPresent = async (page: Page, recreate: boolean = false) => {
-    await page.goto(`${Helpers.UI_BASE}/topics/test-topic-1`, {
+    await page.goto(`${Helpers.UI_BASE}/topics/test-topic-1b-1`, {
         waitUntil: 'domcontentloaded'
     });
 
     // Bookmark topic
-    await expect(page.locator('h1')).toHaveText('Test topic');
+    await expect(page.locator('h1')).toHaveText('Test sub-topic B 1');
+
+    await page.waitForResponse((response) => response.url().includes('/topics') && response.ok());
 
     const isRemoveBookmarkVisible = await page.isVisible(PageModel.topic.removeBookmark);
     if (isRemoveBookmarkVisible) {
@@ -25,10 +27,9 @@ const ensureBookmarkPresent = async (page: Page, recreate: boolean = false) => {
         await expect(page.locator(PageModel.topic.addBookmark)).toBeVisible();
         await page.locator(PageModel.topic.addBookmark).click();
     }
-}
+};
 
 test.describe('Topic page', () => {
-
     test('Bookmark a topic', async ({ browser }) => {
         // Start up test
         const page = await browser.newPage();
@@ -40,11 +41,12 @@ test.describe('Topic page', () => {
 
         // Add bookmark
         await ensureBookmarkPresent(page, true);
-    
+
         // Confirm it is present on 'my bookmarks' page
         await page.locator(PageModel.header.usernameButton).click();
         await page.locator(PageModel.header.myBookmarksButton).click();
-    
+        await page.waitForURL('**/my-bookmarks');
+
         await expect(page.locator(PageModel.myBookmarks.topicBookmark)).toBeVisible();
     });
 

--- a/e2e/tests/PageModel.ts
+++ b/e2e/tests/PageModel.ts
@@ -146,8 +146,8 @@ export const PageModel = {
     },
     myBookmarks: {
         publicationBookmark: 'a[href="/publications/cl3fz14dr0001es6i5ji51rq4"]',
-        topicBookmark: 'a[href="/topics/test-topic-1"]',
-        removeTopicBookmark: 'a[href="/topics/test-topic-1"] + button[aria-label="Remove bookmark"]'
+        topicBookmark: 'a[href="/topics/test-topic-1b-1"]',
+        removeTopicBookmark: 'a[href="/topics/test-topic-1b-1"] + button[aria-label="Remove bookmark"]'
     },
     publish: {
         title: 'input[type="text"]',

--- a/ui/src/pages/topics/[id]/index.tsx
+++ b/ui/src/pages/topics/[id]/index.tsx
@@ -70,6 +70,7 @@ const Topic: Types.NextPage<Props> = (props): React.ReactElement => {
         setBookmarkId(props.bookmarkId);
     }, [props.bookmarkId, props.topic.id]);
 
+    // if current topic has only one parent, fetch the parent and check if it's the god topic
     const { data: parentTopic } = useSWR<Interfaces.Topic>(
         topic.parents.length === 1 ? `${Config.endpoints.topics}/${props.topic.parents[0].id}` : null
     );

--- a/ui/src/pages/topics/[id]/index.tsx
+++ b/ui/src/pages/topics/[id]/index.tsx
@@ -11,6 +11,7 @@ import * as Interfaces from '@interfaces';
 import * as Layouts from '@layouts';
 import * as Stores from '@stores';
 import * as Types from '@types';
+import useSWR from 'swr';
 
 export const getServerSideProps: Types.GetServerSideProps = async (context) => {
     const id = context.query.id;
@@ -69,13 +70,14 @@ const Topic: Types.NextPage<Props> = (props): React.ReactElement => {
         setBookmarkId(props.bookmarkId);
     }, [props.bookmarkId, props.topic.id]);
 
-    const isBookmarkButtonVisible = useMemo(() => {
-        if (user && topic) {
-            return true;
-        } else {
-            return false;
-        }
-    }, [topic, user]);
+    const { data: parentTopic } = useSWR<Interfaces.Topic>(
+        topic.parents.length === 1 ? `${Config.endpoints.topics}/${props.topic.parents[0].id}` : null
+    );
+
+    // cannot bookmark god topic and second level topics
+    const isBookmarkButtonVisible = Boolean(
+        user && ((topic && topic.parents.length > 1) || (parentTopic && parentTopic.parents.length))
+    );
 
     const onBookmarkHandler = async () => {
         if (isBookmarked) {


### PR DESCRIPTION
The purpose of this PR was to prevent users from bookmarking god topic and first level topics

---

### Acceptance Criteria:

As per [OC-488](https://jiscdev.atlassian.net/browse/OC-488)

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

<img width="1224" alt="image" src="https://github.com/JiscSD/octopus/assets/48569671/f0145b82-0c6c-4ca8-b270-15c4ad00dc35">


---

### Screenshots:


[OC-488]: https://jiscdev.atlassian.net/browse/OC-488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ