### PR TITLE
OC-786: Use newer versions of github actions

### DIFF
--- a/.github/workflows/api-build.yml
+++ b/.github/workflows/api-build.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node 18.x Environment
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: "18.x"
 
@@ -27,10 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node 18.x Environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "18.x"
 
@@ -47,10 +47,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node 18.x Environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "18.x"
 

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Note: this step is only required locally when using act since the ubuntu image
       # does not come with docker-compose installed, however the alternative to the reinstall

--- a/.github/workflows/ui-tasks.yml
+++ b/.github/workflows/ui-tasks.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node 18.x Environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "18.x"
 
@@ -37,10 +37,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node 18.x Environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "18.x"
 
@@ -57,10 +57,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node 18.x Environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "18.x"
 
@@ -81,10 +81,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node 18.x Environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "18.x"
 
@@ -101,10 +101,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node 18.x Environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "18.x"
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A new way to publish your scientific work that's fast, free and fair.
 
 To run this application locally you will need:
 
-- [Node v14 (v14.18.1 or greater)](https://nodejs.org/en/about/releases/)
+- [Node v18](https://nodejs.org/en/about/releases/)
 - [Docker](https://www.docker.com/)
 - [Serverless Framework](https://www.serverless.com/)
 - [AWS Credentials File](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
@@ -42,13 +42,13 @@ You will need to register a client with ORCID and enter your application ID and 
 - [Registering a Public API client](https://info.orcid.org/documentation/integration-guide/registering-a-public-api-client/)
 - [ORCID documentation](https://info.orcid.org/documentation)
 
-In addition to this **only allow users who have verified their email address** can access areas of the site which require authentication (such as publishing content or accepting co-author status). The process of verification is explained below.
+In addition to this **only users who have verified their email address** can access areas of the site which require authentication (such as publishing content or accepting co-author status). The process of verification is explained below.
 
 ## Email verification
 
 Once an end user has logged in using their ORCID account, they will be prompted to verify their email address. This ensures that notifications can be successfully delivered to the recipient, as by default a user's email address in ORCID is not shared.
 
-On reaching `/verify` The flow for this is as follows:
+On reaching `/verify` the flow for this is as follows:
 
 1. User enters their email address, and requests a code be sent to them.
 2. A short 7 character code (eg. `UR10WDK`) is then emailed to the provided address.
@@ -91,13 +91,16 @@ These github-actions workflows run on every push:
 
 ### API
 
-- **API Test Suite (TODO)** The Jest test suite for the API runs and outputs any failures.
+- **API Test Suite** The Jest test suite for the API runs and outputs any failures.
 
 ### UI
 
-- **ESLint CI** The ESLint CI Github action runs and ensures the code being checked follows the eslint rules. It will fail if any errors are found.
-- **Prettier CI** The Prettier CI Github actions runs and ensures the code being checked follows the prettier formatting rules. It will fail if any errors are found.
 - **Lighthouse CI** The Lighthouse CI tool runs and if the accessibility score is lower than 95, the action errors and outputs any failures.
+
+### Both API & UI
+
+- **ESLint CI** Ensures the code being checked follows the eslint rules. It will fail if any errors are found.
+- **Prettier CI** Ensures the code being checked follows the prettier formatting rules. It will fail if any errors are found.
 
 All checks will need to pass in order for a PR to be reviewed and merged.
 
@@ -111,7 +114,7 @@ There are eight publication types:
 
 - **Research Problem** - a neatly defined scientific problem.
 - **Rationale/Hypothesis** - an original hypothesis relating to an existing published Problem or the rationale for how you think the Problem could be addressed.
-- **Methods** - a practical method of testing an existing published Rationale/Hypothesis.
+- **Method** - a practical method of testing an existing published Rationale/Hypothesis.
 - **Results** - raw data or summarised results collected according to an existing published Method (can be linked to a data repository).
 - **Analysis** - a statistical or thematic analysis of existing published Results.
 - **Interpretation** - a discussion around an existing published Analysis.
@@ -145,7 +148,7 @@ import * as OutlineIcons from '@heroicons/react/24/outline';
 ```
 
 ```
-import * as Components from '@components';
+import * as Components from '@/components';
 ```
 
 Then this will be referred to in the code as:


### PR DESCRIPTION
The purpose of this PR was to address warnings that are showing up telling us to update our github actions to stop using out of date versions of nodeJS. We should update the following wherever we use them:

- actions/checkout (to v4)
- actions/setup-node (to v4)

---

### Acceptance Criteria:

- We are using v4 of the "checkout" and "setup-node" github actions
- The warnings shown relating to this no longer appear

---

### Checklist:

- [ ] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests: N/A

---

### Screenshots:

This is the output of the API and UI tasks run just before this change (note warnings):

<img width="803" alt="Screenshot 2024-02-20 131635" src="https://github.com/JiscSD/octopus/assets/132363734/d89908b4-9d43-4008-89fc-77476f496a25">
<img width="870" alt="Screenshot 2024-02-20 131652" src="https://github.com/JiscSD/octopus/assets/132363734/4b40ec57-3c26-4a9f-8957-429462b87b9f">

And on the task run triggered by pushing this update, with no warnings:
<img width="763" alt="Screenshot 2024-02-20 131624" src="https://github.com/JiscSD/octopus/assets/132363734/2d99f90b-cb1f-4b15-a0be-2613d8833dbe">
<img width="864" alt="Screenshot 2024-02-20 131645" src="https://github.com/JiscSD/octopus/assets/132363734/f651d440-68d5-4c50-8658-4d390d78f31c">
