### PR TITLE
OC-787: Reduce RDS size on int

### DIFF
--- a/infra/create-app/int.tfvars
+++ b/infra/create-app/int.tfvars
@@ -2,7 +2,7 @@ profile = "octopus-dev"
 
 rds_allocated_storage                     = 50
 rds_max_allocated_storage                 = 100
-rds_instance                              = "db.m5.large"
+rds_instance                              = "db.t4g.medium"
 rds_db_version                            = "14.8"
 rds_backup_retention_period               = 1
 rds_monitoring_interval                   = 60


### PR DESCRIPTION
The purpose of this PR was to use a cheaper instance type for RDS on int because our resource usage is very low and we should try to keep costs down.

Note: this has already been applied.

---

### Acceptance Criteria:

Int environment's RDS is changed from db.m5.large to db.t4g.medium.

---

### Checklist:

- [ ] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

