### PR TITLE
OC-821: Fix puppeteer dependency vulnerability

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -5762,15 +5762,87 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
-            "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
+            "version": "7.23.5",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+            "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
             "dev": true,
             "dependencies": {
-                "@babel/highlight": "^7.22.5"
+                "@babel/highlight": "^7.23.4",
+                "chalk": "^2.4.2"
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/code-frame/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@babel/code-frame/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "dev": true,
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@babel/code-frame/node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dev": true,
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/@babel/code-frame/node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "dev": true
+        },
+        "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/@babel/code-frame/node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/@babel/code-frame/node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/@babel/compat-data": {
@@ -5831,21 +5903,21 @@
             }
         },
         "node_modules/@babel/core/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.5.tgz",
-            "integrity": "sha512-+lcUbnTRhd0jOewtFSedLyiPsD5tswKkbgcezOqqWFUVNEwoUTlpPOBmvhG7OXWLR4jMdv0czPGH5XbflnD1EA==",
+            "version": "7.23.6",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+            "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.22.5",
+                "@babel/types": "^7.23.6",
                 "@jridgewell/gen-mapping": "^0.3.2",
                 "@jridgewell/trace-mapping": "^0.3.17",
                 "jsesc": "^2.5.1"
@@ -5883,9 +5955,9 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -5898,22 +5970,22 @@
             "dev": true
         },
         "node_modules/@babel/helper-environment-visitor": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.5.tgz",
-            "integrity": "sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==",
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+            "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-function-name": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-            "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+            "version": "7.23.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+            "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
             "dev": true,
             "dependencies": {
-                "@babel/template": "^7.22.5",
-                "@babel/types": "^7.22.5"
+                "@babel/template": "^7.22.15",
+                "@babel/types": "^7.23.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -5984,9 +6056,9 @@
             }
         },
         "node_modules/@babel/helper-split-export-declaration": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.5.tgz",
-            "integrity": "sha512-thqK5QFghPKWLhAV321lxF95yCg2K3Ob5yw+M3VHWfdia0IkPXUtoLH8x/6Fh486QUvzhb8YOWHChTVen2/PoQ==",
+            "version": "7.22.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+            "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
             "dev": true,
             "dependencies": {
                 "@babel/types": "^7.22.5"
@@ -5996,18 +6068,18 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-            "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+            "version": "7.23.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+            "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
-            "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
+            "version": "7.22.20",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+            "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -6037,13 +6109,13 @@
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
-            "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
+            "version": "7.23.4",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+            "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.22.5",
-                "chalk": "^2.0.0",
+                "@babel/helper-validator-identifier": "^7.22.20",
+                "chalk": "^2.4.2",
                 "js-tokens": "^4.0.0"
             },
             "engines": {
@@ -6122,9 +6194,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.5.tgz",
-            "integrity": "sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q==",
+            "version": "7.23.9",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.9.tgz",
+            "integrity": "sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==",
             "dev": true,
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -6311,34 +6383,34 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.5.tgz",
-            "integrity": "sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==",
+            "version": "7.23.9",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.23.9.tgz",
+            "integrity": "sha512-+xrD2BWLpvHKNmX2QbpdpsBaWnRxahMwJjO+KZk2JOElj5nSmKezyS1B4u+QbHMTX69t4ukm6hh9lsYQ7GHCKA==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.22.5",
-                "@babel/parser": "^7.22.5",
-                "@babel/types": "^7.22.5"
+                "@babel/code-frame": "^7.23.5",
+                "@babel/parser": "^7.23.9",
+                "@babel/types": "^7.23.9"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.5.tgz",
-            "integrity": "sha512-7DuIjPgERaNo6r+PZwItpjCZEa5vyw4eJGufeLxrPdBXBoLcCJCIasvK6pK/9DVNrLZTLFhUGqaC6X/PA007TQ==",
+            "version": "7.23.9",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.9.tgz",
+            "integrity": "sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.22.5",
-                "@babel/generator": "^7.22.5",
-                "@babel/helper-environment-visitor": "^7.22.5",
-                "@babel/helper-function-name": "^7.22.5",
+                "@babel/code-frame": "^7.23.5",
+                "@babel/generator": "^7.23.6",
+                "@babel/helper-environment-visitor": "^7.22.20",
+                "@babel/helper-function-name": "^7.23.0",
                 "@babel/helper-hoist-variables": "^7.22.5",
-                "@babel/helper-split-export-declaration": "^7.22.5",
-                "@babel/parser": "^7.22.5",
-                "@babel/types": "^7.22.5",
-                "debug": "^4.1.0",
+                "@babel/helper-split-export-declaration": "^7.22.6",
+                "@babel/parser": "^7.23.9",
+                "@babel/types": "^7.23.9",
+                "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
             "engines": {
@@ -6355,13 +6427,13 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.22.5",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.5.tgz",
-            "integrity": "sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==",
+            "version": "7.23.9",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.9.tgz",
+            "integrity": "sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-string-parser": "^7.22.5",
-                "@babel/helper-validator-identifier": "^7.22.5",
+                "@babel/helper-string-parser": "^7.23.4",
+                "@babel/helper-validator-identifier": "^7.22.20",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -7686,15 +7758,15 @@
             }
         },
         "node_modules/@serverless/platform-client": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-4.3.2.tgz",
