### PR TITLE
OC-785: Author search flickers back to first page of results when switching

### DIFF
--- a/ui/src/lib/interfaces.ts
+++ b/ui/src/lib/interfaces.ts
@@ -523,3 +523,12 @@ export interface AdditionalInformation {
     url: string;
     description: string;
 }
+
+export interface AuthorsPaginatedResults {
+    data: CoreUser[];
+    metadata: {
+        total: number;
+        limit: number;
+        offset: number;
+    };
+}

--- a/ui/src/pages/search/authors/index.tsx
+++ b/ui/src/pages/search/authors/index.tsx
@@ -230,7 +230,7 @@ const Authors: Types.NextPage<Props> = (props): React.ReactElement => {
                                     />
                                 )}
 
-                                {!isValidating && results?.data?.length && (
+                                {results?.data?.length && (
                                     <>
                                         <div className="rounded">
                                             {results.data.map((result: any, index: number) => {


### PR DESCRIPTION
The purpose of this PR was to stop the author search from briefly showing a different page of results after changing page.

This was happening because the results were rendering with an animation before the request for the new page had finished and been validated.

I also included some general tidying up of the page and bringing it more in line with the topics search page which was written more recently (this is all in the 2nd commit).

---

### Acceptance Criteria:

- The author search doesn't show incorrect results briefly when changing page.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

E2E:
<img width="130" alt="Screenshot 2024-01-31 150926" src="https://github.com/JiscSD/octopus/assets/132363734/7451f882-d9d0-4964-a02f-6af27e027a46">

UI:
<img width="278" alt="Screenshot 2024-01-31 151024" src="https://github.com/JiscSD/octopus/assets/132363734/f84f3a8a-85b9-4160-a264-c019e7ebb98c">
