### PR TITLE
OC-762: Co-authors unable to view locked drafts

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -14,7 +14,7 @@ dotenv.config();
 const config: PlaywrightTestConfig = {
     testDir: './tests',
     /* Maximum time one test can run for. */
-    timeout: 180000, // some of the publication flow and coauthor tests exceed 2 minutes. We should try and streamline them but for now set this to 3 mins
+    timeout: 300000, // some of the publication flow and coauthor tests exceed 2 minutes. We should try and streamline them but for now set this to 3 mins
     expect: {
         /**
          * Maximum time expect() should wait for the condition to be met.

--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -796,6 +796,7 @@ const checkPublicationOnAccountPage = async (
     if (navigate) {
         await page.locator(PageModel.header.usernameButton).click();
         await page.locator(PageModel.header.myAccountButton).click();
+        await page.waitForURL(`${Helpers.UI_BASE}/account`);
     }
     const publicationContainer = await page.getByTestId('publication-' + publicationDetails.id);
     switch (state) {
@@ -815,6 +816,7 @@ const checkPublicationOnAccountPage = async (
         case 'pending your approval':
             await expect(publicationContainer).toContainText('(Author)');
             await expect(publicationContainer).toContainText('Status: Pending your approval');
+            await expect(publicationContainer.locator(PageModel.myAccount.viewDraftButton)).toBeVisible();
             break;
         case 'approved':
             await expect(publicationContainer).toContainText('Status: Ready to publish');
@@ -837,12 +839,14 @@ const checkPublicationOnAccountPage = async (
             await expect(publicationContainer).toContainText(
                 'Someone else is working on a new draft version, and you do not yet have access to it'
             );
+            await expect(publicationContainer.locator(PageModel.myAccount.requestControlButton)).toBeVisible();
             break;
         case "coauthor's unlocked draft":
             await expect(publicationContainer).toContainText('Status: Editing in progress');
             await expect(publicationContainer).toContainText(
                 `${Helpers.user2.shortName} is working on a new draft version`
             );
+            await expect(publicationContainer.locator(PageModel.myAccount.viewDraftButton)).toBeVisible();
             break;
     }
 };

--- a/e2e/tests/PageModel.ts
+++ b/e2e/tests/PageModel.ts
@@ -139,7 +139,8 @@ export const PageModel = {
         editDraftButton: 'a:has-text("Edit Draft")',
         viewDraftButton: 'a:has-text("View Draft")',
         createDraftVersionButton: 'button:has-text("Create Draft Version")',
-        viewButton: 'a:has-text("View")'
+        viewButton: 'a:has-text("View")',
+        requestControlButton: 'button:has-text("Take over editing")'
     },
     myPublications: {
         liveAuthorPageButton: 'a:has-text("View my public author page")'

--- a/ui/src/components/Publication/SimpleResult/index.tsx
+++ b/ui/src/components/Publication/SimpleResult/index.tsx
@@ -112,7 +112,12 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
                                     </Components.Link>{' '}
                                     is working on a new draft version
                                 </p>
-                                {isAuthorOnLatestLive && requestControl}
+                                <Components.Button
+                                    href={`/publications/${props.publication.id}`}
+                                    endIcon={<OutlineIcons.EyeIcon className="h-4" />}
+                                    title="View Draft"
+                                    className="mt-5 w-fit bg-green-600 px-3 text-white-50 children:border-none children:text-white-50"
+                                />
                             </>
                         ) : draftVersion.currentStatus === 'LOCKED' ? (
                             <Components.Button


### PR DESCRIPTION
The purpose of this PR was to show a View Draft button for publications on the account page when the user is a confirmed coauthor on a locked publication version.

Unfortunately some of our tests just run over 3 minutes now so I increased the timeout further. We should really restructure these soon to make them much quicker because it's causing small changes to take much longer than they need to if the full tests are run. Then this timeout can be reduced to a sensible value.

---

### Acceptance Criteria:

- As a co-author, whilst a publication is displaying the “pending your approval” status, and is locked, I see a “View Draft” button

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Screenshots:

<img width="689" alt="Screenshot 2024-01-02 153000" src="https://github.com/JiscSD/octopus/assets/132363734/635a2eed-59a5-478a-9496-0e4f544e888b">
