### PR TITLE
OC-746: Generate separate sitemaps per 50k users on back end

### DIFF
--- a/api/src/components/sitemap/controller.ts
+++ b/api/src/components/sitemap/controller.ts
@@ -4,7 +4,7 @@ import * as sitemapService from 'sitemap/service';
 
 export const generate = async (): Promise<void> => {
     try {
-        await sitemapService.generatePublicationSitemaps();
+        await Promise.all([sitemapService.generateSitemaps('publications'), sitemapService.generateSitemaps('users')]);
     } catch (err) {
         console.log(err);
     }

--- a/api/src/components/sitemap/service.ts
+++ b/api/src/components/sitemap/service.ts
@@ -42,7 +42,7 @@ export const generateSitemaps = async (category: 'publications' | 'users'): Prom
     // Get IDs for first sitemap
     let queryResults =
         category === 'publications'
-            ? await client.prisma.publication.findMany(queryOptions )
+            ? await client.prisma.publication.findMany(queryOptions)
             : await client.prisma.user.findMany(queryOptions as Prisma.UserFindManyArgs);
     let sitemapCount = 0;
 
@@ -81,7 +81,7 @@ export const generateSitemaps = async (category: 'publications' | 'users'): Prom
                       cursor: {
                           id: queryResults[queryResults.length - 1].id
                       },
-                      ...(queryOptions )
+                      ...queryOptions
                   })
                 : await client.prisma.user.findMany({
                       skip: 1,

--- a/api/src/components/sitemap/service.ts
+++ b/api/src/components/sitemap/service.ts
@@ -16,19 +16,21 @@ const listSitemapBucket = async (): Promise<ListObjectsV2CommandOutput> => {
     );
 };
 
-export const generatePublicationSitemaps = async (): Promise<void> => {
+export const generateSitemaps = async (category: 'publications' | 'users'): Promise<void> => {
     // The maximum number of URLs per sitemap (the maximum google can take in one go)
     const URL_LIMIT = 50000;
-    const now = new Date().toISOString();
-    const queryOptions: Prisma.PublicationFindManyArgs = {
+    // DB query options - publications should only be live ones, users can be any.
+    const queryOptions: Prisma.PublicationFindManyArgs | Prisma.UserFindManyArgs = {
         take: URL_LIMIT,
-        where: {
-            versions: {
-                some: {
-                    currentStatus: 'LIVE'
+        ...(category === 'publications' && {
+            where: {
+                versions: {
+                    some: {
+                        currentStatus: 'LIVE'
+                    }
                 }
             }
-        },
+        }),
         select: {
             id: true
         },
@@ -36,11 +38,15 @@ export const generatePublicationSitemaps = async (): Promise<void> => {
             id: 'asc'
         }
     };
-    // Get publication IDs for first sitemap
-    let queryResults = await client.prisma.publication.findMany(queryOptions);
+
+    // Get IDs for first sitemap
+    let queryResults =
+        category === 'publications'
+            ? await client.prisma.publication.findMany(queryOptions )
+            : await client.prisma.user.findMany(queryOptions as Prisma.UserFindManyArgs);
     let sitemapCount = 0;
 
-    // Put sitemap into S3 and fetch next sitemap's worth of pulication IDs using a cursor
+    // Put sitemap into S3 and fetch next sitemap's worth of IDs using a cursor
     while (queryResults.length > 0) {
         const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
             <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
@@ -48,8 +54,9 @@ export const generatePublicationSitemaps = async (): Promise<void> => {
                     .map(
                         (result) => `
                             <url>
-                                <loc>${process.env.BASE_URL}/publications/${result.id}</loc>
-                                <lastmod>${now}</lastmod>
+                                <loc>${process.env.BASE_URL}/${category === 'users' ? 'authors' : category}/${
+                            result.id
+                        }</loc>
                                 <changefreq>daily</changefreq>
                                 <priority>1.0</priority>
                             </url>
@@ -62,18 +69,27 @@ export const generatePublicationSitemaps = async (): Promise<void> => {
         await s3.client.send(
             new PutObjectCommand({
                 Bucket: s3.buckets.sitemaps,
-                Key: `publications/${sitemapCount}.xml`,
+                Key: `${category}/${sitemapCount}.xml`,
                 ContentType: 'text/xml',
                 Body: sitemap
             })
         );
-        queryResults = await client.prisma.publication.findMany({
-            skip: 1,
-            cursor: {
-                id: queryResults[queryResults.length - 1].id
-            },
-            ...queryOptions
-        });
+        queryResults =
+            category === 'publications'
+                ? await client.prisma.publication.findMany({
+                      skip: 1,
+                      cursor: {
+                          id: queryResults[queryResults.length - 1].id
+                      },
+                      ...(queryOptions )
+                  })
+                : await client.prisma.user.findMany({
+                      skip: 1,
+                      cursor: {
+                          id: queryResults[queryResults.length - 1].id
+                      },
+                      ...(queryOptions as Prisma.UserFindManyArgs)
+                  });
     }
 
     // In case fewer sitemaps were generated than existed previously, clean up the old ones.
@@ -81,13 +97,14 @@ export const generatePublicationSitemaps = async (): Promise<void> => {
     const bucketFiles = await listSitemapBucket();
 
     if (bucketFiles.Contents) {
-        const publicationSitemapsInBucket = bucketFiles.Contents.filter(
-            (file) => file.Key?.slice(0, 13) === 'publications/'
+        const s3KeyPrefix = category + '/';
+        const applicableSitemapsInBucket = bucketFiles.Contents.filter(
+            (file) => file.Key?.slice(0, s3KeyPrefix.length) === s3KeyPrefix
         );
 
-        if (publicationSitemapsInBucket.length > sitemapCount) {
-            for (const file of publicationSitemapsInBucket) {
-                const fileNumber = Number(file.Key?.slice(13, -4));
+        if (applicableSitemapsInBucket.length > sitemapCount) {
+            for (const file of applicableSitemapsInBucket) {
+                const fileNumber = Number(file.Key?.slice(s3KeyPrefix.length, -4));
 
                 if (fileNumber > sitemapCount) {
                     await s3.client.send(

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -22,7 +22,7 @@ const api = axios.create({
     baseURL
 });
 
-export const get = async (url: string, token: string | undefined): Promise<AxiosResponse> => {
+export const get = async (url: string, token?: string): Promise<AxiosResponse> => {
     const headers = {
         headers: {
             Authorization: `Bearer ${token}`

--- a/ui/src/lib/helpers.tsx
+++ b/ui/src/lib/helpers.tsx
@@ -598,7 +598,7 @@ export const toKebabCase = (inputString: string): string => {
 export const getSitemapIndexXML = async (category: 'publications' | 'users'): Promise<string> => {
     let sitemapS3Keys: string[] = [];
     try {
-        const sitemapsRequest = await api.get('/sitemaps/paths', undefined);
+        const sitemapsRequest = await api.get('/sitemaps/paths');
         sitemapS3Keys = sitemapsRequest.data;
     } catch (error) {
         console.log(error);

--- a/ui/src/lib/helpers.tsx
+++ b/ui/src/lib/helpers.tsx
@@ -605,11 +605,8 @@ export const getSitemapIndexXML = async (category: 'publications' | 'users'): Pr
     }
     // Write an XML element for each applicable sitemap we have in S3
     const sitemapXMLElements = sitemapS3Keys
-        .flatMap((sitemapS3Key) =>
-            sitemapS3Key.startsWith(category + '/')
-                ? `<sitemap><loc>${Config.urls.baseUrl}/sitemaps/${sitemapS3Key}</loc></sitemap>`
-                : []
-        )
+        .filter((sitemapS3Key) => sitemapS3Key.startsWith(category + '/'))
+        .map((sitemapS3Key) => `<sitemap><loc>${Config.urls.baseUrl}/sitemaps/${sitemapS3Key}</loc></sitemap>`)
         .join('');
     return `<?xml version="1.0" encoding="UTF-8"?>
         <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">

--- a/ui/src/lib/helpers.tsx
+++ b/ui/src/lib/helpers.tsx
@@ -593,3 +593,27 @@ export const toKebabCase = (inputString: string): string => {
         .replace(/\s+/g, ' ') // Condense longer whitespace down to one space
         .replace(/\s/g, '-'); // Replace single spaces with hyphen
 };
+
+// Fetches sitemaps of a category from the sitemap S3 bucket and constructs a sitemap index of them.
+export const getSitemapIndexXML = async (category: 'publications' | 'users'): Promise<string> => {
+    let sitemapS3Keys: string[] = [];
+    try {
+        const sitemapsRequest = await api.get('/sitemaps/paths', undefined);
+        sitemapS3Keys = sitemapsRequest.data;
+    } catch (error) {
+        console.log(error);
+    }
+    // Write an XML element for each applicable sitemap we have in S3
+    const sitemapXMLElements = sitemapS3Keys
+        .flatMap((sitemapS3Key) =>
+            sitemapS3Key.startsWith(category + '/')
+                ? `<sitemap><loc>${Config.urls.baseUrl}/sitemaps/${sitemapS3Key}</loc></sitemap>`
+                : []
+        )
+        .join('');
+    return `<?xml version="1.0" encoding="UTF-8"?>
+        <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+            ${sitemapXMLElements}
+        </sitemapindex>
+    `;
+};

--- a/ui/src/pages/authors/[id]/index.tsx
+++ b/ui/src/pages/authors/[id]/index.tsx
@@ -37,7 +37,7 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
     }
 
     try {
-        const response = await api.get(userPublicationsUrl, undefined);
+        const response = await api.get(userPublicationsUrl);
         firstUserPublicationsPage = response.data;
     } catch (error) {
         console.log(error);
@@ -74,7 +74,7 @@ const Author: Types.NextPage<Props> = (props): React.ReactElement => {
             return props.userPublicationsUrl.replace('offset=0', `offset=${pageIndex * pageSize}`);
         },
         async (url) => {
-            const response = await api.get(url, undefined);
+            const response = await api.get(url);
             const data = response.data;
             const { offset, limit, total } = data;
 

--- a/ui/src/pages/browse.tsx
+++ b/ui/src/pages/browse.tsx
@@ -17,7 +17,7 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
     let latest: unknown = [];
     let metadata: unknown = {};
     try {
-        const latestResponse = await api.get(swrKey, undefined);
+        const latestResponse = await api.get(swrKey);
         latest = latestResponse.data.data;
         metadata = latestResponse.data.metadata;
     } catch (error) {

--- a/ui/src/pages/search/topics/index.tsx
+++ b/ui/src/pages/search/topics/index.tsx
@@ -30,7 +30,7 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
     const topicsUrl = `${Config.endpoints.topics}?offset=${fallbackData.offset}&limit=${fallbackData.limit}&search=${query}`;
 
     try {
-        fallbackData = (await api.get(topicsUrl, undefined)).data;
+        fallbackData = (await api.get(topicsUrl)).data;
     } catch (error) {
         const { message } = error as Interfaces.JSONResponseError;
         error = message;

--- a/ui/src/pages/sitemap.xml.tsx
+++ b/ui/src/pages/sitemap.xml.tsx
@@ -7,7 +7,7 @@ const Sitemap = () => {
 
 // Return a sitemap index file that refers to the rest of our sitemaps.
 export const getServerSideProps: Types.GetServerSideProps = async ({ res }) => {
-    const sitemaps = ['static', 'blog', 'topics', 'publications']
+    const sitemaps = ['static', 'blog', 'topics', 'publications', 'users']
         .map((resourceName) => `<sitemap><loc>${Config.urls.baseUrl}/sitemaps/${resourceName}.xml</loc></sitemap>`)
         .join('');
     const sitemapIndex = `<?xml version="1.0" encoding="UTF-8"?>

--- a/ui/src/pages/sitemaps/topics.xml.tsx
+++ b/ui/src/pages/sitemaps/topics.xml.tsx
@@ -13,7 +13,7 @@ export const getServerSideProps: Types.GetServerSideProps = async ({ res }) => {
     // Get URLs of topics from the API.
     let topicUrls: string[] = [];
     try {
-        const response = await api.get(Config.endpoints.topics, undefined);
+        const response = await api.get(Config.endpoints.topics);
         const data: Interfaces.TopicsPaginatedResults = response.data;
         if (data.results.length) {
             topicUrls = data.results.map((topic) => `${Config.urls.viewTopic.canonical}/${topic.id}`);

--- a/ui/src/pages/sitemaps/users.xml.tsx
+++ b/ui/src/pages/sitemaps/users.xml.tsx
@@ -7,7 +7,7 @@ const Sitemap = () => {
 
 export const getServerSideProps: Types.GetServerSideProps = async ({ res }) => {
     // Get details of sitemaps hosted in S3 bucket.
-    const sitemapIndex = await Helpers.getSitemapIndexXML('publications');
+    const sitemapIndex = await Helpers.getSitemapIndexXML('users');
     res.setHeader('Content-Type', 'text/xml');
     res.write(sitemapIndex);
     res.end();

--- a/ui/src/pages/sitemaps/users/[sitemap].tsx
+++ b/ui/src/pages/sitemaps/users/[sitemap].tsx
@@ -1,0 +1,17 @@
+import * as Config from '@/config';
+import * as Types from '@/types';
+
+const Sitemap = () => {
+    return null;
+};
+
+export const getServerSideProps: Types.GetServerSideProps = async (context) => {
+    return {
+        redirect: {
+            destination: `${Config.urls.sitemapBucket}/users/${context.query.sitemap}`,
+            permanent: true
+        }
+    };
+};
+
+export default Sitemap;


### PR DESCRIPTION
The purpose of this PR was to have sitemaps of a size that google can manage. We need to make sure that they only contain 50,000 URLs. In the case of users, we should develop a solution that can cope with the system having over 50,000 users.

---

### Acceptance Criteria:

- Every 24 hours, a cron job triggers a lambda to generate a sitemap for users which is then stored in an s3 bucket 
- The API endpoint which is used to return XML sitemaps for publications (OC-745) also returns the sitemaps for users
- The sitemaps at /users/[number].xml in an s3 bucket contain links to the “[number]th” 50,000 user in octopus (a consistent sort order between the sitemaps is needed but it doesn’t especially matter what it is). For example, /sitemaps/users/3.xml would contain the 100,001st user up to the 150,000th user.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Screenshots:

<img width="356" alt="Screenshot 2024-01-29 093454" src="https://github.com/JiscSD/octopus/assets/132363734/852a77e1-386b-4212-aab6-b31dbab2aff4">

<img width="396" alt="Screenshot 2024-01-29 093509" src="https://github.com/JiscSD/octopus/assets/132363734/2f6aeb96-1eeb-4fed-8f55-d9c5c1d6c3b8">
