### PR TITLE
OC-761: Allow confirmation of involvement from account page

### DIFF
--- a/api/src/components/coauthor/__tests__/linkCoAuthor.test.ts
+++ b/api/src/components/coauthor/__tests__/linkCoAuthor.test.ts
@@ -7,13 +7,12 @@ describe('Link co-author', () => {
         await testUtils.testSeed();
     });
 
-    test('Link a co-author to a publication version (allow)', async () => {
+    test('Can confirm publication involvement using authentication (and no code)', async () => {
         const link = await testUtils.agent
             .patch('/publication-versions/publication-hypothesis-draft-v1/link-coauthor')
             .query({ apiKey: '000000007' })
             .send({
                 email: 'test-user-7@jisc.ac.uk',
-                code: 'test-code-user-7',
                 approve: true
             });
         expect(link.status).toEqual(200);
@@ -25,13 +24,46 @@ describe('Link co-author', () => {
         expect(dbLink?.linkedUser).toEqual('test-user-7');
     });
 
-    test('Link a co-author to a publication version (do not allow) with authentication', async () => {
+    test('Can confirm involvement with a different email if code is provided', async () => {
         const link = await testUtils.agent
             .patch('/publication-versions/publication-problem-draft-v1/link-coauthor')
-            .query({ apiKey: '987654321' })
+            .query({ apiKey: '123456789' }) // Test user 1
+            .send({
+                email: 'test-user-8@jisc.ac.uk',
+                code: 'test-code-user-8',
+                approve: true
+            });
+
+        expect(link.status).toEqual(200);
+
+        // Email should be updated to that of the authenticated user.
+        const dbLink = await client.prisma.coAuthors.findFirst({
+            where: { code: 'test-code-user-8', publicationVersionId: 'publication-problem-draft-v1' }
+        });
+        expect(dbLink?.linkedUser).toEqual('test-user-1');
+        expect(dbLink?.email).toEqual('test-user-1@jisc.ac.uk');
+    });
+
+    test('Cannot confirm involvement if no code is provided and user email does not match coauthor record', async () => {
+        const link = await testUtils.agent
+            .patch('/publication-versions/publication-hypothesis-draft-v1/link-coauthor')
+            .query({ apiKey: '123456789' }) // Test user 1
             .send({
                 email: 'test-user-7@jisc.ac.uk',
-                code: 'test-code-user-7',
+                approve: true
+            });
+        expect(link.status).toEqual(400);
+        expect(link.body.message).toEqual(
+            'To confirm or deny your involvement, you must either provide a code or be authenticated as a user with a verified email matching the co-author record.'
+        );
+    });
+
+    test('Can deny publication involvement using authentication (and no code)', async () => {
+        const link = await testUtils.agent
+            .patch('/publication-versions/publication-problem-draft-v1/link-coauthor')
+            .query({ apiKey: '000000007' })
+            .send({
+                email: 'test-user-7@jisc.ac.uk',
                 approve: false
             });
         expect(link.status).toEqual(200);
@@ -43,10 +75,9 @@ describe('Link co-author', () => {
         expect(dbLink).toEqual(null);
     });
 
-    test('Link a co-author to a publication version (do not allow) without authentication', async () => {
+    test('Can deny publication involvement using a code (and no authentication)', async () => {
         const link = await testUtils.agent
             .patch('/publication-versions/publication-problem-draft-v1/link-coauthor')
-            .query({ apiKey: '987654321' })
             .send({
                 email: 'test-user-7@jisc.ac.uk',
                 code: 'test-code-user-7',
@@ -56,7 +87,7 @@ describe('Link co-author', () => {
         expect(link.status).toEqual(200);
     });
 
-    test('Cannot link as co-author if you are the creator', async () => {
+    test('Cannot confirm involvement if you are the creator', async () => {
         const link = await testUtils.agent
             .patch('/publication-versions/publication-problem-draft-v1/link-coauthor')
             .query({ apiKey: '000000005' })
@@ -69,7 +100,7 @@ describe('Link co-author', () => {
         expect(link.status).toEqual(404);
     });
 
-    test('Cannot link co-author if user has already been linked as another co-author', async () => {
+    test('Cannot confirm involvement if user has already been linked as another co-author', async () => {
         const link = await testUtils.agent
             .patch('/publication-versions/publication-problem-draft-v1/link-coauthor')
             .query({ apiKey: '000000006' })
@@ -93,5 +124,6 @@ describe('Link co-author', () => {
             });
 
         expect(link.status).toEqual(404);
+        expect(link.body.message).toEqual('User has already been linked to this publication.');
     });
 });

--- a/api/src/components/coauthor/controller.ts
+++ b/api/src/components/coauthor/controller.ts
@@ -203,6 +203,16 @@ export const link = async (
             return response.json(403, { message: 'You are not currently listed as an author on this draft' });
         }
 
+        // The requestor must either supply a code or log in as a verified user with the same email as the co-author record.
+        const emailMatch = event.user?.email === coAuthorByEmail.email;
+
+        if (!(emailMatch || event.body.code)) {
+            return response.json(400, {
+                message:
+                    'To confirm or deny your involvement, you must either provide a code or be authenticated as a user with a verified email matching the co-author record.'
+            });
+        }
+
         if (!event.body.approve) {
             // check if user has already been linked
             if (coAuthorByEmail.linkedUser) {
@@ -212,7 +222,7 @@ export const link = async (
                 });
             }
 
-            await coAuthorService.removeFromPublicationVersion(version.id, event.body.email, event.body.code);
+            await coAuthorService.removeFromPublicationVersion(version.id, event.body.email);
 
             // notify main author about rejection
             await email.notifyCoAuthorRejection({
@@ -269,12 +279,12 @@ export const link = async (
             });
         }
 
-        await coAuthorService.linkUser(event.user.id, version.id, event.body.email, event.body.code);
+        await coAuthorService.linkUser(event.user.id, version.id, event.body.email);
 
         // The email of the linked user may not match the email the invitation was sent to
         // (e.g. user manages their orcid account with a different email to their work email).
         // In this case, we need to update the coauthor's email field because it becomes outdated.
-        if (event.user.email !== coAuthorByEmail.email) {
+        if (!emailMatch) {
             // We already check that the logged in user's email is not already a coauthor on this version,
             // so this is safe.
             await coAuthorService.update(coAuthorByEmail.id, { email: event.user.email });

--- a/api/src/components/coauthor/schema/link.ts
+++ b/api/src/components/coauthor/schema/link.ts
@@ -12,7 +12,7 @@ const linkCoAuthorSchema = {
             type: 'boolean'
         }
     },
-    required: ['email', 'code', 'approve'],
+    required: ['email', 'approve'],
     additionalProperties: false
 };
 

--- a/api/src/components/coauthor/service.ts
+++ b/api/src/components/coauthor/service.ts
@@ -130,12 +130,11 @@ export const deleteCoAuthorByEmail = async (publicationVersionId: string, email:
     return deleteCoAuthor;
 };
 
-export const linkUser = async (userId: string, publicationVersionId: string, email: string, code: string) => {
+export const linkUser = async (userId: string, publicationVersionId: string, email: string) => {
     const update = await client.prisma.coAuthors.updateMany({
         where: {
             publicationVersionId,
-            email,
-            code
+            email
         },
         data: {
             linkedUser: userId
@@ -148,12 +147,11 @@ export const linkUser = async (userId: string, publicationVersionId: string, ema
     return update;
 };
 
-export const removeFromPublicationVersion = async (publicationVersionId: string, email: string, code: string) => {
+export const removeFromPublicationVersion = async (publicationVersionId: string, email: string) => {
     const removeCoAuthor = client.prisma.coAuthors.deleteMany({
         where: {
             publicationVersionId,
-            email,
-            code
+            email
         }
     });
     await publicationVersionService.update(publicationVersionId, {

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -492,8 +492,8 @@ export interface ConfirmCoAuthorPathParams {
 
 export interface ConfirmCoAuthorBody {
     email: string;
-    code: string;
     approve: boolean;
+    code?: string;
 }
 
 export interface ChangeCoAuthorRequestBody {

--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -779,6 +779,7 @@ const unlockPublication = async (page: Page) => {
 
 type AccountPagePublicationState =
     | 'own first draft'
+    | 'unconfirmed coauthor'
     | 'pending coauthor approval'
     | 'pending your approval'
     | 'approved'
@@ -813,6 +814,14 @@ const checkPublicationOnAccountPage = async (
         case 'pending coauthor approval':
             await expect(publicationContainer).toContainText('Status: Pending author approval');
             await expect(publicationContainer.locator(PageModel.myAccount.viewDraftButton)).toBeVisible();
+            break;
+        case 'unconfirmed coauthor':
+            await expect(publicationContainer).toContainText('(Invited)');
+            await expect(publicationContainer).toContainText('Status: Pending author approval');
+            await expect(publicationContainer).toContainText(
+                `${Helpers.user1.shortName} has created a new draft version. You will need to confirm your involvement to access it.`
+            );
+            await expect(publicationContainer.locator(PageModel.myAccount.confirmInvolvementButton)).toBeVisible();
             break;
         case 'pending your approval':
             await expect(publicationContainer).toContainText('(Author)');
@@ -1478,9 +1487,14 @@ test.describe('Publication flow + co-authors', () => {
         // Check locked details
         await checkPublicationOnAccountPage(page, { id: publicationId }, 'pending coauthor approval', true);
 
-        // As co-author, confirm involvement without approving
+        // Check details as unconfirmed co-author
         const page2 = await browser.newPage();
-        await confirmInvolvement(browser, coAuthor, page2, true);
+        await page2.goto(Helpers.UI_BASE);
+        await Helpers.login(page2, browser, Helpers.user2);
+        await checkPublicationOnAccountPage(page2, { id: publicationId }, 'unconfirmed coauthor', true);
+
+        // As co-author, confirm involvement without approving
+        await confirmInvolvement(browser, coAuthor, page2);
 
         // Check details as co-author
         await checkPublicationOnAccountPage(page2, { id: publicationId }, 'pending your approval', true);
@@ -1516,24 +1530,20 @@ test.describe('Publication flow + co-authors', () => {
         );
         await page2.waitForURL('**/edit?**');
 
-        // Check details as co-author (new corresponding author)
-        await checkPublicationOnAccountPage(page2, { id: publicationId }, 'own new version', true);
-
-        // Check details as old corresponding author
-        await page.reload();
-        await checkPublicationOnAccountPage(page, { id: publicationId }, "coauthor's new version", false);
-
         // Request approval on new version
-        await page2.getByTestId(publicationContainerTestId).locator(PageModel.myAccount.editDraftButton).click();
         await expect(page2.locator(PageModel.publish.requestApprovalButton)).toBeEnabled();
         await page2.locator(PageModel.publish.requestApprovalButton).click();
         await page2.locator(PageModel.publish.confirmRequestApproval).click();
         await page2.waitForSelector(PageModel.publish.unlockButton);
 
+        // Check details as co-author (new corresponding author)
+        await checkPublicationOnAccountPage(page2, { id: publicationId }, 'own new version', true);
+
         // Confirm involvement on new version
         await confirmInvolvement(browser, Helpers.user1, page);
 
         // Unlock publication
+        await page2.getByTestId(publicationContainerTestId).locator(PageModel.myAccount.viewDraftButton).click();
         await unlockPublication(page2);
 
         // Check details as old author
@@ -1543,6 +1553,17 @@ test.describe('Publication flow + co-authors', () => {
             "coauthor's unlocked draft",
             true
         );
+
+        // Remove original author from coauthors and save
+        await page2.locator('aside button:has-text("Co-authors")').first().click();
+        await removeCoAuthor(page2, Helpers.user1);
+        await page2.locator('button[title="Save"]').first().click();
+        await page2.locator('div[role="dialog"] button[aria-label="Save"]').click();
+        await page2.waitForSelector('p:has-text("Publication successfully saved")');
+
+        // Check details as old corresponding author
+        await page.reload();
+        await checkPublicationOnAccountPage(page, { id: publicationId }, "coauthor's new version", false);
 
         await Promise.all([page.close(), page2.close()]);
     });
@@ -2352,13 +2373,17 @@ test.describe('Publication flow + co-authors', () => {
         // request control over the new version
         const publicationRow = page2.getByTestId(publicationTestId);
         await expect(publicationRow).toContainText(problemPublication2.title);
-        await publicationRow.locator('button[title="Take over editing"]').click();
+        await publicationRow.locator(PageModel.myAccount.confirmInvolvementButton).click();
+        await page2.waitForURL('**/versions/latest');
+        await page2.locator('#desktop-versions-accordion a[title="Take over editing"]').click();
         await page2.click('button[title="Request Control"]');
         await page2.waitForResponse((response) => response.url().includes('/request-control') && response.ok());
 
-        await expect(page2.getByTestId(publicationTestId)).toContainText(
-            'You have requested control over this publication version.'
-        );
+        // Uncomment when https://github.com/JiscSD/octopus/pull/571 has been merged
+        // and navigate to account page first to check this
+        // await expect(page2.getByTestId(publicationTestId)).toContainText(
+        //     'You have requested control over this publication version.'
+        // );
 
         // transfer ownership to user2
         await approveControlRequest(context, Helpers.user1, Helpers.user2.fullName, true);

--- a/e2e/tests/PageModel.ts
+++ b/e2e/tests/PageModel.ts
@@ -140,7 +140,8 @@ export const PageModel = {
         viewDraftButton: 'a:has-text("View Draft")',
         createDraftVersionButton: 'button:has-text("Create Draft Version")',
         viewButton: 'a:has-text("View")',
-        requestControlButton: 'button:has-text("Take over editing")'
+        requestControlButton: 'button:has-text("Take over editing")',
+        confirmInvolvementButton: 'a:has-text("Confirm Involvement")'
     },
     myPublications: {
         liveAuthorPageButton: 'a:has-text("View my public author page")'

--- a/ui/src/components/Publication/SimpleResult/index.tsx
+++ b/ui/src/components/Publication/SimpleResult/index.tsx
@@ -6,8 +6,6 @@ import * as Components from '@/components';
 import * as Config from '@/config';
 import * as Hooks from '@/hooks';
 
-import { useRouter } from 'next/router';
-
 type Props = {
     publication: Interfaces.Publication;
     user: Interfaces.User;
@@ -89,8 +87,10 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
                         <span>
                             {latestVersion.user.id === props.user.id
                                 ? ' (Corresponding Author)'
-                                : latestVersion.coAuthors.find((coAuthor) => coAuthor.linkedUser === props.user.id) &&
-                                  ' (Author)'}
+                                : latestVersion.coAuthors.find((coAuthor) => coAuthor.linkedUser === props.user.id)
+                                ? ' (Author)'
+                                : latestVersion.coAuthors.find((coAuthor) => coAuthor.email === props.user.email) &&
+                                  ' (Invited)'}
                         </span>
                     )}
                 </p>
@@ -104,23 +104,45 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
                             Status: {Helpers.getPublicationStatusByAuthor(draftVersion, props.user)}
                         </p>
                         {props.user.id !== draftVersion.user.id ? (
-                            <>
-                                <p>
-                                    <Components.Link
-                                        href={`${Config.urls.viewUser.path}/${draftVersion.user.id}`}
-                                        className="underline"
-                                    >
-                                        {draftVersion.user.firstName.substring(0, 1)}. {draftVersion.user.lastName}
-                                    </Components.Link>{' '}
-                                    is working on a new draft version
-                                </p>
-                                <Components.Button
-                                    href={`/publications/${props.publication.id}`}
-                                    endIcon={<OutlineIcons.EyeIcon className="h-4" />}
-                                    title="View Draft"
-                                    className="mt-5 w-fit bg-green-600 px-3 text-white-50 children:border-none children:text-white-50"
-                                />
-                            </>
+                            draftVersion.coAuthors.some(
+                                (coAuthor) => coAuthor.email === props.user.email && !coAuthor.linkedUser
+                            ) ? (
+                                <>
+                                    <p>
+                                        <Components.Link
+                                            href={`${Config.urls.viewUser.path}/${draftVersion.user.id}`}
+                                            className="underline"
+                                        >
+                                            {draftVersion.user.firstName.substring(0, 1)}. {draftVersion.user.lastName}
+                                        </Components.Link>{' '}
+                                        has created a new draft version. You will need to confirm your involvement to
+                                        access it.
+                                    </p>
+                                    <Components.Button
+                                        href={`/author-link?email=${props.user.email}&publicationId=${props.publication.id}&versionId=${draftVersion.id}&approve=true`}
+                                        title="Confirm Involvement"
+                                        className="mt-5 w-fit bg-green-600 px-3 text-white-50 children:border-none children:text-white-50"
+                                    />
+                                </>
+                            ) : (
+                                <>
+                                    <p>
+                                        <Components.Link
+                                            href={`${Config.urls.viewUser.path}/${draftVersion.user.id}`}
+                                            className="underline"
+                                        >
+                                            {draftVersion.user.firstName.substring(0, 1)}. {draftVersion.user.lastName}
+                                        </Components.Link>{' '}
+                                        is working on a new draft version
+                                    </p>
+                                    <Components.Button
+                                        href={`/publications/${props.publication.id}`}
+                                        endIcon={<OutlineIcons.EyeIcon className="h-4" />}
+                                        title="View Draft"
+                                        className="mt-5 w-fit bg-green-600 px-3 text-white-50 children:border-none children:text-white-50"
+                                    />
+                                </>
+                            )
                         ) : draftVersion.currentStatus === 'LOCKED' ? (
                             <Components.Button
                                 href={`/publications/${props.publication.id}`}

--- a/ui/src/pages/author-link.tsx
+++ b/ui/src/pages/author-link.tsx
@@ -9,18 +9,12 @@ import axios from 'axios';
 
 export const getServerSideProps: Types.GetServerSideProps = async (context) => {
     let email: string | null = null;
-    let code: string | null = null;
+    let code: string | undefined | null = null;
     let approve = null;
     let publicationId: string | null = null;
     let versionId: string | null = null;
 
-    if (
-        !context.query.code ||
-        !context.query.email ||
-        !context.query.approve ||
-        !context.query.publicationId ||
-        !context.query.versionId
-    ) {
+    if (!context.query.email || !context.query.approve || !context.query.publicationId || !context.query.versionId) {
         return {
             props: {
                 message: 'Invalid link.'


### PR DESCRIPTION
The purpose of this PR was to show a "Confirm Involvement" button to unconfirmed co-authors who view a publication on their account page. This replaces the "Take over editing" button in this scenario and provides users the convenience of being able to confirm their involvement from within the application (compared to using the link from an email).

---

### Acceptance Criteria:

1. If a publication is locked for approval, any unconfirmed authors whose emails are listed on the draft (even on the first version) have that publication listed in their account page (even the draft goes back into “DRAFT” status, and has never been published, and they are unconfirmed).
2. Instead of the “Someone else has created a draft version and you do not yet have access to it” text, text is present reading “<Corresponding author> has created a new draft version. You will need to confirm your involvement to access it.”
3. Instead of the “Take over editing” button on the account page for that publication, a “Confirm involvement” button is displayed. Using this button will confirm involvement in the same manner as if they had clicked the “Confirm my involvement” link in an invitation email.

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

E2E
<img width="136" alt="Screenshot 2024-01-16 105551" src="https://github.com/JiscSD/octopus/assets/132363734/c89684db-5670-4a7f-88a0-a25001df8f8e">

API
<img width="144" alt="Screenshot 2024-01-16 110349" src="https://github.com/JiscSD/octopus/assets/132363734/8de0ac2f-37bc-4265-86ab-17ae8abf2f67">

UI
<img width="266" alt="Screenshot 2024-01-16 110511" src="https://github.com/JiscSD/octopus/assets/132363734/5574438a-6dcc-45a5-a958-ce07b701754c">


---

### Screenshots:
<img width="1145" alt="Screenshot 2024-01-16 112337" src="https://github.com/JiscSD/octopus/assets/132363734/297d923f-3e7a-49f2-aa2f-a93daff844e6">
