### PR TITLE
OC-799: Sprint 37 security updates

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -24,7 +24,7 @@
                 "html-to-text": "^8.2.1",
                 "jsonwebtoken": "^9.0.2",
                 "luxon": "^3.4.3",
-                "nodemailer": "^6.9.5",
+                "nodemailer": "^6.9.9",
                 "puppeteer-core": "^20.9.0",
                 "supertest": "^6.3.3"
             },

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -12,7 +12,7 @@
                 "@middy/core": "^4.6.2",
                 "@middy/do-not-wait-for-empty-event-loop": "^4.6.2",
                 "@middy/http-json-body-parser": "^4.6.2",
-                "@opensearch-project/opensearch": "^2.3.1",
+                "@opensearch-project/opensearch": "^2.5.0",
                 "@paralleldrive/cuid2": "^2.2.2",
                 "@prisma/client": "^4.16.2",
                 "@sparticuz/chromium": "^114.0.0",
@@ -7440,9 +7440,9 @@
             }
         },
         "node_modules/@opensearch-project/opensearch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/@opensearch-project/opensearch/-/opensearch-2.3.1.tgz",
-            "integrity": "sha512-Kg8tddAx6sinStnNi6IeGilfvLWlonIxaRdVNiJcNPr1yMqd0c9TSegn18zKr0Pb0IM9xBIGBSkRPuh67ZN6Hw==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@opensearch-project/opensearch/-/opensearch-2.5.0.tgz",
+            "integrity": "sha512-RY5J6Jt/Jbbr2F9XByGY9LJr0VNmXJjgVvvntpKE4NtZa/r9ak3o8YtGK1iey1yHgzMzze25598qq7ZYFk42DA==",
             "dependencies": {
                 "aws4": "^1.11.0",
                 "debug": "^4.3.1",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -9,9 +9,9 @@
             "version": "1.0.0",
             "license": "GPL-3.0-only",
             "dependencies": {
-                "@middy/core": "^4.6.2",
-                "@middy/do-not-wait-for-empty-event-loop": "^4.6.2",
-                "@middy/http-json-body-parser": "^4.6.2",
+                "@middy/core": "^4.7.0",
+                "@middy/do-not-wait-for-empty-event-loop": "^4.7.0",
+                "@middy/http-json-body-parser": "^4.7.0",
                 "@opensearch-project/opensearch": "^2.5.0",
                 "@paralleldrive/cuid2": "^2.2.2",
                 "@prisma/client": "^4.16.2",
@@ -7346,9 +7346,9 @@
             "peer": true
         },
         "node_modules/@middy/core": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/@middy/core/-/core-4.6.2.tgz",
-            "integrity": "sha512-pEy2tAvlQfo3hyskZBkgeEi2kjjc7ZQoblcLHKanyfgubf1NPfzW35oHj1jW5GNK4lDpJoV3LAflAMH1NxdX2Q==",
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/@middy/core/-/core-4.7.0.tgz",
+            "integrity": "sha512-yI++DmhDQ8+ugvY7+GrEnb2PF0M/6Wzbgu4Tf7QhOlhwKGDd4j6or+Ab7qYPWx+jnKf8F0tqlmh0gV4JLi0yHw==",
             "engines": {
                 "node": ">=16"
             },
@@ -7358,9 +7358,9 @@
             }
         },
         "node_modules/@middy/do-not-wait-for-empty-event-loop": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/@middy/do-not-wait-for-empty-event-loop/-/do-not-wait-for-empty-event-loop-4.6.2.tgz",
-            "integrity": "sha512-f6qZ06eU97lOFd/vkHmtKhVcHKKtgfSdgGEYya7Bm8hQlby6RhVNcRwx7Cj3TxE+m+/39SWRt60KnR7maPQkug==",
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/@middy/do-not-wait-for-empty-event-loop/-/do-not-wait-for-empty-event-loop-4.7.0.tgz",
+            "integrity": "sha512-p86HtdkRiBL3rG1vYpPdki0opbvtJKeHlBwoQZLFjp1CphQALyrL9RFTT4uypQl2up0TxcVa+dlVo0w8j91U2g==",
             "engines": {
                 "node": ">=16"
             },
@@ -7370,11 +7370,11 @@
             }
         },
         "node_modules/@middy/http-json-body-parser": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/@middy/http-json-body-parser/-/http-json-body-parser-4.6.2.tgz",
-            "integrity": "sha512-vro0av3rBGNJCWIy5SvC/up01w13CXaCy8gpivPHZHuTAsEY9SRj9y4yEvvL4UCAagPcpa7Crtc2nBc3FVd1mA==",
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/@middy/http-json-body-parser/-/http-json-body-parser-4.7.0.tgz",
+            "integrity": "sha512-OKDKAerCi3lDvSmZeV3lViKNHSPzj26nwNnVKt6Dcb0so0Llb9pDQtT5/GiEVjyuBbVteY1COz9AZlgprOw7lQ==",
             "dependencies": {
-                "@middy/util": "4.6.2"
+                "@middy/util": "4.7.0"
             },
             "engines": {
                 "node": ">=16"
@@ -7385,9 +7385,9 @@
             }
         },
         "node_modules/@middy/util": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/@middy/util/-/util-4.6.2.tgz",
