### PR TITLE
OC-782: API functionality for adding grant IDs

### DIFF
--- a/api/prisma/createVersionedDOIs.ts
+++ b/api/prisma/createVersionedDOIs.ts
@@ -40,7 +40,8 @@ const createVersionedDOIs = async (): Promise<number> => {
                     country: true,
                     name: true,
                     link: true,
-                    ror: true
+                    ror: true,
+                    grantId: true
                 }
             },
             coAuthors: {

--- a/api/prisma/migrations/20240130093815_funder_grant/migration.sql
+++ b/api/prisma/migrations/20240130093815_funder_grant/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Funders" ADD COLUMN     "grantId" TEXT;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -117,6 +117,7 @@ model Funders {
     city                 String
     link                 String
     ror                  String?
+    grantId              String?
     createdAt            DateTime           @default(now())
     publicationVersionId String
     publicationVersion   PublicationVersion @relation(fields: [publicationVersionId], references: [id], onDelete: Cascade)

--- a/api/prisma/seeds/publications.ts
+++ b/api/prisma/seeds/publications.ts
@@ -318,13 +318,23 @@ const publicationSeeds: Prisma.PublicationCreateInput[] = [
                     ]
                 },
                 funders: {
-                    create: {
-                        id: 'publication-problem-draft-funder',
-                        name: 'name',
-                        country: 'country',
-                        city: 'city',
-                        link: 'https://example.com'
-                    }
+                    create: [
+                        {
+                            id: 'publication-problem-draft-funder-1',
+                            name: 'name',
+                            country: 'country',
+                            city: 'city',
+                            link: 'https://example.com',
+                            grantId: 'testing-co-12345'
+                        },
+                        {
+                            id: 'publication-problem-draft-funder-2',
+                            name: 'Example Funder',
+                            country: 'United Kingdom',
+                            city: 'London',
+                            link: 'https://examplefunder.com'
+                        }
+                    ]
                 },
                 additionalInformation: {
                     create: {

--- a/api/src/components/funder/__tests__/createFunder.test.ts
+++ b/api/src/components/funder/__tests__/createFunder.test.ts
@@ -106,4 +106,63 @@ describe('create a funder', () => {
 
         expect(funder.status).toEqual(400);
     });
+    test('User can create a duplicate funder if grant ID is different', async () => {
+        const funder = await testUtils.agent
+            .post('/publication-versions/publication-problem-draft-v1/funders')
+            .query({ apiKey: '000000005' })
+            .send({
+                name: 'name',
+                country: 'country',
+                city: 'city',
+                link: 'https://example.com',
+                grantId: 'new-grant-id'
+            });
+
+        expect(funder.status).toEqual(200);
+    });
+    test('User cannot create a duplicate funder if no grant ID is supplied', async () => {
+        const funder = await testUtils.agent
+            .post('/publication-versions/publication-problem-draft-v1/funders')
+            .query({ apiKey: '000000005' })
+            .send({
+                name: 'name',
+                country: 'country',
+                city: 'city',
+                link: 'https://example.com'
+            });
+
+        expect(funder.status).toEqual(400);
+        expect(funder.body.message).toEqual('This funder already exists on this publication version.');
+    });
+    test('User cannot create a duplicate funder if the existing funder has no grant ID', async () => {
+        const funder = await testUtils.agent
+            .post('/publication-versions/publication-problem-draft-v1/funders')
+            .query({ apiKey: '000000005' })
+            .send({
+                name: 'Example Funder',
+                country: 'United Kingdom',
+                city: 'London',
+                link: 'https://examplefunder.com'
+            });
+
+        expect(funder.status).toEqual(400);
+        expect(funder.body.message).toEqual('This funder already exists on this publication version.');
+    });
+    test('User cannot create a duplicate funder with the same grant ID', async () => {
+        const funder = await testUtils.agent
+            .post('/publication-versions/publication-problem-draft-v1/funders')
+            .query({ apiKey: '000000005' })
+            .send({
+                name: 'name',
+                country: 'country',
+                city: 'city',
+                link: 'https://example.com',
+                grantId: 'testing-co-12345'
+            });
+
+        expect(funder.status).toEqual(400);
+        expect(funder.body.message).toEqual(
+            'This funder and grant identifier already exist on this publication version.'
+        );
+    });
 });

--- a/api/src/components/funder/controller.ts
+++ b/api/src/components/funder/controller.ts
@@ -29,12 +29,22 @@ export const create = async (
             });
         }
 
