### PR TITLE
Fixes for OC-745

### DIFF
--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -70,6 +70,12 @@ provider:
           Resource: 'arn:aws:s3:::science-octopus-publishing-pdfs-${self:provider.stage}/*'
           Action: 's3:PutObject'
         - Effect: 'Allow'
+          Resource: 'arn:aws:s3:::science-octopus-publishing-sitemaps-${self:provider.stage}/*'
+          Action: 's3:PutObject'
+        - Effect: 'Allow'
+          Resource: 'arn:aws:s3:::science-octopus-publishing-sitemaps-${self:provider.stage}'
+          Action: 's3:ListBucket'
+        - Effect: 'Allow'
           Resource: 'arn:aws:sqs:eu-west-1:948306873545:science-octopus-pdf-queue-${self:provider.stage}'
           Action:
               - 'lambda:CreateEventSourceMapping'

--- a/ui/README.md
+++ b/ui/README.md
@@ -28,6 +28,12 @@ To view any dynamic pages, you will also need to start the API. More information
 
 ---
 
+## Working with the UI
+
+If you add a new static page to the site, remember to add it to the array of static page names in the static pages sitemap at `src/pages/sitemaps/static.xml.tsx`.
+
+---
+
 ## Technologies
 
 ### Languages
@@ -74,7 +80,6 @@ You need the API and the UI to be running. To run the tests use:
 $ ~/ui $ npm run test:e2e
 
 ```
-
 
 ---
 

--- a/ui/src/pages/sitemaps/static.xml.tsx
+++ b/ui/src/pages/sitemaps/static.xml.tsx
@@ -1,5 +1,3 @@
-import fs from 'fs';
-
 import * as Config from '@/config';
 import * as Types from '@/types';
 
@@ -11,39 +9,26 @@ export const getServerSideProps: Types.GetServerSideProps = async ({ res }) => {
     const now = new Date().toISOString();
 
     // Get URLs of all static pages by scanning file system.
-    const staticUrls = fs
-        .readdirSync(process.cwd() + '/src/pages')
-        .filter(
-            (staticPage) =>
-                ![
-                    '404.tsx',
-                    '500.tsx',
-                    '_app.tsx',
-                    '_document.tsx',
-                    'account.tsx',
-                    'api',
-                    'approve-control-request.tsx',
-                    'author-link.tsx',
-                    'authors',
-                    'login.tsx',
-                    'my-bookmarks.tsx',
-                    'publications',
-                    'sitemap.xml.tsx',
-                    'topics',
-                    'verify.tsx'
-                ].includes(staticPage) && !staticPage.startsWith('.')
-        )
-        .map((staticPagePath) => {
-            if (staticPagePath.includes('.tsx')) {
-                staticPagePath = staticPagePath.replace('.tsx', '');
-            }
-
-            if (staticPagePath === 'index') {
-                staticPagePath = staticPagePath.replace('index', '');
-            }
-
-            return `${Config.urls.baseUrl}${staticPagePath ? `/${staticPagePath}` : ''}`;
-        });
+    const staticUrls = [
+        '',
+        'about',
+        'accessibility',
+        'author-guide',
+        'blog',
+        'browse',
+        'create',
+        'documentation',
+        'faq',
+        'get-involved',
+        'octopus-aims',
+        'privacy',
+        'research-culture-report',
+        'search',
+        'terms',
+        'user-terms'
+    ].map((staticPagePath) => {
+        return `${Config.urls.baseUrl}${staticPagePath ? `/${staticPagePath}` : ''}`;
+    });
 
     const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
         <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">


### PR DESCRIPTION
The purpose of this PR was to fix some issues that were occurring with the sitemap code from OC-745:
- Lambdas didn't have correct permission to put objects in and list the sitemap S3 bucket
- The method of listing the src/pages directory to get a static pages list doesn't seem to work on amplify. Rather than adapt to that, decided and agreed with PO to base the static pages sitemap on a manually managed list. This also has the advantage of not letting new pages that we wouldn't want to show get included in the sitemap.

---

### Acceptance Criteria:

As per [OC-745](https://jiscdev.atlassian.net/browse/OC-745).

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [x] Documentation updated - added a note to the readme about the sitemap.


[OC-745]: https://jiscdev.atlassian.net/browse/OC-745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