### PR TITLE
OC-767: Sending new versions to pubrouter

### DIFF
--- a/api/src/components/publication/controller.ts
+++ b/api/src/components/publication/controller.ts
@@ -167,8 +167,8 @@ export const getPDF = async (
         }
     }
 
-    if (!pdfUrl) {
-        // generate new PDF
+    if (!pdfUrl || generateNewPDF) {
+        // Generate new PDF (overwrites if there is an existing one).
         try {
             // We know the publication has at least one LIVE version.
             const latestPublishedVersion = await publicationVersionService.get(publication.id, 'latestLive');
@@ -177,7 +177,7 @@ export const getPDF = async (
                 throw Error('Unable to get latest published version from supplied object');
             }
 
-            const newPDFUrl = await publicationService.generatePDF(latestPublishedVersion);
+            const newPDFUrl = await publicationVersionService.generatePDF(latestPublishedVersion);
 
             if (!newPDFUrl) {
                 throw Error('Failed to generate PDF');

--- a/api/src/components/publicationVersion/controller.ts
+++ b/api/src/components/publicationVersion/controller.ts
@@ -292,6 +292,8 @@ export const updateStatus = async (
             }
         }
 
+        // Publication version is being made LIVE
+
         let previousPublicationVersion: I.PublicationVersion | null = null;
 
         if (publicationVersion.versionNumber > 1) {

--- a/api/src/components/sqs/handler.ts
+++ b/api/src/components/sqs/handler.ts
@@ -5,7 +5,9 @@ export const generatePDFs = async (event): Promise<void> => {
         const { body } = record;
 
         try {
-            await axios.get(`https://${process.env.STAGE}.api.octopus.ac/v1/publications/${body}/pdf`);
+            await axios.get(
+                `https://${process.env.STAGE}.api.octopus.ac/v1/publications/${body}/pdf?generateNewPDF=true`
+            );
         } catch (err) {
             console.log(err);
         }

--- a/ui/src/components/Publication/SidebarCard/Actions/index.tsx
+++ b/ui/src/components/Publication/SidebarCard/Actions/index.tsx
@@ -161,7 +161,7 @@ const Actions: React.FC<ActionProps> = (props): React.ReactElement => {
                             Download:
                         </span>
                         <button
-                            aria-label="Print"
+                            aria-label="Download PDF"
                             onClick={() => {
                                 window.open(
                                     `${Config.endpoints.publications}/${props.publicationVersion.versionOf}/pdf?redirectToPreview=true`,


### PR DESCRIPTION
The purpose of this PR was to send an updated record to publications router under the “all versions” DOI when a new version of a publication is published.

Also moved the generatePDF function from the publication service to the publication version service as per the TODO comment.

Some parts of this flow are unavailable locally so the full flow including this part will have to be confirmed on the int environment:
- Triggering PDF generation via SQS messages
    - Locally, they're generated when requested, and this won't force a regenerate like the SQS triggered calls will
- Triggering the message to pubrouter when a PDF is put in the S3 bucket

Also fleshed out a basic todo e2e test to confirm that PDFs are generated.

---

### Acceptance Criteria:

Upon the publication of a new version, a new PDF for that version is generated, triggering a new notification to publications router containing all details about the new version, using the “all versions”/canonical DOI.

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
<img width="258" alt="Screenshot 2024-02-07 134247" src="https://github.com/JiscSD/octopus/assets/132363734/51f43305-9e42-4355-a45b-a850ba962c04">

API
<img width="159" alt="Screenshot 2024-02-07 133813" src="https://github.com/JiscSD/octopus/assets/132363734/9b39b7dd-d060-4106-b7e9-6955181a5f2e">

E2E
<img width="128" alt="Screenshot 2024-02-07 133125" src="https://github.com/JiscSD/octopus/assets/132363734/aa1f901a-07ef-45c8-818a-618aff1f16f6">