-            "integrity": "sha512-DAa5Z0JAZc6UfrTZLYwqoZxgAponZpFwaqd7WzzMA+loMCkYWyJNwxrAmV6cr2UUJpkko4toPZuJ3vM9Ie+NDA==",
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/@serverless/platform-client/-/platform-client-4.5.1.tgz",
+            "integrity": "sha512-XltmO/029X76zi0LUFmhsnanhE2wnqH1xf+WBt5K8gumQA9LnrfwLgPxj+VA+mm6wQhy+PCp7H5SS0ZPu7F2Cw==",
             "dev": true,
             "peer": true,
             "dependencies": {
                 "adm-zip": "^0.5.5",
                 "archiver": "^5.3.0",
-                "axios": "^0.21.1",
+                "axios": "^1.6.2",
                 "fast-glob": "^3.2.7",
                 "https-proxy-agent": "^5.0.0",
                 "ignore": "^5.1.8",
@@ -7710,16 +7782,6 @@
             },
             "engines": {
                 "node": ">=10.0"
-            }
-        },
-        "node_modules/@serverless/platform-client/node_modules/axios": {
-            "version": "0.21.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-            "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "follow-redirects": "^1.14.0"
             }
         },
         "node_modules/@serverless/platform-client/node_modules/jwt-decode": {
@@ -12610,9 +12672,9 @@
             }
         },
         "node_modules/eslint-config-airbnb-base/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -14222,9 +14284,9 @@
             }
         },
         "node_modules/ip": {
-            "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.8.tgz",
-            "integrity": "sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg=="
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
+            "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
         },
         "node_modules/is-arguments": {
             "version": "1.1.1",
@@ -14665,9 +14727,9 @@
             }
         },
         "node_modules/istanbul-lib-instrument/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver.js"
@@ -17280,12 +17342,11 @@
             }
         },
         "node_modules/pac-resolver": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.0.tgz",
-            "integrity": "sha512-Fd9lT9vJbHYRACT8OhCbZBbxr6KRSawSovFpy8nDGshaK99S/EBhVIHp9+crhxrsZOuvLpgL1n23iyPg6Rl2hg==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+            "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
             "dependencies": {
                 "degenerator": "^5.0.0",
-                "ip": "^1.1.8",
                 "netmask": "^2.0.2"
             },
             "engines": {
@@ -18406,9 +18467,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+            "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
             "dev": true,
             "bin": {
                 "semver": "bin/semver"
@@ -19637,11 +19698,6 @@
                 "node": ">= 14"
             }
         },
-        "node_modules/socks/node_modules/ip": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-            "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
-        },
         "node_modules/sort-keys": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -20495,9 +20551,9 @@
             }
         },
         "node_modules/ts-loader/node_modules/semver": {
-            "version": "7.3.5",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+            "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"


### PR DESCRIPTION
The purpose of this PR was to address a vulnerability with the ip package flagged by Snyk: https://security.snyk.io/vuln/SNYK-JS-IP-6240864

In order to fix it I had to run npm audit fix as suggested here: https://github.com/puppeteer/puppeteer/issues/11884. This also made some updates to other packages.

---

### Acceptance Criteria:

We no longer use the ip package at a vulnerable version (1.1.8 or before)

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

API
<img width="138" alt="Screenshot 2024-02-20 100025" src="https://github.com/JiscSD/octopus/assets/132363734/360651b4-47b1-4a67-9741-12b8dd51b60d">

E2E
<img width="102" alt="Screenshot 2024-02-20 095303" src="https://github.com/JiscSD/octopus/assets/132363734/67cbce0a-b7de-4d21-9c6a-ae55e27d39ce">
