### PR TITLE
OC-805: Author search not responding to search terms

### DIFF
--- a/ui/src/__tests__/components/PageTitle.test.tsx
+++ b/ui/src/__tests__/components/PageTitle.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+
+import * as Components from '@/components';
+
+describe('Page title', () => {
+    const text = 'The meaning of Octopus';
+    const className = 'dummyclass';
+    beforeEach(() => {
+        render(<Components.PageTitle text={text} className={className} />);
+    });
+
+    it('Renders a first-level heading', () => {
+        expect(screen.getByRole('heading', { level: 1 }));
+    });
+
+    it('Displays title', () => {
+        expect(screen.getByText(text));
+    });
+
+    it('Adds className to classes', () => {
+        expect(screen.getByRole('heading', { level: 1 })).toHaveClass(className);
+    });
+});

--- a/ui/src/__tests__/components/PageTitle.test.tsx
+++ b/ui/src/__tests__/components/PageTitle.test.tsx
@@ -10,11 +10,11 @@ describe('Page title', () => {
     });
 
     it('Renders a first-level heading', () => {
-        expect(screen.getByRole('heading', { level: 1 }));
+        expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
     });
 
     it('Displays title', () => {
-        expect(screen.getByText(text));
+        expect(screen.getByText(text)).toBeInTheDocument();
     });
 
     it('Adds className to classes', () => {

--- a/ui/src/lib/interfaces.ts
+++ b/ui/src/lib/interfaces.ts
@@ -533,3 +533,7 @@ export interface AuthorsPaginatedResults {
         offset: number;
     };
 }
+
+export interface AuthorSearchQuery extends ParsedUrlQuery {
+    query?: string;
+}

--- a/ui/src/pages/search/authors/index.tsx
+++ b/ui/src/pages/search/authors/index.tsx
@@ -87,7 +87,7 @@ type Props = {
 const Authors: Types.NextPage<Props> = (props): React.ReactElement => {
     const router = Router.useRouter();
     // Query params
-    const [query] = React.useState(props.query ? props.query : '');
+    const { query = '' } = router.query as Interfaces.AuthorSearchQuery;
     const [limit, setLimit] = React.useState(props.limit ? parseInt(props.limit, 10) : 10);
     const [offset, setOffset] = React.useState(props.offset ? parseInt(props.offset, 10) : 0);
 


### PR DESCRIPTION
The purpose of this PR was to fix a bug where entering a query in the "quick search" box on the author search page didn't affect the results.

Added some tests for our PageTitle component.

---

### Acceptance Criteria:

- When a search term is submitted into the author search, results are filtered to match the term against the author's first or last name.

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
<img width="267" alt="Screenshot 2024-02-13 102603" src="https://github.com/JiscSD/octopus/assets/132363734/1201eab9-d811-48d4-920b-7aacbade5d7f">

E2E
<img width="132" alt="Screenshot 2024-02-13 102540" src="https://github.com/JiscSD/octopus/assets/132363734/4393b82e-2ce8-4cd9-bf48-cee800ab4ae1">

---

### Screenshots:

No query
<img width="1016" alt="Screenshot 2024-02-13 102913" src="https://github.com/JiscSD/octopus/assets/132363734/94d71a8f-b86f-4c33-a753-1dd2d72753a2">

Query
<img width="1017" alt="Screenshot 2024-02-13 102902" src="https://github.com/JiscSD/octopus/assets/132363734/38a0794a-65c7-4122-9036-06b6c060416a">

