### PR TITLE
OC-749: Displaying additional information fields on publications

### DIFF
--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -87,6 +87,15 @@ export const get = async (id: string) => {
                             title: true,
                             createdAt: true
                         }
+                    },
+                    additionalInformation: {
+                        select: {
+                            id: true,
+                            title: true,
+                            url: true,
+                            description: true,
+                            createdAt: true
+                        }
                     }
                 },
                 orderBy: {

--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -875,6 +875,10 @@ export const createPublicationHTMLTemplate = (
                     font-size: 12pt;
                 }
 
+                .section-subtitle {
+                    font-size: 10pt;
+                }
+
                 #title {
                     font-family: 'Montserrat', sans-serif;
                     text-align: center;
@@ -1006,21 +1010,25 @@ export const createPublicationHTMLTemplate = (
             </div>
 
             ${
-                additionalInformation.length &&
-                '<div class="section"><h2 class="section-title">Additional parts of this work hosted elsewhere</h2><ul>' +
-                    additionalInformation
+                additionalInformation.length
+                    ? `<div class="section">
+                    <h2 class="section-title">Additional parts of this work hosted elsewhere</h2>
+                    <ul>
+                    ${additionalInformation
                         .map(
                             (additionalInfoEntry) =>
-                                `<li><h3><b>${additionalInfoEntry.title}</b></h3>${
-                                    additionalInfoEntry.description && `<p>${additionalInfoEntry.description}</p>`
-                                }
-                                <p><a href="${additionalInfoEntry.url}" aria-label="${
-                                    additionalInfoEntry.title
-                                }">Link to ${additionalInfoEntry.title}</a></p>
+                                `<li>
+                                    <h3 class="section-subtitle"><b>${additionalInfoEntry.title}</b></h3>
+                                    ${additionalInfoEntry.description && `<p>${additionalInfoEntry.description}</p>`}
+                                    <p><a href="${additionalInfoEntry.url}" aria-label="${additionalInfoEntry.title}">
+                                        Link to ${additionalInfoEntry.title}
+                                    </a></p>
                                 </li>`
                         )
-                        .join('') +
-                    '</ul></div>'
+                        .join('')}
+                    </ul>
+                </div>`
+                    : ''
             }
 
             <div class="section affiliations">

--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -706,7 +706,8 @@ export const createPublicationHTMLTemplate = (
         dataPermissionsStatement,
         dataPermissionsStatementProvidedBy,
         dataAccessStatement,
-        selfDeclaration
+        selfDeclaration,
+        additionalInformation
     } = publicationVersion;
 
     // cheerio uses htmlparser2
@@ -871,6 +872,7 @@ export const createPublicationHTMLTemplate = (
                     margin-top: 5rem;
                     margin-bottom: 1rem;
                     font-weight: 600;
+                    font-size: 12pt;
                 }
 
                 #title {
@@ -1003,8 +1005,26 @@ export const createPublicationHTMLTemplate = (
                 ${mainText}
             </div>
 
+            ${
+                additionalInformation.length &&
+                '<div class="section"><h2 class="section-title">Additional parts of this work hosted elsewhere</h2><ul>' +
+                    additionalInformation
+                        .map(
+                            (additionalInfoEntry) =>
+                                `<li><h3><b>${additionalInfoEntry.title}</b></h3>${
+                                    additionalInfoEntry.description && `<p>${additionalInfoEntry.description}</p>`
+                                }
+                                <p><a href="${additionalInfoEntry.url}" aria-label="${
+                                    additionalInfoEntry.title
+                                }">Link to ${additionalInfoEntry.title}</a></p>
+                                </li>`
+                        )
+                        .join('') +
+                    '</ul></div>'
+            }
+
             <div class="section affiliations">
-                <h5 class="section-title">Affiliations</h5>
+                <h2 class="section-title">Affiliations</h2>
                 ${
                     affiliations.length
                         ? '<ol>' +
@@ -1024,7 +1044,7 @@ export const createPublicationHTMLTemplate = (
             </div>
 
             <div class="section references">
-                <h5 class="section-title">References</h5>
+                <h2 class="section-title">References</h2>
                 ${
                     references.length
                         ? references
@@ -1044,7 +1064,7 @@ export const createPublicationHTMLTemplate = (
             ${
                 linkedTo.length
                     ? ` <div class="section">
