### PR TITLE
OC-131 fix: Use same path variable names throughout serverless.yml

### DIFF
--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -158,7 +158,7 @@ functions:
         handler: src/components/publication/routes.get
         events:
             - http:
-                  path: ${self:custom.versions.v1}/publications/{id}
+                  path: ${self:custom.versions.v1}/publications/{publicationId}
                   method: GET
                   cors: true
     getSeedDataPublications:
@@ -179,7 +179,7 @@ functions:
         handler: src/components/publication/routes.getPublicationLinks
         events:
             - http:
-                  path: ${self:custom.versions.v1}/publications/{id}/links
+                  path: ${self:custom.versions.v1}/publications/{publicationId}/links
                   method: GET
                   cors: true
     getPDF:
@@ -187,7 +187,7 @@ functions:
         memorySize: 2048 # https://github.com/alixaxel/chrome-aws-lambda#:~:text=You%20should%20allocate%20at%20least%20512%20MB%20of%20RAM%20to%20your%20Lambda%2C%20however%201600%20MB%20(or%20more)%20is%20recommended
         events:
             - http:
-                  path: ${self:custom.versions.v1}/publications/{id}/pdf
+                  path: ${self:custom.versions.v1}/publications/{publicationId}/pdf
                   method: GET
                   cors: true
     # Publication Versions
@@ -195,14 +195,14 @@ functions:
         handler: src/components/publicationVersion/routes.create
         events:
             - http:
-                  path: ${self:custom.versions.v1}/publications/{id}/publication-versions
+                  path: ${self:custom.versions.v1}/publications/{publicationId}/publication-versions
                   method: POST
                   cors: true
     getPublicationVersion:
         handler: src/components/publicationVersion/routes.get
         events:
             - http:
-                  path: ${self:custom.versions.v1}/publications/{id}/publication-versions/{version} # {version} can be a version id, number, "latest" or "latestLive"
+                  path: ${self:custom.versions.v1}/publications/{publicationId}/publication-versions/{version} # {version} can be a version id, number, "latest" or "latestLive"
                   method: GET
                   cors: true
     getIndexedPublicationVersions:
@@ -216,35 +216,35 @@ functions:
         handler: src/components/publicationVersion/routes.update
         events:
             - http:
-                  path: ${self:custom.versions.v1}/publication-versions/{id}
+                  path: ${self:custom.versions.v1}/publication-versions/{publicationVersionId}
                   method: PATCH
                   cors: true
     updateStatus:
         handler: src/components/publicationVersion/routes.updateStatus
         events:
             - http:
-                  path: ${self:custom.versions.v1}/publication-versions/{id}/status/{status}
+                  path: ${self:custom.versions.v1}/publication-versions/{publicationVersionId}/status/{status}
                   method: PUT
                   cors: true
     deleteVersion:
         handler: src/components/publicationVersion/routes.deleteVersion
         events:
             - http:
-                  path: ${self:custom.versions.v1}/publication-versions/{id}
+                  path: ${self:custom.versions.v1}/publication-versions/{publicationVersionId}
                   method: DELETE
                   cors: true
     requestControl:
         handler: src/components/publicationVersion/routes.requestControl
         events:
             - http:
-                  path: ${self:custom.versions.v1}/publications/{id}/publication-versions/{version}/request-control
+                  path: ${self:custom.versions.v1}/publications/{publicationId}/publication-versions/{version}/request-control
                   method: GET
                   cors: true
     approveControlRequest:
         handler: src/components/publicationVersion/routes.approveControlRequest
         events:
             - http:
-                  path: ${self:custom.versions.v1}/publications/{id}/publication-versions/{version}/approve-control-request
+                  path: ${self:custom.versions.v1}/publications/{publicationId}/publication-versions/{version}/approve-control-request
                   method: POST
                   cors: true
     # Users

--- a/api/src/components/additionalInformation/__tests__/createAdditionalInformation.test.ts
+++ b/api/src/components/additionalInformation/__tests__/createAdditionalInformation.test.ts
@@ -109,6 +109,6 @@ describe('Create a piece of additional information', () => {
             });
 
         expect(createAdditionalInformation.status).toEqual(403);
-        expect(createAdditionalInformation.body.message).toEqual('You must supply a valid URL');
+        expect(createAdditionalInformation.body.message).toEqual('Please supply a valid URL starting with "http"');
     });
 });