-            "integrity": "sha512-VPxAEGNKJ/Rn1Wa3stElHDajTdyLTsctPdXgr2n8dB6QooT/EvAAzw94IvTzfpXvNKEXAYo+PZBRRLnErwp6Xw==",
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/@middy/util/-/util-4.7.0.tgz",
+            "integrity": "sha512-HUh0EOLGzBQjmJks4N12mmEebshtCUwyzdhk59UmAj97zzM0qn0exQvZDfbkY0pb/6b7sNnf7IpFww8Z6YxpWw==",
             "engines": {
                 "node": ">=16"
             },

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -18415,9 +18415,9 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
-            "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
             "dependencies": {
                 "randombytes": "^2.1.0"
             }

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -16745,9 +16745,9 @@
             }
         },
         "node_modules/nodemailer": {
-            "version": "6.9.5",
-            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.5.tgz",
-            "integrity": "sha512-/dmdWo62XjumuLc5+AYQZeiRj+PRR8y8qKtFCOyuOl1k/hckZd8durUUHs/ucKx6/8kN+wFxqKJlQ/LK/qR5FA==",
+            "version": "6.9.9",
+            "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.9.tgz",
+            "integrity": "sha512-dexTll8zqQoVJEZPwQAKzxxtFn0qTnjdQTchoU6Re9BUUGBJiOy3YMn/0ShTW6J5M0dfQ1NeDeRTTl4oIWgQMA==",
             "engines": {
                 "node": ">=6.0.0"
             }

--- a/api/package.json
+++ b/api/package.json
@@ -35,7 +35,7 @@
         "@middy/core": "^4.6.2",
         "@middy/do-not-wait-for-empty-event-loop": "^4.6.2",
         "@middy/http-json-body-parser": "^4.6.2",
-        "@opensearch-project/opensearch": "^2.3.1",
+        "@opensearch-project/opensearch": "^2.5.0",
         "@paralleldrive/cuid2": "^2.2.2",
         "@prisma/client": "^4.16.2",
         "@sparticuz/chromium": "^114.0.0",

--- a/api/package.json
+++ b/api/package.json
@@ -32,9 +32,9 @@
         "lint:fix": "eslint --fix src/"
     },
     "dependencies": {
-        "@middy/core": "^4.6.2",
-        "@middy/do-not-wait-for-empty-event-loop": "^4.6.2",
-        "@middy/http-json-body-parser": "^4.6.2",
+        "@middy/core": "^4.7.0",
+        "@middy/do-not-wait-for-empty-event-loop": "^4.7.0",
+        "@middy/http-json-body-parser": "^4.7.0",
         "@opensearch-project/opensearch": "^2.5.0",
         "@paralleldrive/cuid2": "^2.2.2",
         "@prisma/client": "^4.16.2",

--- a/api/package.json
+++ b/api/package.json
@@ -47,7 +47,7 @@
         "html-to-text": "^8.2.1",
         "jsonwebtoken": "^9.0.2",
         "luxon": "^3.4.3",
-        "nodemailer": "^6.9.5",
+        "nodemailer": "^6.9.9",
         "puppeteer-core": "^20.9.0",
         "supertest": "^6.3.3"
     },


### PR DESCRIPTION
The purpose of this PR was to apply updates to mitigate two vulnerabilities:

- Update nodemailer to fix: https://app.snyk.io/org/digital-resources/project/cec951e8-deaa-43b3-bffb-ac3d3f1bddcb#issue-SNYK-JS-NODEMAILER-6219989
- Update subdependencies of copy-webpack-plugin to fix: https://app.snyk.io/org/digital-resources/project/cec951e8-deaa-43b3-bffb-ac3d3f1bddcb#issue-SNYK-JS-SERIALIZEJAVASCRIPT-6147607

Additionally, some modules are flagged as having newer versions, and although our versions don’t have vulnerabilities, we are recommended to update to them:

- @opensearch-project/opensearch from 2.3.1 to 2.5.0
- @middy/core from 4.6.2 to 4.7.0
- @middy/do-not-wait-for-empty-event-loop from 4.6.2 to 4.7.0
- @middy/http-json-body-parser from 4.6.2 to 4.7.0

---

### Acceptance Criteria:

Octopus API is using the following versions of these packages:

- nodemailer: 6.9.9
- serialize-javascript: 6.0.2
- @opensearch-project/opensearch: 2.5.0
- @middy/core, @middy/do-not-wait-for-empty-event-loop, @middy/http-json-body-parser: 4.7.0

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

API
<img width="159" alt="Screenshot 2024-02-07 153836" src="https://github.com/JiscSD/octopus/assets/132363734/f478df97-6b8b-4f5a-b6fe-8cca453e984b">

E2E
<img width="142" alt="Screenshot 2024-02-08 094134" src="https://github.com/JiscSD/octopus/assets/132363734/f939136c-46b0-4090-a6eb-e6401a2d48b5">