-                            <h5 class="section-title">Parent publications</h5>
+                            <h2 class="section-title">Parent publications</h2>
                             ${linkedTo
                                 .map(
                                     (link) =>
@@ -1058,7 +1078,7 @@ export const createPublicationHTMLTemplate = (
             ${
                 selfDeclaration && ['PROTOCOL', 'HYPOTHESIS'].includes(publicationVersion.publication.type)
                     ? ` <div class="section">
-                            <h5 class="section-title">Data access statement</h5>
+                            <h2 class="section-title">Data access statement</h2>
                             ${
                                 publicationVersion.publication.type === 'PROTOCOL'
                                     ? '<p>Data has not yet been collected according to this method/protocol.</p>'
@@ -1071,7 +1091,7 @@ export const createPublicationHTMLTemplate = (
             ${
                 ethicalStatement
                     ? ` <div class="section">
-                            <h5 class="section-title">Ethical statement</h5>
+                            <h2 class="section-title">Ethical statement</h2>
                             <p>${ethicalStatement}</p>
                             ${ethicalStatementFreeText ? `<p>${ethicalStatementFreeText}</p>` : ''}
                         </div>`
@@ -1081,7 +1101,7 @@ export const createPublicationHTMLTemplate = (
             ${
                 dataPermissionsStatement
                     ? ` <div class="section">
-                            <h5 class="section-title">Data permissions statement</h5>
+                            <h2 class="section-title">Data permissions statement</h2>
                             <p>${dataPermissionsStatement}</p>
                             ${dataPermissionsStatementProvidedBy ? `<p>${dataPermissionsStatementProvidedBy}</p>` : ''}
                         </div>`
@@ -1091,14 +1111,14 @@ export const createPublicationHTMLTemplate = (
             ${
                 dataAccessStatement
                     ? ` <div class="section">
-                            <h5 class="section-title">Data access statement</h5>
+                            <h2 class="section-title">Data access statement</h2>
                             <p>${dataAccessStatement}</p>
                         </div>`
                     : ''
             }
 
             <div class="section">
-                <h5 class="section-title">Funders</h5>
+                <h2 class="section-title">Funders</h2>
                 ${
                     funders.length
                         ? ` <div>
@@ -1116,7 +1136,7 @@ export const createPublicationHTMLTemplate = (
                 }
             </div>
             <div class="section">
-                <h5 class="section-title">Conflict of interest</h5>
+                <h2 class="section-title">Conflict of interest</h2>
                 ${
                     conflictOfInterestText
                         ? `<p>${conflictOfInterestText}</p>`

--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -1620,6 +1620,7 @@ test.describe('Publication flow + co-authors', () => {
 
         // Request approval on new version
         await page2.getByTestId(publicationContainerTestId).locator(PageModel.myAccount.editDraftButton).click();
+        await page2.waitForURL('**/edit?**');
         await expect(page2.locator(PageModel.publish.requestApprovalButton)).toBeEnabled();
         await page2.locator(PageModel.publish.requestApprovalButton).click();
         await page2.locator(PageModel.publish.confirmRequestApproval).click();

--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -259,6 +259,7 @@ interface PublicationTestType {
     dataPermissionsStatement?: string;
     dataCollectionApprover?: string;
     dataAccessStatement?: string;
+    additionalInformation?: AdditionalInformation;
 }
 
 const problemPublication: PublicationTestType = {
@@ -270,7 +271,8 @@ const problemPublication: PublicationTestType = {
     references: referencesList,
     coi: 'This Research Problem does not have any specified conflicts of interest.',
     funding: 'This Research Problem has the following sources of funding:',
-    fundingExtraDetails: 'extra details'
+    fundingExtraDetails: 'extra details',
+    additionalInformation: sampleAdditionalInformation
 };
 
 const problemPublication2: PublicationTestType = {
@@ -359,7 +361,8 @@ const checkPublication = async (page: Page, publication: PublicationTestType, au
         ...(publication.ethicalApprover ? [`text="${publication.ethicalApprover}"`] : []),
         ...(publication.dataPermissionsStatement ? [`text="${publication.dataPermissionsStatement}"`] : []),
         ...(publication.dataCollectionApprover ? [`text="${publication.dataCollectionApprover}"`] : []),
-        ...(publication.dataAccessStatement ? [`text="${publication.dataAccessStatement}"`] : [])
+        ...(publication.dataAccessStatement ? [`text="${publication.dataAccessStatement}"`] : []),
+        ...(publication.additionalInformation ? [`text="${publication.additionalInformation.title}"`] : [])
     ];
 
     await Promise.all(publicationTemplate(publication).map((selector) => expect(page.locator(selector)).toBeVisible()));

--- a/ui/src/components/AdditionalInformationCard/index.tsx
+++ b/ui/src/components/AdditionalInformationCard/index.tsx
@@ -8,23 +8,25 @@ type Props = {
     };
 };
 
-const AdditionalInformationCard: React.FC<Props> = (props): React.ReactElement => (
+const AdditionalInformationCard: React.FC<Props> = ({
+    additionalInformation: { title, url, description }
+}): React.ReactElement => (
     <section className="w-full space-y-4 rounded bg-white-50 px-6 py-6 shadow transition-colors duration-500 dark:bg-grey-700">
         <h3 className="font-montserrat font-bold text-grey-800 transition-colors duration-500 dark:text-white-100">
-            {props.additionalInformation.title}
+            {title}
         </h3>
-        {props.additionalInformation.description && (
+        {description && (
             <p className="leading-relaxed text-grey-800 transition-colors duration-500 dark:text-grey-100">
-                {props.additionalInformation.description}
+                {description}
             </p>
         )}
         <a
-            href={props.additionalInformation.url}
-            title={props.additionalInformation.title}
-            aria-label={props.additionalInformation.title}
+            href={url}
+            title={title}
+            aria-label={title}
             className="block text-sm font-semibold uppercase text-teal-600 underline transition-colors duration-500 dark:text-teal-300"
         >
-            Link to {props.additionalInformation.title}
+            Link to {title}
         </a>
     </section>
 );

--- a/ui/src/components/AdditionalInformationCard/index.tsx
+++ b/ui/src/components/AdditionalInformationCard/index.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+type Props = {
+    additionalInformation: {
+        title: string;
+        url: string;
+        description?: string;
+    };
+};
+
+const AdditionalInformationCard: React.FC<Props> = (props): React.ReactElement => (
+    <section className="w-full space-y-4 rounded bg-white-50 px-6 py-6 shadow transition-colors duration-500 dark:bg-grey-700">
+        <h3 className="font-montserrat font-bold text-grey-800 transition-colors duration-500 dark:text-white-100">
+            {props.additionalInformation.title}
+        </h3>
+        {props.additionalInformation.description && (
+            <p className="leading-relaxed text-grey-800 transition-colors duration-500 dark:text-grey-100">
+                {props.additionalInformation.description}
+            </p>
+        )}
+        <a
+            href={props.additionalInformation.url}
+            title={props.additionalInformation.title}
+            aria-label={props.additionalInformation.title}
+            className="block text-sm font-semibold uppercase text-teal-600 underline transition-colors duration-500 dark:text-teal-300"
+        >
+            Link to {props.additionalInformation.title}
+        </a>
+    </section>
+);
+
+export default AdditionalInformationCard;

--- a/ui/src/components/index.tsx
+++ b/ui/src/components/index.tsx
@@ -1,5 +1,6 @@
 export { default as ActionBar } from './Publication/ActionBar';
 export { default as ActionCard } from './ActionCard';
+export { default as AdditionalInformationCard } from './AdditionalInformationCard';
 export { default as AdditionalInformationForm } from './Publication/Creation/AdditionalInformation/Form';
 export { default as AdditionalInformationTable } from './Publication/Creation/AdditionalInformation/Table';
 export { default as AddReferences } from './References/AddReferences';

--- a/ui/src/pages/publications/[id]/versions/[versionId].tsx
+++ b/ui/src/pages/publications/[id]/versions/[versionId].tsx
@@ -215,6 +215,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
 
     const list = [];
 
+    const showAdditionalInformation = Boolean(publicationVersion?.additionalInformation.length);
     const showReferences = Boolean(references?.length);
     const showChildProblems = Boolean(childProblems.length);
     const showParentPublications = Boolean(parentPublications.length);
@@ -715,6 +716,21 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                             <Components.ParseHTML content={publicationVersion.content ?? ''} />
                         </div>
                     </Components.ContentSection>
+
+                    {/** Additional information */}
+                    {showAdditionalInformation && (
+                        <Components.ContentSection
+                            id="additional-information"
+                            title="Additional parts of this work hosted elsewhere"
+                            hasBreak
+                        >
+                            <div className="flex flex-col space-y-8">
+                                {publicationVersion.additionalInformation.map((additionalInfoEntry) => (
+                                    <Components.AdditionalInformationCard additionalInformation={additionalInfoEntry} />
+                                ))}
+                            </div>
+                        </Components.ContentSection>
+                    )}
 
                     {/* References */}
                     {showReferences && (

--- a/ui/src/pages/publications/[id]/versions/[versionId].tsx
+++ b/ui/src/pages/publications/[id]/versions/[versionId].tsx
@@ -726,7 +726,10 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                         >
                             <div className="flex flex-col space-y-8">
                                 {publicationVersion.additionalInformation.map((additionalInfoEntry) => (
-                                    <Components.AdditionalInformationCard additionalInformation={additionalInfoEntry} />
+                                    <Components.AdditionalInformationCard
+                                        key={additionalInfoEntry.id}
+                                        additionalInformation={additionalInfoEntry}
+                                    />
                                 ))}
                             </div>
                         </Components.ContentSection>


### PR DESCRIPTION
The purpose of this PR was to display the new additional information fields when viewing a publication webpage and a publication PDF.

---

### Acceptance Criteria:

- On the publication page, immediately below the main text (above the sections for linked publications), a heading is present for “Additional parts of this work hosted elsewhere” with a list of each, displayed with:
    - The title in bold
    - The description immediately on the line below the title
    - The URL for the resource displayed as a hyperlink
        - This link should be marked up using the link’s title in the format “Link to <title>”, to be announced to screen readers
- On PDFs, a section is present to display additional information, including the section title “Additional parts of this work hosted elsewhere” in the same font size/style as other heading styles such as “Funders”, “Conflicts of Interest”, “Parent Publications” etc.
    - Below the section heading, each additional info link is displayed with it’s titled in bold, followed by it’s description in body-style text, and a hyperlink of its URL.
        - If possible, this hyperlink is marked up to read the title to screen readers
        - A double linebreak (or similar spacing) is present between each additional info link to make it easier for readers to distinguish them.

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
<img width="263" alt="Screenshot 2024-01-25 135304" src="https://github.com/JiscSD/octopus/assets/132363734/0fc0622e-dca3-4fb0-b4d5-9d849ee701de">

API
<img width="157" alt="Screenshot 2024-01-25 114748" src="https://github.com/JiscSD/octopus/assets/132363734/b8b338fe-8c6e-4ea3-b11d-0f4cf8b2a471">

E2E
<img width="127" alt="Screenshot 2024-01-25 135243" src="https://github.com/JiscSD/octopus/assets/132363734/e7a06549-b1a4-4b0d-87d6-8d44ff903250">


---

### Screenshots:

Publication page
<img width="871" alt="Screenshot 2024-01-25 144821" src="https://github.com/JiscSD/octopus/assets/132363734/a828114e-9dac-4b2f-b38f-abbf71d5f9a5">

PDF
<img width="418" alt="Screenshot 2024-01-25 144921" src="https://github.com/JiscSD/octopus/assets/132363734/d5914b0e-2790-4d95-8c94-480a98303852">

