### PR TITLE
OC-768: Create global log in set up script for end to end tests

### DIFF
--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 /test-results/
 /playwright-report/
 /playwright/.cache/
+/playwright/.auth/
 
 # local env files
 .env

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -28,8 +28,8 @@ You can use the playwright command line tools to run specific tests, or use othe
 
 If it is your first time using playwright, you might need to install some further dependencies so that it can do things such as launch browsers correctly. You can attempt to run the tests and playwright will suggest what you need to install in the output of failed tests, or you can install what you need in advance:
 
-- `npx playwright install`
-- `npx playwright install-deps`
+-   `npx playwright install`
+-   `npx playwright install-deps`
 
 ### Running via VSCode
 
@@ -64,7 +64,9 @@ staticPages.e2e.spec.ts
 
 ### Logged In
 
-These test areas of the site that do require authentication. They are split into respective parts of the site:
+These test areas of the site that do require authentication. Note that these tests have a setup dependency; this will run first, log in all the test users and store the browser state in a file that is reused by the LoggedIn tests. This saves us having to repeatedly log in in each separate test that needs it.
+
+They are split into respective parts of the site:
 
 ```
 browse.e2e.spec.ts

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -14,7 +14,7 @@ dotenv.config();
 const config: PlaywrightTestConfig = {
     testDir: './tests',
     /* Maximum time one test can run for. */
-    timeout: 300000, // some of the publication flow and coauthor tests exceed 2 minutes. We should try and streamline them but for now set this to 3 mins
+    timeout: 180000, // some of the publication flow and coauthor tests exceed 2 minutes. We should try and streamline them but for now set this to 3 mins
     expect: {
         /**
          * Maximum time expect() should wait for the condition to be met.
@@ -37,56 +37,50 @@ const config: PlaywrightTestConfig = {
         /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
         actionTimeout: 0,
         /* Base URL to use in actions like `await page.goto('/')`. */
-        // baseURL: 'http://localhost:3000',
+        baseURL: process.env.UI_BASE,
 
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
         trace: 'on-first-retry',
+        screenshot: 'only-on-failure',
         ignoreHTTPSErrors: true
     },
 
     /* Configure projects for major browsers */
     projects: [
         {
-            name: 'chromium',
+            name: 'setup',
+            testMatch: '**/*.setup.ts'
+        },
+        {
+            name: 'chromium - logged in',
+            use: {
+                ...devices['Desktop Chrome']
+            },
+            testMatch: 'LoggedIn/**',
+            dependencies: ['setup']
+        },
+        {
+            name: 'firefox - logged in',
+            use: {
+                ...devices['Desktop Firefox']
+            },
+            testMatch: 'LoggedIn/**',
+            dependencies: ['setup']
+        },
+        {
+            name: 'chromium - logged out',
+            testMatch: 'LoggedOut/**',
             use: {
                 ...devices['Desktop Chrome']
             }
         },
-
         {
-            name: 'firefox',
+            name: 'firefox - logged out',
+            testMatch: 'LoggedOut/**',
             use: {
                 ...devices['Desktop Firefox']
             }
         }
-
-        /* Test against mobile viewports. */
-        // {
-        //   name: 'Mobile Chrome',
-        //   use: {
-        //     ...devices['Pixel 5'],
-        //   },
-        // },
-        // {
-        //   name: 'Mobile Safari',
-        //   use: {
-        //     ...devices['iPhone 12'],
-        //   },
-        // },
-
-        /* Test against branded browsers. */
-        // {
-        //   name: 'Microsoft Edge',
-        //   use: {
-        //     channel: 'msedge',
-        //   },
-        // },
-        // {
-        //   name: 'Google Chrome',
-        //   use: {
-        //     channel: 'chrome',
-        //   },
-        // },
     ]
 
     /* Folder for test artifacts such as screenshots, videos, traces, etc. */

--- a/e2e/tests/LoggedIn/browse.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/browse.e2e.spec.ts
@@ -4,12 +4,8 @@ import { PageModel } from '../PageModel';
 
 test.describe('Browse', () => {
     test('Browse contents', async ({ browser }) => {
-        // Start up test
-        const page = await browser.newPage();
-
-        // Login
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser, Helpers.user2);
+        const page = await Helpers.getPageAsUser(browser, Helpers.user2);
+        await page.goto('/');
         await expect(page.locator(PageModel.header.usernameButton)).toHaveText(`${Helpers.user2.fullName}`);
 
         // Navigate to browse page

--- a/e2e/tests/LoggedIn/livePublication.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/livePublication.e2e.spec.ts
@@ -5,7 +5,7 @@ import { PageModel } from '../PageModel';
 test.describe.configure({ mode: 'serial' });
 
 export const testBookmarking = async (page: Page, id: string) => {
-    await page.goto(`${Helpers.UI_BASE}/publications/${id}`, {
+    await page.goto(`/publications/${id}`, {
         waitUntil: 'domcontentloaded'
     });
 
@@ -37,7 +37,7 @@ export const testBookmarking = async (page: Page, id: string) => {
 };
 
 export const testFlagging = async (page: Page, id: string, redFlagContent: string) => {
-    await page.goto(`${Helpers.UI_BASE}/publications/${id}`, {
+    await page.goto(`/publications/${id}`, {
         waitUntil: 'domcontentloaded'
     });
 
@@ -68,53 +68,27 @@ export const testFlagging = async (page: Page, id: string, redFlagContent: strin
 
 test.describe('Live Publication', () => {
     test('Live Publication page contents', async ({ browser }) => {
-        // Start up test
-        const page = await browser.newPage();
-
-        // Login
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(`${Helpers.user1.fullName}`);
-
+        const page = await Helpers.getPageAsUser(browser);
         await Helpers.checkLivePublicationLayout(page, 'cl3fz14dr0001es6i5ji51rq4', true);
     });
 
     test('Bookmarking a publication', async ({ browser }) => {
-        // Start up test
-        const page = await browser.newPage();
-
-        // Login
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(`${Helpers.user1.fullName}`);
-
+        const page = await Helpers.getPageAsUser(browser);
         await testBookmarking(page, 'cl3fz14dr0001es6i5ji51rq4');
     });
 
     test('Flagging a publication', async ({ browser }) => {
-        // Start up test
-        const page = await browser.newPage();
-
-        // Login
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(`${Helpers.user1.fullName}`);
-
+        const page = await Helpers.getPageAsUser(browser);
         await testFlagging(page, 'cl3fz14dr0001es6i5ji51rq4', 'testing the flagging functionality');
     });
 
     test('Author profile', async ({ browser }) => {
-        // Start up test
-        const page = await browser.newPage();
-
-        // Login
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(`${Helpers.user1.fullName}`);
-        await page.goto(`${Helpers.UI_BASE}/publications/cl3fz14dr0001es6i5ji51rq4`, { waitUntil: 'domcontentloaded' });
+        const page = await Helpers.getPageAsUser(browser);
+        await page.goto(`/publications/cl3fz14dr0001es6i5ji51rq4`, { waitUntil: 'domcontentloaded' });
 
         // Check and click author link
         await page.locator(PageModel.livePublication.authorLink).click();
+        await page.waitForResponse((response) => response.url().includes('/authors/') && response.ok());
 
         // Check name
         await expect(page.locator(PageModel.authorInfo.name)).toBeVisible();
@@ -131,11 +105,8 @@ test.describe('Live Publication', () => {
     });
 
     test('Download pdf/json', async ({ browser, headless }) => {
-        const page = await browser.newPage();
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(`${Helpers.user1.fullName}`);
-        await page.goto(`${Helpers.UI_BASE}/publications/cl3fz14dr0001es6i5ji51rq4`, { waitUntil: 'domcontentloaded' });
+        const page = await Helpers.getPageAsUser(browser);
+        await page.goto(`/publications/cl3fz14dr0001es6i5ji51rq4`, { waitUntil: 'domcontentloaded' });
 
         // Behaviour is different depending on whether test is running headless or not.
         if (headless) {

--- a/e2e/tests/LoggedIn/login.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/login.e2e.spec.ts
@@ -4,13 +4,12 @@ import { PageModel } from '../PageModel';
 
 test.describe('Login', () => {
     test('Can sign in and out using ORCID', async ({ browser }) => {
-        const page = await browser.newPage();
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser, Helpers.user3);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(`${Helpers.user3.fullName}`);
-
+        const page = await Helpers.getPageAsUser(browser, Helpers.user3);
+        await page.goto('/');
         await Helpers.logout(page);
 
         await expect(page.locator(PageModel.header.loginButton)).toBeVisible();
+        // Log back in to go back to pre-test state.
+        await Helpers.login(page, browser, Helpers.user3);
     });
 });

--- a/e2e/tests/LoggedIn/profile.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/profile.e2e.spec.ts
@@ -3,21 +3,13 @@ import { BrowserContext, expect, Page, test } from '@playwright/test';
 import { PageModel } from '../PageModel';
 
 test.describe('Live author page', () => {
-    let context: BrowserContext;
     let page: Page;
 
     test.beforeAll(async ({ browser }) => {
-        context = await browser.newContext();
-        page = await context.newPage();
-        // navigate to homepage
-        await page.goto(Helpers.UI_BASE, { waitUntil: 'domcontentloaded' });
-        await expect(page).toHaveTitle('Octopus | Built for Researchers');
-
-        // login
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(`${Helpers.user1.fullName}`);
+        page = await Helpers.getPageAsUser(browser);
 
         // go to "Live author page" page
+        await page.goto('/');
         await page.locator(PageModel.header.usernameButton).click();
         await page.locator(PageModel.header.myAccountButton).click();
         await page.locator(PageModel.myAccount.liveAuthorPageButton).click();
@@ -50,6 +42,7 @@ test.describe('Live author page', () => {
         await expect(orcidProfileLink).toBeVisible();
 
         await orcidProfileLink.click();
+        const context = page.context();
         await context.waitForEvent('page');
 
         const pages = context.pages();

--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -4,7 +4,7 @@ import { PageModel } from '../PageModel';
 import cuid2 from '@paralleldrive/cuid2';
 
 const createPublication = async (page: Page, publicationTitle: string, pubType: string) => {
-    await page.goto(`${Helpers.UI_BASE}/create`);
+    await page.goto(`/create`);
     // title
     await page.locator(PageModel.publish.title).click();
     await page.keyboard.type(publicationTitle);
@@ -383,14 +383,7 @@ test.describe('Publication flow', () => {
     // - Conflict of Interest: no conflict of interest
     // - Funders: Adding a funder by ROR ID and entering details manually
     test('Create a problem (standard publication)', async ({ browser }) => {
-        // Start up test
-        const page = await browser.newPage();
-
-        // Login
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
-
+        const page = await Helpers.getPageAsUser(browser);
         await createPublication(page, 'test title', 'PROBLEM');
         await completeKeyInformationTab(page);
         await completeAffiliationsTab(page, false);
@@ -438,14 +431,7 @@ test.describe('Publication flow', () => {
     // Covers field interaction unique to hypotheses/methods:
     // - Research process: declare that this is a pre-registration
     test('Create a hypothesis (standard publication)', async ({ browser }) => {
-        // Start up test
-        const page = await browser.newPage();
-
-        // Login
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
-
+        const page = await Helpers.getPageAsUser(browser);
         await createPublication(page, 'test title', 'HYPOTHESIS');
         await completeKeyInformationTab(page);
         await completeAffiliationsTab(page, true);
@@ -476,14 +462,7 @@ test.describe('Publication flow', () => {
     // - Research process: declare that this is a pre-registration
     // (should produce different text to hypotheses when publication is viewed)
     test('Create a method (standard publication)', async ({ browser }) => {
-        // Start up test
-        const page = await browser.newPage();
-
-        // Login
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
-
+        const page = await Helpers.getPageAsUser(browser);
         await createPublication(page, 'test title', 'PROTOCOL');
         await completeKeyInformationTab(page);
         await completeAffiliationsTab(page, false);
@@ -509,14 +488,7 @@ test.describe('Publication flow', () => {
     // Covers field interactions unique to results:
     // - Data statements: all fields
     test('Create results (standard publication)', async ({ browser }) => {
-        // Start up test
-        const page = await browser.newPage();
-
-        // Login
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
-
+        const page = await Helpers.getPageAsUser(browser);
         await createPublication(page, 'test title', 'DATA');
         await completeKeyInformationTab(page);
         await completeAffiliationsTab(page, false);
@@ -553,14 +525,7 @@ test.describe('Publication flow', () => {
 
     // Analyses have no unique fields. Just test that we can make one successfully.
     test('Create an analysis (standard publication)', async ({ browser }) => {
-        // Start up test
-        const page = await browser.newPage();
-
-        // Login
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
-
+        const page = await Helpers.getPageAsUser(browser);
         await createPublication(page, 'test title', 'ANALYSIS');
         await completeKeyInformationTab(page);
         await completeAffiliationsTab(page, false);
@@ -586,14 +551,7 @@ test.describe('Publication flow', () => {
 
     // Interpretations have no unique fields. Just test that we can make one successfully.
     test('Create an interpretation (standard publication)', async ({ browser }) => {
-        // Start up test
-        const page = await browser.newPage();
-
-        // Login
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
-
+        const page = await Helpers.getPageAsUser(browser);
         await createPublication(page, 'test title', 'INTERPRETATION');
         await completeKeyInformationTab(page);
         await completeAffiliationsTab(page, true);
@@ -614,14 +572,7 @@ test.describe('Publication flow', () => {
 
     // Real world applications have no unique fields. Just test that we can make one successfully.
     test('Create a real world application (standard publication)', async ({ browser }) => {
-        // Start up test
-        const page = await browser.newPage();
-
-        // Login
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
-
+        const page = await Helpers.getPageAsUser(browser);
         await createPublication(page, 'test title', 'REAL_WORLD_APPLICATION');
         await completeKeyInformationTab(page);
         await completeAffiliationsTab(page, true);
@@ -641,14 +592,7 @@ test.describe('Publication flow', () => {
     });
 
     test('Create a problem and link it to a topic', async ({ browser }) => {
-        // Start up test
-        const page = await browser.newPage();
-
-        // Login
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
-
+        const page = await Helpers.getPageAsUser(browser);
         await createPublication(page, 'problem to link to topic', 'PROBLEM');
         // Go to Linked Items tab
         await (await page.waitForSelector("aside button:has-text('Linked items')")).click();
@@ -663,14 +607,7 @@ test.describe('Publication flow', () => {
     });
 
     test('Cannot link a non-problem publication to a topic', async ({ browser }) => {
-        // Start up test
-        const page = await browser.newPage();
-
-        // Login
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
-
+        const page = await Helpers.getPageAsUser(browser);
         await createPublication(page, 'hypothesis that should not be linkable to a topic', 'HYPOTHESIS');
         // Go to Linked Items tab
         await (await page.waitForSelector("aside button:has-text('Linked items')")).click();
@@ -681,20 +618,14 @@ test.describe('Publication flow', () => {
     });
 
     test('Create a problem from an existing research topic', async ({ browser }) => {
-        // Start up test
-        const page = await browser.newPage();
-
-        // Login
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
+        const page = await Helpers.getPageAsUser(browser);
 
         // Navigate to topic and create related problem
-        await page.goto(`${Helpers.UI_BASE}/topics/test-topic-1`);
+        await page.goto(`/topics/test-topic-1`);
         await page.locator(PageModel.topic.createProblemLink).click();
 
         // Fill in basic fields
-        await page.waitForURL(`${Helpers.UI_BASE}/create?topic=test-topic-1&type=PROBLEM`);
+        await page.waitForURL(`/create?topic=test-topic-1&type=PROBLEM`);
         await page.locator(PageModel.publish.title).click();
         await page.keyboard.type('Problem from topic');
         await page.locator(PageModel.publish.confirmPublicationType).click();
@@ -728,11 +659,13 @@ const removeCoAuthor = async (page: Page, user: Helpers.TestUser) => {
     await row.locator('button[title="Delete"]').click();
 };
 
-const confirmInvolvement = async (browser: Browser, user: Helpers.TestUser, page: Page, loginRequired?: boolean) => {
-    if (loginRequired) {
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser, user);
-    }
+const requestApproval = async (page: Page) => {
+    await page.locator(PageModel.publish.requestApprovalButton).click();
+    await page.locator(PageModel.publish.confirmRequestApproval).click();
+    await page.waitForResponse((response) => response.url().includes('/request-approval') && response.ok());
+};
+
+const confirmInvolvement = async (browser: Browser, user: Helpers.TestUser, page: Page) => {
     const mailhogPage = await browser.newPage();
     await mailhogPage.goto(Helpers.MAIL_HOG);
     await mailhogPage.waitForSelector('.messages > .row');
@@ -774,21 +707,19 @@ const approvePublication = async (page: Page, hasAffiliations?: boolean) => {
 };
 
 const confirmCoAuthorInvitation = async (browser: Browser, user: Helpers.TestUser) => {
-    const context = await browser.newContext();
-    const page = await context.newPage();
-    await confirmInvolvement(browser, user, page, true);
+    const page = await Helpers.getPageAsUser(browser, user);
+    await confirmInvolvement(browser, user, page);
     await approvePublication(page);
-
-    await context.close();
+    await page.close();
 };
 
 const approveControlRequest = async (
-    context: BrowserContext,
+    browser: Browser,
     user: Helpers.TestUser,
     requesterName: string,
     approve: boolean
 ) => {
-    const page = await context.newPage();
+    const page = await Helpers.getPageAsUser(browser, user);
 
     await page.goto(Helpers.MAIL_HOG);
     await page.waitForSelector('.messages > .row');
@@ -827,11 +758,8 @@ const rejectCoAuthorInvitation = async (
     checkErrorMessage: boolean = false,
     errorMessage?: string
 ) => {
-    const context = await browser.newContext();
-    const page = await context.newPage();
-    await page.goto(Helpers.UI_BASE);
-    await Helpers.login(page, browser, user);
-    const page2 = await context.newPage();
+    const page = await Helpers.getPageAsUser(browser, user);
+    const page2 = await browser.newPage();
     await page2.goto(Helpers.MAIL_HOG);
     await page2.waitForSelector('.messages > .row');
 
@@ -850,15 +778,14 @@ const rejectCoAuthorInvitation = async (
         .getAttribute('href');
 
     // navigating to 'I am not an author link' will remove this co-author from the publication
-    const page3 = await context.newPage();
-    await page3.goto(invitationLink);
-    await page3.waitForLoadState('networkidle');
+    await page.goto(invitationLink);
+    await page.waitForLoadState('networkidle');
 
     if (checkErrorMessage) {
-        await expect(page3.locator(`h2.error-message-e2e`)).toHaveText(errorMessage);
+        await expect(page.locator(`h2.error-message-e2e`)).toHaveText(errorMessage);
     }
 
-    await context.close();
+    await Promise.all([page.close(), page2.close()]);
 };
 
 const verifyLastEmailNotification = async (browser: Browser, user: Helpers.TestUser, emailSubject: string) => {
@@ -893,9 +820,7 @@ const checkPublicationOnAccountPage = async (
     navigate?: boolean
 ) => {
     if (navigate) {
-        await page.locator(PageModel.header.usernameButton).click();
-        await page.locator(PageModel.header.myAccountButton).click();
-        await page.waitForURL(`${Helpers.UI_BASE}/account`);
+        await page.goto(`/account`);
     }
     const publicationContainer = await page.getByTestId('publication-' + publicationDetails.id);
     switch (state) {
@@ -963,54 +888,40 @@ const checkPublicationOnAccountPage = async (
     }
 };
 
+const createPublishReadyPublication = async (page: Page) => {
+    await createPublication(page, publicationWithCoAuthors.title, publicationWithCoAuthors.type);
+    await completeKeyInformationTab(page);
+    await completeAffiliationsTab(page, true);
+    await completeLinkedItemsTab(
+        page,
+        'living organisms',
+        'How do living organisms function, survive, reproduce and evolve?'
+    );
+    await completeMainTextTabMinimally(page, publicationWithCoAuthors.content);
+    await completeConflictOfInterestTab(page, false);
+};
+
+const addCoAuthorsAndRequestApproval = async (page: Page, coAuthors: Helpers.TestUser[]) => {
+    await page.locator('aside button:has-text("Co-authors")').first().click();
+    for (const coAuthor of coAuthors) {
+        await addCoAuthor(page, coAuthor);
+        // verify co-author has been added
+        await expect(page.locator(`td:has-text("${coAuthor.email}")`)).toBeVisible();
+    }
+    await expect(page.locator(PageModel.publish.requestApprovalButton)).toBeEnabled();
+    await requestApproval(page);
+};
+
 test.describe('Publication flow + co-authors', () => {
     test.describe.configure({ mode: 'serial' });
 
     test('Create a PROBLEM publication with co-authors', async ({ browser }) => {
-        const context = await browser.newContext();
-        const page = await context.newPage();
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
+        const page = await Helpers.getPageAsUser(browser);
 
-        // create new publication
-        await createPublication(page, publicationWithCoAuthors.title, publicationWithCoAuthors.type);
-
-        // fill 'Key information' tab
-        await completeKeyInformationTab(page);
-
-        // fill affiliation tab
-        await completeAffiliationsTab(page, true);
-
-        // add linked publication
-        await (await page.waitForSelector("aside button:has-text('Linked items')")).click();
-        await completeLinkedItemsTab(
-            page,
-            'living organisms',
-            'How do living organisms function, survive, reproduce and evolve?'
-        );
-
-        // specify conflict of interest status
-        await (await page.waitForSelector("aside button:has-text('Conflict of interest')")).click();
-        await completeConflictOfInterestTab(page, false);
-
-        // verify 'Publish' button is disabled
-        await expect(page.locator(PageModel.publish.publishButton)).toBeDisabled();
-
-        // add main text
-        await (await page.waitForSelector("aside button:has-text('Main text')")).click();
-        await page.locator(PageModel.publish.text.editor).click();
-        await page.keyboard.type(publicationWithCoAuthors.content);
+        // create new publication and fill in other required fields
+        await createPublishReadyPublication(page);
 
         // verify 'Publish' button is now enabled
-        await expect(page.locator(PageModel.publish.publishButton)).toBeEnabled();
-
-        // add new line and white space in the Main Text
-        await page.locator(PageModel.publish.text.editor).click();
-        await page.keyboard.press('Enter');
-        await page.keyboard.press('Space');
-
-        // verify 'Publish' button is still enabled
         await expect(page.locator(PageModel.publish.publishButton)).toBeEnabled();
 
         // add co-authors
@@ -1023,8 +934,7 @@ test.describe('Publication flow + co-authors', () => {
         await expect(requestApprovalButton).toBeEnabled();
 
         // Request approval from co authors
-        await page.locator(PageModel.publish.requestApprovalButton).click();
-        await page.locator(PageModel.publish.confirmRequestApproval).click();
+        await requestApproval(page);
 
         // first co-author confirmation
         await confirmCoAuthorInvitation(browser, Helpers.user2);
@@ -1044,6 +954,15 @@ test.describe('Publication flow + co-authors', () => {
 
         // refresh corresponding author page
         await page.reload();
+
+        // Check details in approval tracker
+        await expect(page.getByText(Helpers.user2.fullName)).toBeVisible();
+        await expect(page.getByText(Helpers.user2.email)).toBeVisible();
+        await expect(page.getByText(Helpers.user3.fullName)).toBeVisible();
+        await expect(page.getByText(Helpers.user3.email)).toBeVisible();
+        await expect(page.getByText('All authors have approved this publication').first()).toBeVisible();
+        await expect(page.getByText('Your role on this publication: Corresponding author')).toBeVisible();
+        await expect(page.getByText(`${Helpers.user1.fullName} (You)`)).toBeVisible();
 
         // verify publish button is now enabled
         await page.waitForSelector(PageModel.publish.publishButtonTracker);
@@ -1065,45 +984,10 @@ test.describe('Publication flow + co-authors', () => {
     });
 
     test('Main author is notified via email when a co-author rejects invitation', async ({ browser }) => {
-        const context = await browser.newContext();
-        const page = await context.newPage();
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
+        const page = await Helpers.getPageAsUser(browser);
 
-        // create new publication
-        await createPublication(page, publicationWithCoAuthors.title, publicationWithCoAuthors.type);
-
-        // fill 'Key information' tab
-        await completeKeyInformationTab(page);
-
-        // fill affiliations tab
-        await completeAffiliationsTab(page, false);
-
-        // add linked publication
-        await (await page.waitForSelector("aside button:has-text('Linked items')")).click();
-        await completeLinkedItemsTab(
-            page,
-            'living organisms',
-            'How do living organisms function, survive, reproduce and evolve?'
-        );
-
-        // add main text
-        await (await page.waitForSelector("aside button:has-text('Main text')")).click();
-        await page.locator(PageModel.publish.text.editor).click();
-        await page.keyboard.type(publicationWithCoAuthors.content);
-
-        // confirm conflict of interest
-        await completeConflictOfInterestTab(page, true, 'Some conflict of interest text');
-
-        // add one co-author
-        await page.locator('aside button:has-text("Co-authors")').first().click();
-        await addCoAuthor(page, Helpers.user2);
-
-        // Request approval from co author
-        await expect(page.locator(PageModel.publish.requestApprovalButton)).toBeEnabled();
-        await page.locator(PageModel.publish.requestApprovalButton).click();
-        await page.locator(PageModel.publish.confirmRequestApproval).click();
+        await createPublishReadyPublication(page);
+        await addCoAuthorsAndRequestApproval(page, [Helpers.user2]);
 
         // co-author rejects invitation
         await rejectCoAuthorInvitation(browser, Helpers.user2);
@@ -1115,49 +999,10 @@ test.describe('Publication flow + co-authors', () => {
     });
 
     test("Co Author is notified via email when they've been removed from a publication", async ({ browser }) => {
-        const context = await browser.newContext();
-        const page = await context.newPage();
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
+        const page = await Helpers.getPageAsUser(browser);
 
-        // create new publication
-        await createPublication(page, publicationWithCoAuthors.title, publicationWithCoAuthors.type);
-
-        // fill 'Key information' tab
-        await completeKeyInformationTab(page);
-
-        // fill affiliations tab
-        await completeAffiliationsTab(page, false);
-
-        // add linked publication
-        await (await page.waitForSelector("aside button:has-text('Linked items')")).click();
-        await completeLinkedItemsTab(
-            page,
-            'living organisms',
-            'How do living organisms function, survive, reproduce and evolve?'
-        );
-
-        // add main text
-        await (await page.waitForSelector("aside button:has-text('Main text')")).click();
-        await page.locator(PageModel.publish.text.editor).click();
-        await page.keyboard.type(publicationWithCoAuthors.content);
-
-        // confirm conflict of interest
-        await completeConflictOfInterestTab(page, true, 'Some conflict of interest text');
-
-        // add co-author
-        await page.locator('aside button:has-text("Co-authors")').first().click();
-        await addCoAuthor(page, Helpers.user3);
-
-        // verify co-author has been added
-        await expect(page.locator(`td:has-text("${Helpers.user3.email}")`)).toBeVisible();
-
-        // Request approval from co author
-        await expect(page.locator(PageModel.publish.requestApprovalButton)).toBeEnabled();
-        await page.locator(PageModel.publish.requestApprovalButton).click();
-        await page.locator(PageModel.publish.confirmRequestApproval).click();
-        await page.waitForResponse((response) => response.url().includes('/request-approval') && response.ok());
+        await createPublishReadyPublication(page);
+        await addCoAuthorsAndRequestApproval(page, [Helpers.user3]);
 
         // verify notification sent to co-author
         await verifyLastEmailNotification(browser, Helpers.user3, 'You’ve been added as a co-author on Octopus');
@@ -1183,42 +1028,16 @@ test.describe('Publication flow + co-authors', () => {
     });
 
     test('Authors order can be changed', async ({ browser }) => {
-        const context = await browser.newContext();
-        const page = await context.newPage();
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
+        const page = await Helpers.getPageAsUser(browser);
 
         // create new publication
-        await createPublication(page, publicationWithCoAuthors.title, publicationWithCoAuthors.type);
-
-        // fill 'Key information' tab
-        await completeKeyInformationTab(page);
-
-        // fill affiliations tab
-        await completeAffiliationsTab(page, false);
-
-        // add linked publication
-        await (await page.waitForSelector("aside button:has-text('Linked items')")).click();
-        await completeLinkedItemsTab(
-            page,
-            'living organisms',
-            'How do living organisms function, survive, reproduce and evolve?'
-        );
-
-        // add main text
-        await (await page.waitForSelector("aside button:has-text('Main text')")).click();
-        await page.locator(PageModel.publish.text.editor).click();
-        await page.keyboard.type(publicationWithCoAuthors.content);
-
-        // confirm conflict of interest
-        await completeConflictOfInterestTab(page, true, 'Some conflict of interest text');
+        await createPublishReadyPublication(page);
 
         // add co-authors
         await page.locator('aside button:has-text("Co-authors")').first().click();
         await addCoAuthor(page, Helpers.user2);
 
-        // verify authors order into the table
+        // verify authors order in the table
         await expect(page.locator('table > tbody > tr').first()).toContainText(Helpers.user1.email);
         await expect(page.locator('table > tbody > tr').nth(1)).toContainText(Helpers.user2.email);
 
@@ -1236,8 +1055,7 @@ test.describe('Publication flow + co-authors', () => {
         await expect(page.locator('table > tbody > tr').nth(1)).toContainText(Helpers.user1.email);
 
         // Request approval from co author
-        await page.locator(PageModel.publish.requestApprovalButton).click();
-        await page.locator(PageModel.publish.confirmRequestApproval).click();
+        await requestApproval(page);
 
         // handle co-author confirmation
         await confirmCoAuthorInvitation(browser, Helpers.user2);
@@ -1267,52 +1085,10 @@ test.describe('Publication flow + co-authors', () => {
     test('Co Author shown publication does not exist when denying an invite from a deleted publication', async ({
         browser
     }) => {
-        const context = await browser.newContext();
-        const page = await context.newPage();
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
+        const page = await Helpers.getPageAsUser(browser);
 
-        // create new publication
-        await createPublication(page, publicationWithCoAuthors.title, publicationWithCoAuthors.type);
-
-        // fill 'Key information' tab
-        await completeKeyInformationTab(page);
-
-        // fill affiliations tab
-        await completeAffiliationsTab(page, false);
-
-        // add linked publication
-        await (await page.waitForSelector("aside button:has-text('Linked items')")).click();
-        await completeLinkedItemsTab(
-            page,
-            'living organisms',
-            'How do living organisms function, survive, reproduce and evolve?'
-        );
-
-        // add main text
-        await (await page.waitForSelector("aside button:has-text('Main text')")).click();
-        await page.locator(PageModel.publish.text.editor).click();
-        await page.keyboard.type(publicationWithCoAuthors.content);
-
-        // confirm conflict of interest
-        await completeConflictOfInterestTab(page, true, 'Some conflict of interest text');
-
-        // add co-author
-        await page.locator('aside button:has-text("Co-authors")').first().click();
-        await addCoAuthor(page, Helpers.user2);
-
-        // verify co-author has been added
-        await expect(page.locator(`td:has-text("${Helpers.user2.email}")`)).toBeVisible();
-
-        // Request approval from co author
-        await expect(page.locator(PageModel.publish.requestApprovalButton)).toBeEnabled();
-        await page.locator(PageModel.publish.requestApprovalButton).click();
-        await page.locator(PageModel.publish.confirmRequestApproval).click();
-        await page.waitForResponse((response) => response.url().includes('/request-approval') && response.ok());
-
-        // verify notification sent to co-author
-        await verifyLastEmailNotification(browser, Helpers.user2, 'You’ve been added as a co-author on Octopus');
+        await createPublishReadyPublication(page);
+        await addCoAuthorsAndRequestApproval(page, [Helpers.user2]);
 
         // Unlock publication
         await unlockPublication(page);
@@ -1341,52 +1117,10 @@ test.describe('Publication flow + co-authors', () => {
     });
 
     test('Co Author deny message informs them publication has gone live', async ({ browser }) => {
-        const context = await browser.newContext();
-        const page = await context.newPage();
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
+        const page = await Helpers.getPageAsUser(browser);
 
-        // create new publication
-        await createPublication(page, publicationWithCoAuthors.title, publicationWithCoAuthors.type);
-
-        // fill 'Key information' tab
-        await completeKeyInformationTab(page);
-
-        // fill affiliations tab
-        await completeAffiliationsTab(page, false);
-
-        // add linked publication
-        await (await page.waitForSelector("aside button:has-text('Linked items')")).click();
-        await completeLinkedItemsTab(
-            page,
-            'living organisms',
-            'How do living organisms function, survive, reproduce and evolve?'
-        );
-
-        // add main text
-        await (await page.waitForSelector("aside button:has-text('Main text')")).click();
-        await page.locator(PageModel.publish.text.editor).click();
-        await page.keyboard.type(publicationWithCoAuthors.content);
-
-        // confirm conflict of interest
-        await completeConflictOfInterestTab(page, true, 'Some conflict of interest text');
-
-        // add co-author
-        await page.locator('aside button:has-text("Co-authors")').first().click();
-        await addCoAuthor(page, Helpers.user2);
-
-        // verify co-author has been added
-        await expect(page.locator(`td:has-text("${Helpers.user2.email}")`)).toBeVisible();
-
-        // Request approval from co author
-        await expect(page.locator(PageModel.publish.requestApprovalButton)).toBeEnabled();
-        await page.locator(PageModel.publish.requestApprovalButton).click();
-        await page.locator(PageModel.publish.confirmRequestApproval).click();
-        await page.waitForResponse((response) => response.url().includes('/request-approval') && response.ok());
-
-        // verify notification sent to co-author
-        await verifyLastEmailNotification(browser, Helpers.user2, 'You’ve been added as a co-author on Octopus');
+        await createPublishReadyPublication(page);
+        await addCoAuthorsAndRequestApproval(page, [Helpers.user2]);
 
         // Unlock publication
         await unlockPublication(page);
@@ -1409,52 +1143,10 @@ test.describe('Publication flow + co-authors', () => {
     });
 
     test('Co Author who is no longer listed is presented with the correct error message', async ({ browser }) => {
-        const context = await browser.newContext();
-        const page = await context.newPage();
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
+        const page = await Helpers.getPageAsUser(browser);
 
-        // create new publication
-        await createPublication(page, publicationWithCoAuthors.title, publicationWithCoAuthors.type);
-
-        // fill 'Key information' tab
-        await completeKeyInformationTab(page);
-
-        // fill affiliations tab
-        await completeAffiliationsTab(page, false);
-
-        // add linked publication
-        await (await page.waitForSelector("aside button:has-text('Linked items')")).click();
-        await completeLinkedItemsTab(
-            page,
-            'living organisms',
-            'How do living organisms function, survive, reproduce and evolve?'
-        );
-
-        // add main text
-        await (await page.waitForSelector("aside button:has-text('Main text')")).click();
-        await page.locator(PageModel.publish.text.editor).click();
-        await page.keyboard.type(publicationWithCoAuthors.content);
-
-        // confirm conflict of interest
-        await completeConflictOfInterestTab(page, true, 'Some conflict of interest text');
-
-        // add co-author
-        await page.locator('aside button:has-text("Co-authors")').first().click();
-        await addCoAuthor(page, Helpers.user2);
-
-        // verify co-author has been added
-        await expect(page.locator(`td:has-text("${Helpers.user2.email}")`)).toBeVisible();
-
-        // Request approval from co author
-        await expect(page.locator(PageModel.publish.requestApprovalButton)).toBeEnabled();
-        await page.locator(PageModel.publish.requestApprovalButton).click();
-        await page.locator(PageModel.publish.confirmRequestApproval).click();
-        await page.waitForResponse((response) => response.url().includes('/request-approval') && response.ok());
-
-        // verify notification sent to co-author
-        await verifyLastEmailNotification(browser, Helpers.user2, 'You’ve been added as a co-author on Octopus');
+        await createPublishReadyPublication(page);
+        await addCoAuthorsAndRequestApproval(page, [Helpers.user2]);
 
         // Unlock publication
         await unlockPublication(page);
@@ -1481,55 +1173,13 @@ test.describe('Publication flow + co-authors', () => {
         await page.close();
     });
 
-    test('Co Author who denys after accepting the invite is presented with the correct error message', async ({
+    test('Co Author who denies after accepting the invite is presented with the correct error message', async ({
         browser
     }) => {
-        const context = await browser.newContext();
-        const page = await context.newPage();
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
+        const page = await Helpers.getPageAsUser(browser);
 
-        // create new publication
-        await createPublication(page, publicationWithCoAuthors.title, publicationWithCoAuthors.type);
-
-        // fill 'Key information' tab
-        await completeKeyInformationTab(page);
-
-        // fill affiliations tab
-        await completeAffiliationsTab(page, false);
-
-        // add linked publication
-        await (await page.waitForSelector("aside button:has-text('Linked items')")).click();
-        await completeLinkedItemsTab(
-            page,
-            'living organisms',
-            'How do living organisms function, survive, reproduce and evolve?'
-        );
-
-        // add main text
-        await (await page.waitForSelector("aside button:has-text('Main text')")).click();
-        await page.locator(PageModel.publish.text.editor).click();
-        await page.keyboard.type(publicationWithCoAuthors.content);
-
-        // confirm conflict of interest
-        await completeConflictOfInterestTab(page, false);
-
-        // add co-author
-        await page.locator('aside button:has-text("Co-authors")').first().click();
-        await addCoAuthor(page, Helpers.user2);
-
-        // verify co-author has been added
-        await expect(page.locator(`td:has-text("${Helpers.user2.email}")`)).toBeVisible();
-
-        // Request approval from co author
-        await expect(page.locator(PageModel.publish.requestApprovalButton)).toBeEnabled();
-        await page.locator(PageModel.publish.requestApprovalButton).click();
-        await page.locator(PageModel.publish.confirmRequestApproval).click();
-        await page.waitForResponse((response) => response.url().includes('/request-approval') && response.ok());
-
-        // verify notification sent to co-author
-        await verifyLastEmailNotification(browser, Helpers.user2, 'You’ve been added as a co-author on Octopus');
+        await createPublishReadyPublication(page);
+        await addCoAuthorsAndRequestApproval(page, [Helpers.user2]);
 
         await confirmCoAuthorInvitation(browser, Helpers.user2);
 
@@ -1547,11 +1197,7 @@ test.describe('Publication flow + co-authors', () => {
     test('Coauthored publications show on your own profile with correct publication status', async ({ browser }) => {
         const publicationTitle = 'account page check';
         const coAuthor = Helpers.user2;
-        const page = await browser.newPage();
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
-
+        const page = await Helpers.getPageAsUser(browser);
         await createPublication(page, publicationTitle, 'PROBLEM');
         const publicationId = page.url().split('/').slice(-2)[0];
         const publicationContainerTestId = 'publication-' + publicationId;
@@ -1579,16 +1225,13 @@ test.describe('Publication flow + co-authors', () => {
         await page.locator('aside button:has-text("Co-authors")').first().click();
         await addCoAuthor(page, coAuthor);
         await expect(page.locator(PageModel.publish.requestApprovalButton)).toBeEnabled();
-        await page.locator(PageModel.publish.requestApprovalButton).click();
-        await page.locator(PageModel.publish.confirmRequestApproval).click();
+        await requestApproval(page);
 
         // Check locked details
         await checkPublicationOnAccountPage(page, { id: publicationId }, 'pending coauthor approval', true);
 
         // Check details as unconfirmed co-author
-        const page2 = await browser.newPage();
-        await page2.goto(Helpers.UI_BASE);
-        await Helpers.login(page2, browser, Helpers.user2);
+        const page2 = await Helpers.getPageAsUser(browser, Helpers.user2);
         await checkPublicationOnAccountPage(page2, { id: publicationId }, 'unconfirmed coauthor', true);
 
         // As co-author, confirm involvement without approving
@@ -1598,7 +1241,7 @@ test.describe('Publication flow + co-authors', () => {
         await checkPublicationOnAccountPage(page2, { id: publicationId }, 'pending your approval', true);
 
         // Approve publication
-        await page2.goto(Helpers.UI_BASE + '/publications/' + publicationId);
+        await page2.goto('/publications/' + publicationId);
         await approvePublication(page2);
 
         // Check details as co-author
@@ -1630,9 +1273,7 @@ test.describe('Publication flow + co-authors', () => {
 
         // Request approval on new version
         await expect(page2.locator(PageModel.publish.requestApprovalButton)).toBeEnabled();
-        await page2.locator(PageModel.publish.requestApprovalButton).click();
-        await page2.locator(PageModel.publish.confirmRequestApproval).click();
-        await page2.waitForSelector(PageModel.publish.unlockButton);
+        await requestApproval(page2);
 
         // Check details as co-author (new corresponding author)
         await checkPublicationOnAccountPage(page2, { id: publicationId }, 'own new version', true);
@@ -1666,126 +1307,12 @@ test.describe('Publication flow + co-authors', () => {
         await Promise.all([page.close(), page2.close()]);
     });
 
-    test('Co Authors appear properly in the Approvals Tracker', async ({ browser }) => {
-        const context = await browser.newContext();
-        const page = await context.newPage();
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
-
-        // create new publication
-        await createPublication(page, publicationWithCoAuthors.title, publicationWithCoAuthors.type);
-
-        // fill 'Key information' tab
-        await completeKeyInformationTab(page);
-
-        // fill affiliations tab
-        await completeAffiliationsTab(page, false);
-
-        // add linked publication
-        await (await page.waitForSelector("aside button:has-text('Linked items')")).click();
-        await completeLinkedItemsTab(
-            page,
-            'living organisms',
-            'How do living organisms function, survive, reproduce and evolve?'
-        );
-
-        // add main text
-        await (await page.waitForSelector("aside button:has-text('Main text')")).click();
-        await page.locator(PageModel.publish.text.editor).click();
-        await page.keyboard.type(publicationWithCoAuthors.content);
-
-        // confirm conflict of interest
-        await completeConflictOfInterestTab(page, false);
-
-        // add co-author
-        await page.locator('aside button:has-text("Co-authors")').first().click();
-        await addCoAuthor(page, Helpers.user2);
-
-        // verify co-author has been added
-        await expect(page.locator(`td:has-text("${Helpers.user2.email}")`)).toBeVisible();
-
-        // add co-author
-        await page.locator('aside button:has-text("Co-authors")').first().click();
-        await addCoAuthor(page, Helpers.user3);
-
-        // verify co-author has been added
-        await expect(page.locator(`td:has-text("${Helpers.user3.email}")`)).toBeVisible();
-
-        // Request approval from co author
-        await expect(page.locator(PageModel.publish.requestApprovalButton)).toBeEnabled();
-        await page.locator(PageModel.publish.requestApprovalButton).click();
-        await page.locator(PageModel.publish.confirmRequestApproval).click();
-        await page.waitForResponse((response) => response.url().includes('/request-approval') && response.ok());
-
-        await confirmCoAuthorInvitation(browser, Helpers.user2);
-        await confirmCoAuthorInvitation(browser, Helpers.user3);
-
-        // refresh corresponding author page
-        await page.reload();
-
-        await expect(page.getByText(Helpers.user2.fullName)).toBeVisible();
-        await expect(page.getByText(Helpers.user2.email)).toBeVisible();
-        await expect(page.getByText(Helpers.user3.fullName)).toBeVisible();
-        await expect(page.getByText(Helpers.user3.email)).toBeVisible();
-        await expect(page.getByText('All authors have approved this publication').first()).toBeVisible();
-        await expect(page.getByText('Your role on this publication: Corresponding author')).toBeVisible();
-        await expect(page.getByText(`${Helpers.user1.fullName} (You)`)).toBeVisible();
-
-        await page.close();
-    });
-
     test('Corresponding author can publish from Approvals Tracker', async ({ browser }) => {
-        const context = await browser.newContext();
-        const page = await context.newPage();
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
+        const page = await Helpers.getPageAsUser(browser);
 
         // create new publication
-        await createPublication(page, publicationWithCoAuthors.title, publicationWithCoAuthors.type);
-
-        // fill 'Key information' tab
-        await completeKeyInformationTab(page);
-
-        // fill affiliations tab
-        await completeAffiliationsTab(page, false);
-
-        // add linked publication
-        await (await page.waitForSelector("aside button:has-text('Linked items')")).click();
-        await completeLinkedItemsTab(
-            page,
-            'living organisms',
-            'How do living organisms function, survive, reproduce and evolve?'
-        );
-
-        // add main text
-        await (await page.waitForSelector("aside button:has-text('Main text')")).click();
-        await page.locator(PageModel.publish.text.editor).click();
-        await page.keyboard.type(publicationWithCoAuthors.content);
-
-        // confirm conflict of interest
-        await completeConflictOfInterestTab(page, false);
-
-        // add co-author
-        await page.locator('aside button:has-text("Co-authors")').first().click();
-        await addCoAuthor(page, Helpers.user2);
-
-        // verify co-author has been added
-        await expect(page.locator(`td:has-text("${Helpers.user2.email}")`)).toBeVisible();
-
-        // add co-author
-        await page.locator('aside button:has-text("Co-authors")').first().click();
-        await addCoAuthor(page, Helpers.user3);
-
-        // verify co-author has been added
-        await expect(page.locator(`td:has-text("${Helpers.user3.email}")`)).toBeVisible();
-
-        // Request approval from co author
-        await expect(page.locator(PageModel.publish.requestApprovalButton)).toBeEnabled();
-        await page.locator(PageModel.publish.requestApprovalButton).click();
-        await page.locator(PageModel.publish.confirmRequestApproval).click();
-        await page.waitForResponse((response) => response.url().includes('/request-approval') && response.ok());
+        await createPublishReadyPublication(page);
+        await addCoAuthorsAndRequestApproval(page, [Helpers.user2, Helpers.user3]);
 
         // check preview page
         await expect(page.getByText('This publication is locked for approval')).toBeVisible();
@@ -1822,49 +1349,11 @@ test.describe('Publication flow + co-authors', () => {
     test("Corresponding author can change unconfirmed author's email from Approvals Tracker table", async ({
         browser
     }) => {
-        const context = await browser.newContext();
-        const page = await context.newPage();
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
+        const page = await Helpers.getPageAsUser(browser);
 
         // create new publication
-        await createPublication(page, publicationWithCoAuthors.title, publicationWithCoAuthors.type);
-
-        // fill 'Key information' tab
-        await completeKeyInformationTab(page);
-
-        // fill affiliations tab
-        await completeAffiliationsTab(page, false);
-
-        // add linked publication
-        await (await page.waitForSelector("aside button:has-text('Linked items')")).click();
-        await completeLinkedItemsTab(
-            page,
-            'living organisms',
-            'How do living organisms function, survive, reproduce and evolve?'
-        );
-
-        // add main text
-        await (await page.waitForSelector("aside button:has-text('Main text')")).click();
-        await page.locator(PageModel.publish.text.editor).click();
-        await page.keyboard.type(publicationWithCoAuthors.content);
-
-        // confirm conflict of interest
-        await completeConflictOfInterestTab(page, false);
-
-        // add co-author
-        await page.locator('aside button:has-text("Co-authors")').first().click();
-        await addCoAuthor(page, Helpers.user2);
-
-        // verify co-author has been added
-        await expect(page.locator(`td:has-text("${Helpers.user2.email}")`)).toBeVisible();
-
-        // Request approval from co author
-        await expect(page.locator(PageModel.publish.requestApprovalButton)).toBeEnabled();
-        await page.locator(PageModel.publish.requestApprovalButton).click();
-        await page.locator(PageModel.publish.confirmRequestApproval).click();
-        await page.waitForResponse((response) => response.url().includes('/request-approval') && response.ok());
+        await createPublishReadyPublication(page);
+        await addCoAuthorsAndRequestApproval(page, [Helpers.user2]);
 
         // check preview page
         await expect(page.getByText('This publication is locked for approval')).toBeVisible();
@@ -1893,49 +1382,10 @@ test.describe('Publication flow + co-authors', () => {
     });
 
     test('Corresponding author can send reminders', async ({ browser }) => {
-        const context = await browser.newContext();
-        const page = await context.newPage();
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
+        const page = await Helpers.getPageAsUser(browser);
 
-        // create new publication
-        await createPublication(page, publicationWithCoAuthors.title, publicationWithCoAuthors.type);
-
-        // fill 'Key information' tab
-        await completeKeyInformationTab(page);
-
-        // fill affiliations tab
-        await completeAffiliationsTab(page, false);
-
-        // add linked publication
-        await (await page.waitForSelector("aside button:has-text('Linked items')")).click();
-        await completeLinkedItemsTab(
-            page,
-            'living organisms',
-            'How do living organisms function, survive, reproduce and evolve?'
-        );
-
-        // add main text
-        await (await page.waitForSelector("aside button:has-text('Main text')")).click();
-        await page.locator(PageModel.publish.text.editor).click();
-        await page.keyboard.type(publicationWithCoAuthors.content);
-
-        // confirm conflict of interest
-        await completeConflictOfInterestTab(page, false);
-
-        // add co-author
-        await page.locator('aside button:has-text("Co-authors")').first().click();
-        await addCoAuthor(page, Helpers.user2);
-
-        // verify co-author has been added
-        await expect(page.locator(`td:has-text("${Helpers.user2.email}")`)).toBeVisible();
-
-        // Request approval from co author
-        await expect(page.locator(PageModel.publish.requestApprovalButton)).toBeEnabled();
-        await page.locator(PageModel.publish.requestApprovalButton).click();
-        await page.locator(PageModel.publish.confirmRequestApproval).click();
-        await page.waitForResponse((response) => response.url().includes('/request-approval') && response.ok());
+        await createPublishReadyPublication(page);
+        await addCoAuthorsAndRequestApproval(page, [Helpers.user2]);
 
         // check preview page
         await expect(page.getByText('This publication is locked for approval')).toBeVisible();
@@ -1974,49 +1424,10 @@ test.describe('Publication flow + co-authors', () => {
     });
 
     test('Editing a publication removes existing approvals', async ({ browser }) => {
-        const context = await browser.newContext();
-        const page = await context.newPage();
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
+        const page = await Helpers.getPageAsUser(browser);
 
-        // create new publication
-        await createPublication(page, publicationWithCoAuthors.title, publicationWithCoAuthors.type);
-
-        // fill 'Key information' tab
-        await completeKeyInformationTab(page);
-
-        // fill affiliations tab
-        await completeAffiliationsTab(page, false);
-
-        // add linked publication
-        await (await page.waitForSelector("aside button:has-text('Linked items')")).click();
-        await completeLinkedItemsTab(
-            page,
-            'living organisms',
-            'How do living organisms function, survive, reproduce and evolve?'
-        );
-
-        // add main text
-        await (await page.waitForSelector("aside button:has-text('Main text')")).click();
-        await page.locator(PageModel.publish.text.editor).click();
-        await page.keyboard.type(publicationWithCoAuthors.content);
-
-        // confirm conflict of interest
-        await completeConflictOfInterestTab(page, false);
-
-        // add co-author
-        await page.locator('aside button:has-text("Co-authors")').first().click();
-        await addCoAuthor(page, Helpers.user2);
-
-        // verify co-author has been added
-        await expect(page.locator(`td:has-text("${Helpers.user2.email}")`)).toBeVisible();
-
-        // Request approval from co author
-        await expect(page.locator(PageModel.publish.requestApprovalButton)).toBeEnabled();
-        await page.locator(PageModel.publish.requestApprovalButton).click();
-        await page.locator(PageModel.publish.confirmRequestApproval).click();
-        await page.waitForResponse((response) => response.url().includes('/request-approval') && response.ok());
+        await createPublishReadyPublication(page);
+        await addCoAuthorsAndRequestApproval(page, [Helpers.user2]);
 
         await confirmCoAuthorInvitation(browser, Helpers.user2);
 
@@ -2027,9 +1438,7 @@ test.describe('Publication flow + co-authors', () => {
 
         // Request approval from co author
         await expect(page.locator(PageModel.publish.requestApprovalButton)).toBeEnabled();
-        await page.locator(PageModel.publish.requestApprovalButton).click();
-        await page.locator(PageModel.publish.confirmRequestApproval).click();
-        await page.waitForResponse((response) => response.url().includes('/request-approval') && response.ok());
+        await requestApproval(page);
 
         await expect(page.getByText('Approval Pending')).toBeVisible();
 
@@ -2039,56 +1448,16 @@ test.describe('Publication flow + co-authors', () => {
     test('Co-authors are notified if the publication was edited after they confirmed their involvement', async ({
         browser
     }) => {
-        const context = await browser.newContext();
-        const page = await context.newPage();
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
+        const page = await Helpers.getPageAsUser(browser);
 
-        // create new publication
-        await createPublication(page, publicationWithCoAuthors.title, publicationWithCoAuthors.type);
-
-        // fill 'Key information' tab
-        await completeKeyInformationTab(page);
-
-        // fill affiliations tab
-        await completeAffiliationsTab(page, false);
-
-        // add linked publication
-        await (await page.waitForSelector("aside button:has-text('Linked items')")).click();
-        await completeLinkedItemsTab(
-            page,
-            'living organisms',
-            'How do living organisms function, survive, reproduce and evolve?'
-        );
-
-        // add main text
-        await (await page.waitForSelector("aside button:has-text('Main text')")).click();
-        await page.locator(PageModel.publish.text.editor).click();
-        await page.keyboard.type(publicationWithCoAuthors.content);
-
-        // confirm conflict of interest
-        await completeConflictOfInterestTab(page, false);
-
-        // add co-author
-        await page.locator('aside button:has-text("Co-authors")').first().click();
-        await addCoAuthor(page, Helpers.user2);
-
-        // verify co-author has been added
-        await expect(page.locator(`td:has-text("${Helpers.user2.email}")`)).toBeVisible();
-
-        // Request approval from co author
-        await expect(page.locator(PageModel.publish.requestApprovalButton)).toBeEnabled();
-        await page.locator(PageModel.publish.requestApprovalButton).click();
-        await page.locator(PageModel.publish.confirmRequestApproval).click();
-        await page.waitForResponse((response) => response.url().includes('/request-approval') && response.ok());
+        await createPublishReadyPublication(page);
+        await addCoAuthorsAndRequestApproval(page, [Helpers.user2]);
 
         await confirmCoAuthorInvitation(browser, Helpers.user2);
 
         // unlock and request approvals again
         await unlockPublication(page);
-        await page.locator(PageModel.publish.requestApprovalButton).click();
-        await page.locator(PageModel.publish.confirmRequestApproval).click();
-        await page.waitForResponse((response) => response.url().includes('/request-approval') && response.ok());
+        await requestApproval(page);
 
         await verifyLastEmailNotification(
             browser,
@@ -2100,56 +1469,11 @@ test.describe('Publication flow + co-authors', () => {
     });
 
     test('Co Authors can edit their affiliations using Approvals Tracker table', async ({ browser }) => {
-        const context = await browser.newContext();
-        const page = await context.newPage();
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
+        const page = await Helpers.getPageAsUser(browser);
 
         // create new publication
-        await createPublication(page, publicationWithCoAuthors.title, publicationWithCoAuthors.type);
-
-        // fill 'Key information' tab
-        await completeKeyInformationTab(page);
-
-        // fill affiliations tab
-        await completeAffiliationsTab(page, true);
-
-        // add linked publication
-        await (await page.waitForSelector("aside button:has-text('Linked items')")).click();
-        await completeLinkedItemsTab(
-            page,
-            'living organisms',
-            'How do living organisms function, survive, reproduce and evolve?'
-        );
-
-        // add main text
-        await (await page.waitForSelector("aside button:has-text('Main text')")).click();
-        await page.locator(PageModel.publish.text.editor).click();
-        await page.keyboard.type(publicationWithCoAuthors.content);
-
-        // confirm conflict of interest
-        await completeConflictOfInterestTab(page, false);
-
-        // add co-author
-        await page.locator('aside button:has-text("Co-authors")').first().click();
-        await addCoAuthor(page, Helpers.user2);
-
-        // verify co-author has been added
-        await expect(page.locator(`td:has-text("${Helpers.user2.email}")`)).toBeVisible();
-
-        // add co-author
-        await page.locator('aside button:has-text("Co-authors")').first().click();
-        await addCoAuthor(page, Helpers.user3);
-
-        // verify co-author has been added
-        await expect(page.locator(`td:has-text("${Helpers.user3.email}")`)).toBeVisible();
-
-        // Request approval from co author
-        await expect(page.locator(PageModel.publish.requestApprovalButton)).toBeEnabled();
-        await page.locator(PageModel.publish.requestApprovalButton).click();
-        await page.locator(PageModel.publish.confirmRequestApproval).click();
-        await page.waitForResponse((response) => response.url().includes('/request-approval') && response.ok());
+        await createPublishReadyPublication(page);
+        await addCoAuthorsAndRequestApproval(page, [Helpers.user2, Helpers.user3]);
 
         await expect(page.getByText('Unaffiliated').first()).toBeVisible();
         await expect(page.locator('button[title="Edit your affiliations"]')).toBeVisible();
@@ -2242,11 +1566,7 @@ test.describe('Publication flow + co-authors', () => {
     });
 
     test('Corresponding author and co-authors can create multiple versions for a publication', async ({ browser }) => {
-        let page = await browser.newPage();
-
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
+        let page = await Helpers.getPageAsUser(browser);
 
         // create v1
         await createPublication(page, problemPublication.title, 'PROBLEM');
@@ -2293,8 +1613,7 @@ test.describe('Publication flow + co-authors', () => {
         await addCoAuthor(page, Helpers.user2);
 
         // request approvals for v2
-        await page.locator(PageModel.publish.requestApprovalButton).click();
-        await page.locator(PageModel.publish.confirmRequestApproval).click();
+        await requestApproval(page);
         await page.locator(`h1:has-text("${newTitle}")`).first().waitFor({ state: 'visible' });
         await page.locator(`h1:has-text("${newTitle}")`).waitFor(); // wait for redirect
 
@@ -2314,10 +1633,7 @@ test.describe('Publication flow + co-authors', () => {
         await page.close();
 
         // create new session as co-author
-        page = await browser.newPage();
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser, Helpers.user2);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user2.fullName);
+        page = await Helpers.getPageAsUser(browser, Helpers.user2);
 
         // create v3 as co-author
         await checkPublicationOnAccountPage(page, { id: publicationId }, 'published', true);
@@ -2386,11 +1702,7 @@ test.describe('Publication flow + co-authors', () => {
 
     test('Co-authors can transfer ownership of a new DRAFT version', async ({ browser }) => {
         const context = await browser.newContext();
-        const page = await context.newPage();
-
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
+        const page = await Helpers.getPageAsUser(browser);
 
         // create v1
         await createPublication(page, problemPublication2.title, 'PROBLEM');
@@ -2409,8 +1721,7 @@ test.describe('Publication flow + co-authors', () => {
         await addCoAuthor(page, Helpers.user2);
 
         // request approvals for v1
-        await page.locator(PageModel.publish.requestApprovalButton).click();
-        await page.locator(PageModel.publish.confirmRequestApproval).click();
+        await requestApproval(page);
         await page.locator(`h1:has-text("${problemPublication2.title}")`).first().waitFor({ state: 'visible' });
         await page.locator(`h1:has-text("${problemPublication2.title}")`).waitFor(); // wait for redirect
 
@@ -2420,7 +1731,10 @@ test.describe('Publication flow + co-authors', () => {
         // publish v1
         await page.reload();
         await page.locator(PageModel.publish.publishButtonTracker).click();
-        await page.locator(PageModel.publish.confirmPublishButtonTracker).click();
+        await Promise.all([
+            page.waitForNavigation(),
+            page.locator(PageModel.publish.confirmPublishButtonTracker).click()
+        ]);
 
         // get publication id from url and deduct canonical DOI
         const publicationId = page.url().split('/').slice(-3)[0];
@@ -2442,13 +1756,10 @@ test.describe('Publication flow + co-authors', () => {
         await page.waitForURL('**/versions/latest');
 
         // login as co-author and request control over v2
-        const page2 = await browser.newPage();
-        await page2.goto(Helpers.UI_BASE);
-        await Helpers.login(page2, browser, Helpers.user2);
-        await expect(page2.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user2.fullName);
+        const page2 = await Helpers.getPageAsUser(browser, Helpers.user2);
 
         // navigate to /account page
-        await page2.goto(Helpers.UI_BASE + '/account');
+        await page2.goto('/account');
 
         // request control over the new version
         const publicationRow = page2.getByTestId(publicationTestId);
@@ -2466,37 +1777,27 @@ test.describe('Publication flow + co-authors', () => {
         // );
 
         // transfer ownership to user2
-        await approveControlRequest(context, Helpers.user1, Helpers.user2.fullName, true);
+        await approveControlRequest(browser, Helpers.user1, Helpers.user2.fullName, true);
 
         // check that old corresponding author doesn't have permissions to edit the DRAFT anymore
         await page.reload();
         await page.waitForLoadState('networkidle');
         await expect(page.getByText('This publication is currently being edited.')).toBeVisible();
 
-        // login with user2 and check they can edit the new version
-        const page3 = await browser.newPage();
-        await page3.goto(Helpers.UI_BASE);
-        await Helpers.login(page3, browser, Helpers.user2);
-        await expect(page3.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user2.fullName);
-
-        await page3.goto(Helpers.UI_BASE + `/publications/${publicationId}/versions/latest`);
-        await page3.waitForLoadState('networkidle');
-        await expect(page3.locator(PageModel.publish.draftEditButton)).toBeVisible();
-        await page3.locator(PageModel.publish.draftEditButton).click();
-        await page3.waitForURL('**/edit?**');
-        await page3.waitForLoadState('networkidle');
-        await expect(page3.locator('aside button:has-text("Key information")').first()).toBeVisible();
+        // check that user2 can edit the new version
+        await page2.goto(`/publications/${publicationId}/versions/latest`);
+        await page2.waitForLoadState('networkidle');
+        await expect(page2.locator(PageModel.publish.draftEditButton)).toBeVisible();
+        await page2.locator(PageModel.publish.draftEditButton).click();
+        await page2.waitForURL('**/edit?**');
+        await page2.waitForLoadState('networkidle');
+        await expect(page2.locator('aside button:has-text("Key information")').first()).toBeVisible();
     });
 
     test('Authors can create/edit and request control over new version from "Versions" dropdown', async ({
         browser
     }) => {
-        const context = await browser.newContext();
-        const page = await context.newPage();
-
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
+        const page = await Helpers.getPageAsUser(browser);
 
         // create v1
         await createPublication(page, problemPublication2.title, 'PROBLEM');
@@ -2515,8 +1816,7 @@ test.describe('Publication flow + co-authors', () => {
         await addCoAuthor(page, Helpers.user2);
 
         // request approvals for v1
-        await page.locator(PageModel.publish.requestApprovalButton).click();
-        await page.locator(PageModel.publish.confirmRequestApproval).click();
+        await requestApproval(page);
         await page.locator(`h1:has-text("${problemPublication2.title}")`).first().waitFor({ state: 'visible' });
         await page.locator(`h1:has-text("${problemPublication2.title}")`).waitFor(); // wait for redirect
 
@@ -2533,11 +1833,7 @@ test.describe('Publication flow + co-authors', () => {
         const publicationUrl = page.url();
 
         // login as co-author
-        const context2 = await browser.newContext();
-        const page2 = await context2.newPage();
-        await page2.goto(Helpers.UI_BASE);
-        await Helpers.login(page2, browser, Helpers.user2);
-        await expect(page2.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user2.fullName);
+        const page2 = await Helpers.getPageAsUser(browser, Helpers.user2);
         await page2.goto(publicationUrl);
         await page2.locator('aside button[title="Versions"]').waitFor();
 
@@ -2579,9 +1875,7 @@ test.describe('Publication Flow + File import', () => {
     let page: Page;
 
     test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
+        page = await Helpers.getPageAsUser(browser);
     });
 
     test.afterAll(async () => {
@@ -2589,7 +1883,6 @@ test.describe('Publication Flow + File import', () => {
     });
 
     test('Create PROBLEM publication where text is filled from document import', async () => {
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(Helpers.user1.fullName);
         await createPublication(page, 'test publication - file import', 'PROBLEM');
         await completeKeyInformationTab(page);
         await completeAffiliationsTab(page, false);

--- a/e2e/tests/LoggedIn/revokeOrcidAccess.spec.ts
+++ b/e2e/tests/LoggedIn/revokeOrcidAccess.spec.ts
@@ -7,7 +7,7 @@ test.describe.configure({ mode: 'serial' });
 test.describe('Revoke ORCID access', () => {
     test('Can revoke access from ORCID', async ({ browser }) => {
         const page = await browser.newPage();
-        await page.goto(Helpers.UI_BASE);
+        await page.goto('/');
 
         // login into Octopus - this process will log the user into ORCID as well
         await Helpers.login(page, browser, Helpers.user4);
@@ -50,7 +50,7 @@ test.describe('Revoke ORCID access', () => {
         await expect(trustedOrganizationsRow).not.toBeVisible();
 
         // navigate back to Octopus
-        await page.goto(Helpers.UI_BASE);
+        await page.goto('/');
 
         // user should be logged out and the login button should be visible
         await page.waitForLoadState('networkidle');
@@ -61,7 +61,7 @@ test.describe('Revoke ORCID access', () => {
 
     test('Can revoke ORCID access from Octopus', async ({ browser }) => {
         const page = await browser.newPage();
-        await page.goto(Helpers.UI_BASE);
+        await page.goto('/');
         await Helpers.login(page, browser, Helpers.user4);
         await expect(page.locator(PageModel.header.usernameButton)).toHaveText(`${Helpers.user4.fullName}`);
 

--- a/e2e/tests/LoggedIn/search.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/search.e2e.spec.ts
@@ -5,12 +5,8 @@ import { PageModel } from '../PageModel';
 test.describe('Search', () => {
     test('Full publication title search', async ({ browser }) => {
         // Start up test
-        const page = await browser.newPage();
-
-        // Login
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(`${Helpers.user1.fullName}`);
+        const page = await Helpers.getPageAsUser(browser);
+        await page.goto('/');
 
         // search and check result
         await Helpers.search(page, 'How has life on earth evolved?', PageModel.search.publicationSearchResult);
@@ -25,7 +21,7 @@ test.describe('Search term is persisted in URL query string', () => {
     test('Partial search term search', async ({ browser }) => {
         // Start up test
         const page = await browser.newPage();
-        await page.goto(Helpers.UI_BASE);
+        await page.goto('/');
 
         // search and expect URL query string to contain search text
         await Helpers.search(page, PageModel.search.searchTerm);
@@ -43,7 +39,7 @@ test.describe('dateTo and dateFrom fields are persisted in URL query string', ()
     test('dateTo and dateFrom in query string', async ({ browser }) => {
         // Start up test
         const page = await browser.newPage();
-        await page.goto(Helpers.UI_BASE);
+        await page.goto('/');
         await page.locator(PageModel.header.searchButton).click();
 
         //select dateFrom & dateTo

--- a/e2e/tests/LoggedIn/topic.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/topic.e2e.spec.ts
@@ -7,7 +7,7 @@ test.describe.configure({ mode: 'serial' });
 // Recreate parameter controls the behaviour when a bookmark already exists.
 // If true, it will remove and recreate it; if false, it will leave it.
 const ensureBookmarkPresent = async (page: Page, recreate: boolean = false) => {
-    await page.goto(`${Helpers.UI_BASE}/topics/test-topic-1b-1`, {
+    await page.goto(`/topics/test-topic-1b-1`, {
         waitUntil: 'domcontentloaded'
     });
 
@@ -31,13 +31,7 @@ const ensureBookmarkPresent = async (page: Page, recreate: boolean = false) => {
 
 test.describe('Topic page', () => {
     test('Bookmark a topic', async ({ browser }) => {
-        // Start up test
-        const page = await browser.newPage();
-
-        // Login
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(`${Helpers.user1.fullName}`);
+        const page = await Helpers.getPageAsUser(browser);
 
         // Add bookmark
         await ensureBookmarkPresent(page, true);
@@ -51,13 +45,7 @@ test.describe('Topic page', () => {
     });
 
     test('Remove a topic bookmark from topic page', async ({ browser }) => {
-        // Start up test
-        const page = await browser.newPage();
-
-        // Login
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(`${Helpers.user1.fullName}`);
+        const page = await Helpers.getPageAsUser(browser);
 
         await ensureBookmarkPresent(page);
 
@@ -73,13 +61,7 @@ test.describe('Topic page', () => {
     });
 
     test('Remove a topic bookmark from My Bookmarks page', async ({ browser }) => {
-        // Start up test
-        const page = await browser.newPage();
-
-        // Login
-        await page.goto(Helpers.UI_BASE);
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(`${Helpers.user1.fullName}`);
+        const page = await Helpers.getPageAsUser(browser);
 
         await ensureBookmarkPresent(page);
 

--- a/e2e/tests/LoggedIn/z_account.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/z_account.e2e.spec.ts
@@ -7,21 +7,11 @@ import { PageModel } from '../PageModel';
  */
 
 test.describe('My account page', () => {
-    let context: BrowserContext;
     let page: Page;
 
     test.beforeAll(async ({ browser }) => {
-        context = await browser.newContext();
-        page = await context.newPage();
-        // navigate to homepage
-        await page.goto(Helpers.UI_BASE, { waitUntil: 'domcontentloaded' });
-
-        // login
-        await Helpers.login(page, browser);
-        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(`${Helpers.user1.fullName}`);
-
-        // go to '/account' page
-        await page.goto(`${Helpers.UI_BASE}/account`);
+        page = await Helpers.getPageAsUser(browser);
+        await page.goto(`/account`);
     });
 
     test.afterAll(async () => {

--- a/e2e/tests/LoggedOut/blog.e2e.spec.ts
+++ b/e2e/tests/LoggedOut/blog.e2e.spec.ts
@@ -31,7 +31,7 @@ test.describe('Blog', () => {
 
     test('Blogs are paginated', async () => {
         // Navigate to blog page
-        await page.goto(`${Helpers.UI_BASE}/blog`);
+        await page.goto(`/blog`);
 
         // check page title and description
         await expect(page.locator(PageModel.blog.pageTitle)).toBeVisible();

--- a/e2e/tests/LoggedOut/browse.e2e.spec.ts
+++ b/e2e/tests/LoggedOut/browse.e2e.spec.ts
@@ -1,30 +1,22 @@
-import { expect, test } from "@playwright/test";
-import * as Helpers from "../helpers";
-import { PageModel } from "../PageModel";
+import { expect, test } from '@playwright/test';
+import { PageModel } from '../PageModel';
 
-test.describe("Browse", () => {
-  test("Browse contents", async ({ browser }) => {
-    // Start up test
-    const page = await browser.newPage();
-    await page.goto(Helpers.UI_BASE);
-    // Navigate to browse page
-    await page.locator(PageModel.header.browseButton).click();
+test.describe('Browse', () => {
+    test('Browse contents', async ({ browser }) => {
+        // Start up test
+        const page = await browser.newPage();
+        await page.goto('/');
+        // Navigate to browse page
+        await page.locator(PageModel.header.browseButton).click();
 
-    // Check links
-    await expect(
-      page.locator(PageModel.browse.viewAllPublications)
-    ).toHaveAttribute(
-      "href",
-      "/search/publications?type=PROBLEM,HYPOTHESIS,PROTOCOL,DATA,ANALYSIS,INTERPRETATION,REAL_WORLD_APPLICATION,PEER_REVIEW"
-    );
-    await expect(page.locator(PageModel.browse.viewAllAuthors)).toHaveAttribute(
-      "href",
-      "/search/authors"
-    );
+        // Check links
+        await expect(page.locator(PageModel.browse.viewAllPublications)).toHaveAttribute(
+            'href',
+            '/search/publications?type=PROBLEM,HYPOTHESIS,PROTOCOL,DATA,ANALYSIS,INTERPRETATION,REAL_WORLD_APPLICATION,PEER_REVIEW'
+        );
+        await expect(page.locator(PageModel.browse.viewAllAuthors)).toHaveAttribute('href', '/search/authors');
 
-    // Expect 5 cards
-    await expect(
-      page.locator(PageModel.browse.card).locator("visible=true")
-    ).toHaveCount(5);
-  });
+        // Expect 5 cards
+        await expect(page.locator(PageModel.browse.card).locator('visible=true')).toHaveCount(5);
+    });
 });

--- a/e2e/tests/LoggedOut/inaccessiblePages.e2e.spec.ts
+++ b/e2e/tests/LoggedOut/inaccessiblePages.e2e.spec.ts
@@ -8,20 +8,20 @@ test.describe('Checking inaccessible pages', () => {
         const page = await browser.newPage();
 
         // Check publish create page
-        await page.goto(`${Helpers.UI_BASE}/create`, { waitUntil: 'domcontentloaded' });
+        await page.goto(`/create`, { waitUntil: 'domcontentloaded' });
         await page.waitForLoadState();
         await expect(page.locator(PageModel.login.signInButton)).toBeVisible();
 
         // Check account page
         await page.goBack();
-        await page.goto(`${Helpers.UI_BASE}/account`, { waitUntil: 'domcontentloaded' });
+        await page.goto(`/account`, { waitUntil: 'domcontentloaded' });
 
         await page.waitForLoadState();
         await expect(page.locator(PageModel.login.signInButton)).toBeVisible();
 
         // Check my bookmarks page
         await page.goBack();
-        await page.goto(`${Helpers.UI_BASE}/my-bookmarks`, { waitUntil: 'domcontentloaded' });
+        await page.goto(`/my-bookmarks`, { waitUntil: 'domcontentloaded' });
         await page.waitForLoadState();
         await expect(page.locator(PageModel.login.signInButton)).toBeVisible();
     });

--- a/e2e/tests/LoggedOut/livePublication.e2e.spec.ts
+++ b/e2e/tests/LoggedOut/livePublication.e2e.spec.ts
@@ -1,100 +1,69 @@
-import { expect, test } from "@playwright/test";
-import * as Helpers from "../helpers";
-import { PageModel } from "../PageModel";
+import { expect, test } from '@playwright/test';
+import * as Helpers from '../helpers';
+import { PageModel } from '../PageModel';
 
-test.describe("Live Publication", () => {
-  test("Live publication contents", async ({ browser }) => {
-    // Start up test
-    const page = await browser.newPage();
-    await page.goto(Helpers.UI_BASE);
+test.describe('Live Publication', () => {
+    test('Live publication contents', async ({ browser }) => {
+        // Start up test
+        const page = await browser.newPage();
+        await page.goto('/');
 
-    // Navigate to search page
-    await page.locator(PageModel.header.searchButton).click();
-    await page.locator(PageModel.search.searchInput).click();
+        // Navigate to search page
+        await page.locator(PageModel.header.searchButton).click();
+        await page.locator(PageModel.search.searchInput).click();
 
-    // Type in search term
-    await page.keyboard.type("How has life on earth evolved?");
-    await page.keyboard.press("Enter");
-    await expect(page.locator("h1")).toHaveText(
-      "Search results for How has life on earth evolved?"
-    );
-    await expect(
-      page.locator(PageModel.search.publicationSearchResult)
-    ).toBeVisible();
+        // Type in search term
+        await page.keyboard.type('How has life on earth evolved?');
+        await page.keyboard.press('Enter');
+        await expect(page.locator('h1')).toHaveText('Search results for How has life on earth evolved?');
+        await expect(page.locator(PageModel.search.publicationSearchResult)).toBeVisible();
 
-    // Click on search result
-    await page.locator(PageModel.search.publicationSearchResult).click();
-    await expect(page.locator("h1")).toHaveText(
-      "How has life on earth evolved?"
-    );
+        // Click on search result
+        await page.locator(PageModel.search.publicationSearchResult).click();
+        await expect(page.locator('h1')).toHaveText('How has life on earth evolved?');
 
-    // Check sections
-    await Helpers.checkLivePublicationLayout(page, "cl3fz14dr0001es6i5ji51rq4");
+        // Check sections
+        await Helpers.checkLivePublicationLayout(page, 'cl3fz14dr0001es6i5ji51rq4');
 
-    // Check sign in for more button and that bookmark, flag link, review link are not visible
-    await expect(
-      page
-        .locator(PageModel.livePublication.signInForMoreButton)
-        .locator("visible=true")
-    ).toBeVisible();
-    await expect(
-      page.locator(PageModel.livePublication.addBookmark)
-    ).not.toBeVisible();
-    await expect(
-      page.locator(PageModel.livePublication.flagConcern)
-    ).not.toBeVisible();
-    await expect(
-      page.locator(PageModel.livePublication.writeReview)
-    ).not.toBeVisible();
+        // Check sign in for more button and that bookmark, flag link, review link are not visible
+        await expect(page.locator(PageModel.livePublication.signInForMoreButton).locator('visible=true')).toBeVisible();
+        await expect(page.locator(PageModel.livePublication.addBookmark)).not.toBeVisible();
+        await expect(page.locator(PageModel.livePublication.flagConcern)).not.toBeVisible();
+        await expect(page.locator(PageModel.livePublication.writeReview)).not.toBeVisible();
 
-    // Check author link
-    await expect(
-      page.locator(PageModel.livePublication.authorLink)
-    ).toBeVisible();
-  });
+        // Check author link
+        await expect(page.locator(PageModel.livePublication.authorLink)).toBeVisible();
+    });
 
-  test.skip("Unverified email: live publication page", async ({ browser }) => {
-    // TODO unskip when we have an account that hasn't verified their email address
+    test.skip('Unverified email: live publication page', async ({ browser }) => {
+        // TODO unskip when we have an account that hasn't verified their email address
 
-    // Start up test
-    const page = await browser.newPage();
+        // Start up test
+        const page = await browser.newPage();
 
-    // Navigate to search page
-    await page.goto(Helpers.UI_BASE);
-    await Helpers.login(page, browser);
-    await expect(page.locator(PageModel.header.usernameButton)).toHaveText(
-      `${Helpers.user1.fullName}`
-    );
+        // Navigate to search page
+        await page.goto('/');
+        // Uncomment and move this test if it gets worked on - it shouldn't be in LoggedOut directory if it logs in.
+        // await Helpers.login(page, browser);
+        await expect(page.locator(PageModel.header.usernameButton)).toHaveText(`${Helpers.user1.fullName}`);
 
-    await page.locator(PageModel.header.searchButton).click();
-    await page.locator(PageModel.search.searchInput).click();
+        await page.locator(PageModel.header.searchButton).click();
+        await page.locator(PageModel.search.searchInput).click();
 
-    // Type in search term
-    await page.keyboard.type("How has life on earth evolved?");
-    await page.keyboard.press("Enter");
-    await expect(page.locator("h1")).toHaveText(
-      "Search results for How has life on earth evolved?"
-    );
-    await expect(
-      page.locator(PageModel.search.publicationSearchResult)
-    ).toBeVisible();
+        // Type in search term
+        await page.keyboard.type('How has life on earth evolved?');
+        await page.keyboard.press('Enter');
+        await expect(page.locator('h1')).toHaveText('Search results for How has life on earth evolved?');
+        await expect(page.locator(PageModel.search.publicationSearchResult)).toBeVisible();
 
-    // Click on search result
-    await page.locator(PageModel.search.publicationSearchResult).click();
-    await expect(page.locator("h1")).toHaveText(
-      "How has life on earth evolved?"
-    );
-    await expect(
-      page
-        .locator(PageModel.livePublication.verifyEmailForMoreButton)
-        .locator("visible=true")
-    ).toBeVisible();
-    // await expect(page.locator(PageModel.livePublication.addBookmark)).not.toBeVisible(); TODO uncomment this when this is fixed!
-    await expect(
-      page.locator(PageModel.livePublication.flagConcern)
-    ).not.toBeVisible();
-    await expect(
-      page.locator(PageModel.livePublication.writeReview)
-    ).not.toBeVisible();
-  });
+        // Click on search result
+        await page.locator(PageModel.search.publicationSearchResult).click();
+        await expect(page.locator('h1')).toHaveText('How has life on earth evolved?');
+        await expect(
+            page.locator(PageModel.livePublication.verifyEmailForMoreButton).locator('visible=true')
+        ).toBeVisible();
+        // await expect(page.locator(PageModel.livePublication.addBookmark)).not.toBeVisible(); TODO uncomment this when this is fixed!
+        await expect(page.locator(PageModel.livePublication.flagConcern)).not.toBeVisible();
+        await expect(page.locator(PageModel.livePublication.writeReview)).not.toBeVisible();
+    });
 });

--- a/e2e/tests/LoggedOut/profile.e2e.spec.ts
+++ b/e2e/tests/LoggedOut/profile.e2e.spec.ts
@@ -8,7 +8,7 @@ test.describe('Science Octopus profile', () => {
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
         // navigate to Science Octopus profile page
-        await page.goto(`${Helpers.UI_BASE}/authors/octopus`, {
+        await page.goto(`/authors/octopus`, {
             waitUntil: 'domcontentloaded'
         });
         await expect(page).toHaveTitle('Author: XXXX-XXXX-XXXX-XXXX - Octopus | Built for Researchers');

--- a/e2e/tests/LoggedOut/search.e2e.spec.ts
+++ b/e2e/tests/LoggedOut/search.e2e.spec.ts
@@ -6,7 +6,7 @@ test.describe('Publication search', () => {
     test('Full publication title search', async ({ browser }) => {
         // Start up test
         const page = await browser.newPage();
-        await page.goto(Helpers.UI_BASE);
+        await page.goto('/');
 
         // search and check result
         await Helpers.search(page, 'How has life on earth evolved?', PageModel.search.publicationSearchResult);
@@ -19,7 +19,7 @@ test.describe('Publication search', () => {
     test('Partial publication title search', async ({ browser }) => {
         // Start up test
         const page = await browser.newPage();
-        await page.goto(Helpers.UI_BASE);
+        await page.goto('/');
 
         // search and check result
         await Helpers.search(page, 'life evolved', PageModel.search.publicationSearchResult);
@@ -32,7 +32,7 @@ test.describe('Publication search', () => {
     test('No results search checking error', async ({ browser }) => {
         // Start up test
         const page = await browser.newPage();
-        await page.goto(Helpers.UI_BASE);
+        await page.goto('/');
 
         // search and check error
         await Helpers.search(page, 'thisShouldProduceNoResults', PageModel.search.noPublicationsFound);
@@ -42,7 +42,7 @@ test.describe('Publication search', () => {
         // test TODO
         // Start up test
         const page = await browser.newPage();
-        await page.goto(Helpers.UI_BASE);
+        await page.goto('/');
 
         // Navigate to search page
         await page.locator(PageModel.header.searchButton).click();
@@ -62,7 +62,7 @@ test.describe('Topics search', () => {
         const context = await browser.newContext();
         const page = await context.newPage();
 
-        await page.goto(`${Helpers.UI_BASE}/search/topics`);
+        await page.goto(`/search/topics`);
         await page.waitForResponse((response) => response.url().includes('/topics') && response.ok());
         await expect(page.locator('#pagination-info')).toContainText(/Showing \d+ - \d+ of \d+/);
         await expect(page.getByText('Previous')).toBeVisible();
@@ -74,7 +74,7 @@ test.describe('Topics search', () => {
     test('Can search for topics using the quick search input field', async ({ browser }) => {
         const context = await browser.newContext();
         const page = await context.newPage();
-        await page.goto(`${Helpers.UI_BASE}/search/topics`);
+        await page.goto(`/search/topics`);
 
         await search(page, 'no-results');
 
@@ -96,7 +96,7 @@ test.describe('Topics search', () => {
         const page = await context.newPage();
         const searchTerm = 'test';
 
-        await page.goto(`${Helpers.UI_BASE}/search/topics?query=${searchTerm}`);
+        await page.goto(`/search/topics?query=${searchTerm}`);
         await page.waitForResponse((response) => response.url().includes('/topics') && response.ok());
 
         // quick search input value should equal 'test'

--- a/e2e/tests/LoggedOut/staticPages.e2e.spec.ts
+++ b/e2e/tests/LoggedOut/staticPages.e2e.spec.ts
@@ -6,7 +6,7 @@ test.describe('Static pages, logged out', () => {
     test('Check homepage', async ({ browser }) => {
         // Start up test
         const page = await browser.newPage();
-        await page.goto(Helpers.UI_BASE);
+        await page.goto('/');
 
         // Expect elements to be visible
         await expect(page.locator('h1').first()).toHaveText(
@@ -34,7 +34,7 @@ test.describe('Static pages, logged out', () => {
     test('Check about page', async ({ browser }) => {
         // Start up test
         const page = await browser.newPage();
-        await page.goto(Helpers.UI_BASE);
+        await page.goto('/');
         await page.locator(PageModel.footer.links[2]).click();
 
         // Expects h1 and links (faq, author guide, aims)
@@ -77,21 +77,21 @@ test.describe('Static pages, logged out', () => {
     test('Check static pages in the footer', async ({ browser }) => {
         // Start up test
         const page = await browser.newPage();
-        await page.goto(Helpers.UI_BASE);
+        await page.goto('/');
 
         // Check terms
         await page.locator(PageModel.footer.links[5]).click();
-        await expect(page).toHaveURL(`${Helpers.UI_BASE}/user-terms`);
+        await expect(page).toHaveURL(`/user-terms`);
         await page.goBack();
 
         // Check privacy
         await page.locator(PageModel.footer.links[6]).click();
-        await expect(page).toHaveURL(`${Helpers.UI_BASE}/privacy`);
+        await expect(page).toHaveURL(`/privacy`);
         await page.goBack();
 
         // Check accessibility
         await page.locator(PageModel.footer.links[7]).click();
-        await expect(page).toHaveURL(`${Helpers.UI_BASE}/accessibility`);
+        await expect(page).toHaveURL(`/accessibility`);
         await page.goBack();
     });
 });

--- a/e2e/tests/setup/login.setup.ts
+++ b/e2e/tests/setup/login.setup.ts
@@ -1,0 +1,22 @@
+import { existsSync } from 'fs';
+import { test as setup } from '@playwright/test';
+import * as Helpers from '../helpers';
+
+/**
+ * For each test user defined in our helpers, log in and save the storage state to a file that can be reused
+ * by tests that need a page logged in as one of these users.
+ */
+setup('Log in users', async ({ browser }) => {
+    await Promise.all(
+        Helpers.users.map(async (user, idx) => {
+            const storageStatePath = `${Helpers.STORAGE_STATE_BASE}user${idx}.json`;
+            if (!existsSync(storageStatePath)) {
+                const page = await browser.newPage();
+                await Helpers.login(page, browser, user);
+                // Minimise feedback popup
+                await page.getByLabel('Open Close icon').click();
+                await page.context().storageState({ path: storageStatePath });
+            }
+        })
+    );
+});


### PR DESCRIPTION
The purpose of this PR was to speed up our tests by providing a storage file where the tests are being run that individual tests can read and use to authenticate their requests, removing the need to carry out the full log in process in each test that requires being logged in.

Although this PR will show a lot of changes there are basically only a few things being changed, but they affected the tests in lots of places.
- Instead of logging in, tests now use the new getPageAsUser helper.
- A baseUrl has been defined, so we no longer have to use a constant defined in helpers for the base URL. We can use relative paths for navigation instead.
- In publish.e2e.spec.ts, new functions have been made to standardise repeated behaviour and cut code duplication:
    - requestApproval
    - createPublishReadyPublication
    - addCoAuthorsAndRequestApproval
- Removed 'Co Authors appear properly in the Approvals Tracker' test because the only thing it was doing was checking presence of locators that we can check in 'Create a PROBLEM publication with co-authors', which has an identical setup.
- Other than this there are some minor additions to reduce flakiness and cosmetic changes from saving files with prettier.

---

### Acceptance Criteria:

- The end to end tests have a setup script that runs beforehand and logs in each test user
- The tests can use the output of this setup script to skip logging in each time

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [x] Documentation updated

---

### Tests:

E2E:
<img width="146" alt="Screenshot 2024-02-19 161401" src="https://github.com/JiscSD/octopus/assets/132363734/73243fdc-d8ca-4be9-8b59-1f59a1f414b0">