### PR TITLE
OC-763: Display "View Draft" and "Take over editing" at once for co-authors

### DIFF
--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -818,7 +818,7 @@ const checkPublicationOnAccountPage = async (
             await expect(publicationContainer).toContainText('(Author)');
             await expect(publicationContainer).toContainText('Status: Pending your approval');
             await expect(publicationContainer.locator(PageModel.myAccount.viewDraftButton)).toBeVisible();
-            await expect(publicationContainer.locator(PageModel.myAccount.requestControlButton)).not.toBeVisible();
+            await expect(publicationContainer.locator(PageModel.myAccount.requestControlButton)).toBeVisible();
             break;
         case 'approved':
             await expect(publicationContainer).toContainText('Status: Ready to publish');
@@ -851,7 +851,7 @@ const checkPublicationOnAccountPage = async (
                 `${Helpers.user2.shortName} is working on a new draft version`
             );
             await expect(publicationContainer.locator(PageModel.myAccount.viewDraftButton)).toBeVisible();
-            await expect(publicationContainer.locator(PageModel.myAccount.requestControlButton)).not.toBeVisible();
+            await expect(publicationContainer.locator(PageModel.myAccount.requestControlButton)).toBeVisible();
             break;
     }
 };

--- a/ui/src/components/Publication/SimpleResult/index.tsx
+++ b/ui/src/components/Publication/SimpleResult/index.tsx
@@ -57,6 +57,15 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
         </>
     );
 
+    const viewDraftButton = (
+        <Components.Button
+            href={`/publications/${props.publication.id}`}
+            endIcon={<OutlineIcons.EyeIcon className="h-4" />}
+            title="View Draft"
+            className="mt-5 w-fit bg-green-600 px-3 text-white-50 children:border-none children:text-white-50"
+        />
+    );
+
     return (
         <li
             data-testid={`publication-${props.publication.id}`}
@@ -112,20 +121,11 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
                                     </Components.Link>{' '}
                                     is working on a new draft version
                                 </p>
-                                <Components.Button
-                                    href={`/publications/${props.publication.id}`}
-                                    endIcon={<OutlineIcons.EyeIcon className="h-4" />}
-                                    title="View Draft"
-                                    className="mt-5 w-fit bg-green-600 px-3 text-white-50 children:border-none children:text-white-50"
-                                />
+                                {viewDraftButton}
+                                {requestControl}
                             </>
                         ) : draftVersion.currentStatus === 'LOCKED' ? (
-                            <Components.Button
-                                href={`/publications/${props.publication.id}`}
-                                endIcon={<OutlineIcons.EyeIcon className="h-4" />}
-                                title="View Draft"
-                                className="mt-5 w-fit bg-green-600 px-3 text-white-50 children:border-none children:text-white-50"
-                            />
+                            viewDraftButton
                         ) : (
                             <Components.Button
                                 href={`/publications/${props.publication.id}/edit?step=0`}


### PR DESCRIPTION
The purpose of this PR was to always present confirmed coauthors with both the option to view a draft publication they are on and to request to take control of it. Before this they would have had to navigate to the draft to see the option to request control.

---

### Acceptance Criteria:

- On the account page, confirmed co-authors for a publication that has a draft version see:
    - A button to “View draft”
    - A button to “Take over editing”

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
<img width="268" alt="Screenshot 2024-01-10 104520" src="https://github.com/JiscSD/octopus/assets/132363734/41555824-728a-447b-8949-1038ecd6ffde">

E2E
<img width="122" alt="Screenshot 2024-01-10 104458" src="https://github.com/JiscSD/octopus/assets/132363734/377c8c2e-2b91-48f9-a2b7-3ae66326ad2d">

---

### Screenshots:
<img width="839" alt="Screenshot 2024-01-10 105319" src="https://github.com/JiscSD/octopus/assets/132363734/33520f5b-007f-4992-a899-9244a5096cbb">
<img width="834" alt="Screenshot 2024-01-10 105303" src="https://github.com/JiscSD/octopus/assets/132363734/8bd7899b-c0f7-4248-b218-1eceb6883345">