+        // Duplicate funder (designated by ROR ID or funder link) is allowed if both funders have grant IDs and they are different.
+        const duplicateFunders = publicationVersion.funders.filter(
+            (funder) => funder.ror === event.body.ror || funder.link === event.body.link
+        );
+
         if (
-            publicationVersion.funders.some(
-                (funder) => funder.ror === event.body.ror || funder.link === event.body.link
-            )
+            (!event.body.grantId && duplicateFunders.length) ||
+            (event.body.grantId && duplicateFunders.some((funder) => !funder.grantId))
         ) {
             return response.json(400, { message: 'This funder already exists on this publication version.' });
+        } else {
+            if (duplicateFunders.some((funder) => funder.grantId === event.body.grantId)) {
+                return response.json(400, {
+                    message: 'This funder and grant identifier already exist on this publication version.'
+                });
+            }
         }
 
         const funder = await funderService.create(publicationVersion.id, event.body);

--- a/api/src/components/funder/schema/create.ts
+++ b/api/src/components/funder/schema/create.ts
@@ -15,6 +15,9 @@ const createFunderSchema = {
         },
         ror: {
             type: 'string'
+        },
+        grantId: {
+            type: 'string'
         }
     },
     required: ['name', 'country', 'city', 'link'],

--- a/api/src/components/funder/service.ts
+++ b/api/src/components/funder/service.ts
@@ -5,12 +5,8 @@ import * as publicationVersionService from 'publicationVersion/service';
 export const create = async (publicationVersionId: string, data: I.CreateFunderRequestBody) => {
     const funder = await client.prisma.funders.create({
         data: {
-            city: data.city,
-            country: data.country,
-            ror: data.ror,
             publicationVersionId,
-            name: data.name,
-            link: data.link
+            ...data
         }
     });
     await publicationVersionService.update(publicationVersionId, {

--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -54,7 +54,8 @@ export const get = async (id: string) => {
                             country: true,
                             name: true,
                             link: true,
-                            ror: true
+                            ror: true,
+                            grantId: true
                         }
                     },
                     coAuthors: {

--- a/api/src/components/publicationVersion/service.ts
+++ b/api/src/components/publicationVersion/service.ts
@@ -37,7 +37,8 @@ export const getById = (id: string) =>
                     country: true,
                     name: true,
                     link: true,
-                    ror: true
+                    ror: true,
+                    grantId: true
                 }
             },
             coAuthors: {
@@ -133,7 +134,8 @@ export const get = (publicationId: string, version: string | number) =>
                     country: true,
                     name: true,
                     link: true,
-                    ror: true
+                    ror: true,
+                    grantId: true
                 }
             },
             coAuthors: {
@@ -274,7 +276,8 @@ export const update = (id: string, data: Prisma.PublicationVersionUpdateInput) =
                     country: true,
                     name: true,
                     link: true,
-                    ror: true
+                    ror: true,
+                    grantId: true
                 }
             },
             coAuthors: {
@@ -615,7 +618,8 @@ export const create = async (previousVersion: I.PublicationVersion, user: I.User
                         city: funder.city,
                         country: funder.country,
                         link: funder.link,
-                        name: funder.name
+                        name: funder.name,
+                        grantId: funder.grantId
                     }))
                 }
             },
@@ -655,7 +659,8 @@ export const create = async (previousVersion: I.PublicationVersion, user: I.User
                     country: true,
                     name: true,
                     link: true,
-                    ror: true
+                    ror: true,
+                    grantId: true
                 }
             },
             coAuthors: {

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -619,6 +619,7 @@ export interface CreateFunderRequestBody {
     city: string;
     country: string;
     link: string;
+    grantId?: string;
 }
 
 export interface GetFlagByID {

--- a/api/src/scripts/updateDoi.ts
+++ b/api/src/scripts/updateDoi.ts
@@ -37,7 +37,8 @@ const updatePublicationDOIs = async (): Promise<void> => {
                     country: true,
                     name: true,
                     link: true,
-                    ror: true
+                    ror: true,
+                    grantId: true
                 }
             },
             coAuthors: {


### PR DESCRIPTION
The purpose of this PR was to add a new Grant ID field to funders on the API. This also brings with it new validation requirements - a duplicate funder (i.e. having the same ROR ID or link as an existing funder) can be added, if both the existing funder and new funder have a grant ID, and they are different.

---

### Acceptance Criteria:

- Grant IDs can be added as part of each funder entry
- Validation rules are changed to allow duplicate funders to be added as long as they have different grant IDs
- Update tests

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

API:
<img width="162" alt="Screenshot 2024-01-30 115842" src="https://github.com/JiscSD/octopus/assets/132363734/e8f52a0b-c638-48cb-a349-a2bbcdccbc02">

E2E:
<img width="130" alt="Screenshot 2024-01-30 115846" src="https://github.com/JiscSD/octopus/assets/132363734/43e6ab46-767a-4f8f-b3bd-45c3bd6dd30f">