--- a/api/src/components/additionalInformation/controller.ts
+++ b/api/src/components/additionalInformation/controller.ts
@@ -37,7 +37,7 @@ export const create = async (
         // Ensure URL is valid
         if (!Helpers.validateURL(event.body.url)) {
             return response.json(403, {
-                message: 'You must supply a valid URL'
+                message: 'Please supply a valid URL starting with "http"'
             });
         }
 

--- a/api/src/components/publication/controller.ts
+++ b/api/src/components/publication/controller.ts
@@ -10,7 +10,7 @@ export const get = async (
     event: I.APIRequest<undefined, I.GetPublicatonQueryParams, I.GetPublicationPathParams>
 ): Promise<I.JSONResponse> => {
     try {
-        const publication = await publicationService.get(event.pathParameters.id);
+        const publication = await publicationService.get(event.pathParameters.publicationId);
         const fields = event.queryStringParameters?.fields;
 
         if (!publication) {
@@ -96,7 +96,7 @@ export const create = async (
 export const getLinksForPublication = async (
     event: I.APIRequest<undefined, I.GetPublicationLinksQueryParams, I.GetPublicationLinksPathParams>
 ): Promise<I.JSONResponse> => {
-    const publicationId = event.pathParameters.id;
+    const publicationId = event.pathParameters.publicationId;
     const directLinks = event.queryStringParameters?.direct === 'true';
     const user = event.user;
     let includeDraftVersion = false;
@@ -136,7 +136,7 @@ export const getPDF = async (
 ): Promise<I.JSONResponse> => {
     const generateNewPDF = event.queryStringParameters?.generateNewPDF === 'true';
     const redirectToPreview = event.queryStringParameters?.redirectToPreview === 'true';
-    const publicationId = event.pathParameters.id;
+    const publicationId = event.pathParameters.publicationId;
     const publication = await publicationService.get(publicationId);
 
     if (!publication) {

--- a/api/src/components/publication/schema/getPDF.ts
+++ b/api/src/components/publication/schema/getPDF.ts
@@ -3,11 +3,11 @@ import * as I from 'interface';
 const getPDF: I.JSONSchemaType<I.GeneratePDFPathParams> = {
     type: 'object',
     properties: {
-        id: {
+        publicationId: {
             type: 'string'
         }
     },
-    required: ['id'],
+    required: ['publicationId'],
     additionalProperties: false
 };
 

--- a/api/src/components/publicationVersion/schema/updateStatus.ts
+++ b/api/src/components/publicationVersion/schema/updateStatus.ts
@@ -7,11 +7,11 @@ const updateStatusSchema: I.JSONSchemaType<I.UpdateStatusPathParams> = {
             type: 'string',
             enum: ['LIVE', 'DRAFT', 'LOCKED']
         },
-        id: {
+        publicationVersionId: {
             type: 'string'
         }
     },
-    required: ['status', 'id'],
+    required: ['status', 'publicationVersionId'],
     additionalProperties: false
 };
 

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -112,7 +112,7 @@ export interface OpenSearchPublication {
 }
 
 export interface GetPublicationPathParams {
-    id: string;
+    publicationId: string;
 }
 
 export interface GetPublicatonQueryParams {
@@ -120,7 +120,7 @@ export interface GetPublicatonQueryParams {
 }
 
 export interface GetPublicationLinksPathParams {
-    id: string;
+    publicationId: string;
 }
 
 export interface GetPublicationLinksQueryParams {
@@ -128,7 +128,7 @@ export interface GetPublicationLinksQueryParams {
 }
 
 export interface GetPublicationVersionPathParams {
-    id: string;
+    publicationId: string;
     version: string;
 }
 
@@ -141,11 +141,11 @@ export interface UpdatePublicationPathParams {
 }
 
 export interface UpdatePublicationVersionPathParams {
-    id: string;
+    publicationVersionId: string;
 }
 
 export interface UpdateStatusPathParams {
-    id: string;
+    publicationVersionId: string;
     status: 'LIVE' | 'DRAFT' | 'LOCKED';
 }
 
@@ -328,20 +328,20 @@ export interface UpdateUserInformation {
 }
 
 export interface DeletePublicationVersionPathParams {
-    id: string;
+    publicationVersionId: string;
 }
 
 export interface CreatePublicationVersionPathParams {
-    id: string;
+    publicationId: string;
 }
 
 export interface RequestControlPathParams {
-    id: string;
+    publicationId: string;
     version: string;
 }
 
 export interface ApproveControlRequestPathParams {
-    id: string;
+    publicationId: string;
     version: string;
 }
 
@@ -697,7 +697,7 @@ export interface DataCiteUser {
     affiliations: MappedOrcidAffiliation[];
 }
 export interface GeneratePDFPathParams {
-    id: string;
+    publicationId: string;
 }
 
 export interface GeneratePDFQueryParams {

--- a/ui/src/components/Publication/Creation/AdditionalInformation/Form.tsx
+++ b/ui/src/components/Publication/Creation/AdditionalInformation/Form.tsx
@@ -29,7 +29,7 @@ const Form: React.FC = () => {
         const isValidLink = Helpers.validateURL(url);
 
         if (!isValidLink) {
-            return setError('You must supply a valid URL');
+            return setError('Please supply a valid URL starting with "http"');
         }
 
         if (description.length > 255) {


### PR DESCRIPTION
The purpose of this PR was to correct an issue brought about by #570. Some path variables in serverless.yml were changed to be clearer, but AWS API gateway doesn't allow you to use two variables with different names in the same path segment. In our case, we had /publications/{id}/... and /publications/{publicationId}/... and a similar conflict with publication versions. This PR is to ensure we are using the same variable names throughout and API gateway won't throw any conflicts (already confirmed with a deploy to int env).

Also added in a small error text change requested by PO.
