### PR TITLE
OC-770: Sort search page by recency if no criteria have been entered

### DIFF
--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -240,8 +240,11 @@ export const getOpenSearchPublications = async (filters: I.OpenSearchPublication
                   order: filters.orderDirection || 'asc'
               }
           }
-        : null;
-
+        : !filters.search && {
+              publishedDate: {
+                  order: filters.orderDirection || 'desc'
+              }
+          };
     const query = {
         index: 'publications',
         body: {


### PR DESCRIPTION
The purpose of this PR was to show the most recent publications first on the search page, both to aid in finding new content, and to it clear that the site is active, as currently users will see “S. Octopus, 2 years ago” on the search page by default.

Behaviour after a search term is entered is less important, but whilst no keywords have been entered, the page should be sorted with the most recent publications at the top. This includes (if possible) whilst filters are on for publication date and publication type.

---

### Acceptance Criteria:

- If no query term has been provided (including if filters are in use), the search endpoint should return results in order of publication date, from most to least recent. Otherwise, results should be sorted by opensearch score.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

API
<img width="173" alt="Screenshot 2024-01-17 091657" src="https://github.com/JiscSD/octopus/assets/132363734/eb8265f1-6ee1-455e-bd69-5bb1b9b2d531">

E2E
<img width="129" alt="Screenshot 2024-01-17 091636" src="https://github.com/JiscSD/octopus/assets/132363734/60db30d1-a09e-4e1b-879a-b9974299a7ce">

---

### Screenshots:
<img width="1139" alt="Screenshot 2024-01-17 092150" src="https://github.com/JiscSD/octopus/assets/132363734/e5b0827b-2c4f-4ad3-b376-0d3cd5586233">
