### PR TITLE
OC-749 fix: Change additional info link text

### DIFF
--- a/ui/src/components/AdditionalInformationCard/index.tsx
+++ b/ui/src/components/AdditionalInformationCard/index.tsx
@@ -24,9 +24,9 @@ const AdditionalInformationCard: React.FC<Props> = ({
             href={url}
             title={title}
             aria-label={title}
-            className="block text-sm font-semibold uppercase text-teal-600 underline transition-colors duration-500 dark:text-teal-300"
+            className="block text-sm font-semibold text-teal-600 underline transition-colors duration-500 dark:text-teal-300"
         >
-            Link to {title}
+            {url}
         </a>
     </section>
 );


### PR DESCRIPTION
The purpose of this PR was to correct an issue with OC-749 not matching the ACs. The link should show the URL of the additional information to make it clearer where people will be taken.

---

### Acceptance Criteria:

- Additional information link text displays the URL of the additional information.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Screenshots:

Before:
<img width="262" alt="Screenshot 2024-02-01 150854" src="https://github.com/JiscSD/octopus/assets/132363734/78d8d5c1-1b7c-4915-afb2-578aff26e59a">

After:
<img width="262" alt="Screenshot 2024-02-01 150830" src="https://github.com/JiscSD/octopus/assets/132363734/74b09f03-44dc-4be3-9e0f-59edb9672f96">

