### PR TITLE
OC-781: Change "You are not listed as an author" text

### DIFF
--- a/ui/src/components/Publication/SimpleResult/index.tsx
+++ b/ui/src/components/Publication/SimpleResult/index.tsx
@@ -197,7 +197,9 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
                                         Helpers.formatDate(latestLiveVersion.publishedDate)}
                                 </time>
                             </p>
-                            {!isAuthorOnLatestLive && <p>You are not listed as an author on the latest version</p>}
+                            {!isAuthorOnLatestLive && (
+                                <p>You are not listed as an author on the latest published version</p>
+                            )}
                         </div>
                         <Components.Button
                             href={`/publications/${props.publication.id}`}


### PR DESCRIPTION
The purpose of this PR was to change the account page’s wording so that it distinguishes that the user is not an author on the live version specifically.

---

### Acceptance Criteria:

- On the account page, the text that appears if an author is not on the latest live version, “You are not listed as an author on the latest version” now reads “You are not listed as an author on the latest published version”.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

E2E:
<img width="128" alt="Screenshot 2024-01-31 092303" src="https://github.com/JiscSD/octopus/assets/132363734/7c7f0534-296d-48a2-99dd-d5199c904d81">

UI:
<img width="268" alt="Screenshot 2024-01-31 092326" src="https://github.com/JiscSD/octopus/assets/132363734/7af89602-a4a3-4103-9d70-a56d9d953fcd">

---

### Screenshots:
<img width="840" alt="Screenshot 2024-01-30 145959" src="https://github.com/JiscSD/octopus/assets/132363734/7e968204-1e42-4bca-969d-34125b6a07a3">
