### PR TITLE
OC-822: XSS mitigations for main text field

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -22,6 +22,7 @@
                 "cheerio": "^1.0.0-rc.12",
                 "copy-webpack-plugin": "^11.0.0",
                 "html-to-text": "^8.2.1",
+                "isomorphic-dompurify": "^2.4.0",
                 "jsonwebtoken": "^9.0.2",
                 "luxon": "^3.4.3",
                 "nodemailer": "^6.9.9",
@@ -9214,6 +9215,14 @@
             "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
             "dev": true
         },
+        "node_modules/@types/dompurify": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+            "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+            "dependencies": {
+                "@types/trusted-types": "*"
+            }
+        },
         "node_modules/@types/eslint": {
             "version": "8.40.2",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.40.2.tgz",
@@ -9418,6 +9427,11 @@
             "dependencies": {
                 "@types/superagent": "*"
             }
+        },
+        "node_modules/@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
         },
         "node_modules/@types/yargs": {
             "version": "17.0.24",
@@ -11680,6 +11694,17 @@
                 "url": "https://github.com/sponsors/fb55"
             }
         },
+        "node_modules/cssstyle": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.0.1.tgz",
+            "integrity": "sha512-8ZYiJ3A/3OkDd093CBT/0UKDWry7ak4BdPTFP2+QEP7cmhouyq/Up709ASSj2cK02BbZiMgk7kYjZNS4QP5qrQ==",
+            "dependencies": {
+                "rrweb-cssom": "^0.6.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/d": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
@@ -11703,6 +11728,49 @@
             "dev": true,
             "engines": {
                 "node": ">= 12"
+            }
+        },
+        "node_modules/data-urls": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+            "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+            "dependencies": {
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/data-urls/node_modules/tr46": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+            "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/data-urls/node_modules/webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/data-urls/node_modules/whatwg-url": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
+            "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
+            "dependencies": {
+                "tr46": "^5.0.0",
+                "webidl-conversions": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/dayjs": {
@@ -11732,6 +11800,11 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "node_modules/decimal.js": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+            "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
         },
         "node_modules/decompress": {
             "version": "4.2.1",
@@ -12205,6 +12278,11 @@
             "funding": {
                 "url": "https://github.com/fb55/domhandler?sponsor=1"
             }
+        },
+        "node_modules/dompurify": {
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.9.tgz",
+            "integrity": "sha512-uyb4NDIvQ3hRn6NiC+SIFaP4mJ/MdXlvtunaqK9Bn6dD3RuB/1S/gasEjDHD8eiaqdSael2vBv+hOs7Y+jhYOQ=="
         },
         "node_modules/domutils": {
             "version": "2.8.0",
@@ -13962,6 +14040,17 @@
                 "node": ">=14"
             }
         },
+        "node_modules/html-encoding-sniffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+            "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+            "dependencies": {
+                "whatwg-encoding": "^3.1.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/html-escaper": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -14490,6 +14579,11 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-potential-custom-element-name": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+        },
         "node_modules/is-promise": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
@@ -14628,6 +14722,19 @@
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true
+        },
+        "node_modules/isomorphic-dompurify": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-2.4.0.tgz",
+            "integrity": "sha512-OW3VSGrjppnbshcHz7RNKnoYlCJkyBBJzEE5yxrTSA+kOl9JPTIrXsnIgOuH4wdLqqRujx22bz/IXebGWPLMAg==",
+            "dependencies": {
+                "@types/dompurify": "^3.0.5",
+                "dompurify": "^3.0.9",
+                "jsdom": "^24.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/isomorphic-ws": {
             "version": "4.0.1",
@@ -15352,6 +15459,119 @@
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
+            }
+        },
+        "node_modules/jsdom": {
+            "version": "24.0.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.0.0.tgz",
+            "integrity": "sha512-UDS2NayCvmXSXVP6mpTj+73JnNQadZlr9N68189xib2tx5Mls7swlTNao26IoHv46BZJFvXygyRtyXd1feAk1A==",
+            "dependencies": {
+                "cssstyle": "^4.0.1",
+                "data-urls": "^5.0.0",
+                "decimal.js": "^10.4.3",
+                "form-data": "^4.0.0",
+                "html-encoding-sniffer": "^4.0.0",
+                "http-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.2",
+                "is-potential-custom-element-name": "^1.0.1",
+                "nwsapi": "^2.2.7",
+                "parse5": "^7.1.2",
+                "rrweb-cssom": "^0.6.0",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^4.1.3",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^7.0.0",
+                "whatwg-encoding": "^3.1.1",
+                "whatwg-mimetype": "^4.0.0",
+                "whatwg-url": "^14.0.0",
+                "ws": "^8.16.0",
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "canvas": "^2.11.2"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jsdom/node_modules/agent-base": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+            "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+            "dependencies": {
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/jsdom/node_modules/https-proxy-agent": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+            "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+            "dependencies": {
+                "agent-base": "^7.0.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/jsdom/node_modules/tr46": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+            "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/jsdom/node_modules/webidl-conversions": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+            "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/jsdom/node_modules/whatwg-url": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
+            "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
+            "dependencies": {
+                "tr46": "^5.0.0",
+                "webidl-conversions": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/jsdom/node_modules/ws": {
+            "version": "8.16.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+            "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
             }
         },
         "node_modules/jsesc": {
@@ -16891,6 +17111,11 @@
                 "url": "https://github.com/fb55/nth-check?sponsor=1"
             }
         },
+        "node_modules/nwsapi": {
+            "version": "2.2.7",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
+            "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ=="
+        },
         "node_modules/object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -17782,6 +18007,11 @@
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
             "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
+        "node_modules/psl": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+            "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+        },
         "node_modules/pstree.remy": {
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -17798,9 +18028,9 @@
             }
         },
         "node_modules/punycode": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "engines": {
                 "node": ">=6"
             }
@@ -17904,6 +18134,11 @@
             "engines": {
                 "node": ">=0.4.x"
             }
+        },
+        "node_modules/querystringify": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
@@ -18076,6 +18311,11 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/requires-port": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+        },
         "node_modules/resolve": {
             "version": "1.22.2",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
@@ -18197,6 +18437,11 @@
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
+        },
+        "node_modules/rrweb-cssom": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+            "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw=="
         },
         "node_modules/run-async": {
             "version": "2.4.1",
@@ -18322,14 +18567,24 @@
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-            "dev": true
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "node_modules/sax": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
             "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
             "dev": true
+        },
+        "node_modules/saxes": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+            "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "dependencies": {
+                "xmlchars": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=v12.22.7"
+            }
         },
         "node_modules/schema-utils": {
             "version": "3.3.0",
@@ -20074,6 +20329,11 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+        },
         "node_modules/tapable": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -20367,6 +20627,28 @@
             },
             "bin": {
                 "nodetouch": "bin/nodetouch.js"
+            }
+        },
+        "node_modules/tough-cookie": {
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+            "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+            "dependencies": {
+                "psl": "^1.1.33",
+                "punycode": "^2.1.1",
+                "universalify": "^0.2.0",
+                "url-parse": "^1.5.3"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/tough-cookie/node_modules/universalify": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+            "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+            "engines": {
+                "node": ">= 4.0.0"
             }
         },
         "node_modules/tr46": {
@@ -20876,6 +21158,15 @@
                 "querystring": "0.2.0"
             }
         },
+        "node_modules/url-parse": {
+            "version": "1.5.10",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+            "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+            "dependencies": {
+                "querystringify": "^2.1.1",
+                "requires-port": "^1.0.0"
+            }
+        },
         "node_modules/url/node_modules/punycode": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
@@ -20969,6 +21260,17 @@
             },
             "engines": {
                 "node": ">=0.8.0"
+            }
+        },
+        "node_modules/w3c-xmlserializer": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+            "dependencies": {
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/walker": {
@@ -21086,6 +21388,36 @@
                 "node": ">=0.8.x"
             }
         },
+        "node_modules/whatwg-encoding": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+            "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+            "dependencies": {
+                "iconv-lite": "0.6.3"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/whatwg-url": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -21188,6 +21520,14 @@
                 }
             }
         },
+        "node_modules/xml-name-validator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/xml2js": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
@@ -21209,6 +21549,11 @@
             "engines": {
                 "node": ">=4.0"
             }
+        },
+        "node_modules/xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
         },
         "node_modules/y18n": {
             "version": "5.0.8",

--- a/api/package.json
+++ b/api/package.json
@@ -45,6 +45,7 @@
         "cheerio": "^1.0.0-rc.12",
         "copy-webpack-plugin": "^11.0.0",
         "html-to-text": "^8.2.1",
+        "isomorphic-dompurify": "^2.4.0",
         "jsonwebtoken": "^9.0.2",
         "luxon": "^3.4.3",
         "nodemailer": "^6.9.9",

--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosResponse } from 'axios';
 import fs from 'fs';
 import * as cheerio from 'cheerio';
+import * as DOMPurify from 'isomorphic-dompurify';
 import * as I from 'interface';
 import * as referenceService from 'reference/service';
 import * as publicationService from 'publication/service';
@@ -27,13 +28,17 @@ export const isHTMLSafe = (content: string): boolean => {
 };
 
 export const getSafeHTML = (content: string): string => {
+    // Remove all classes and styles
     const $ = cheerio.load(content, null, false);
 
     $('*').map((_, element) => {
         return $(element).removeAttr('class').removeAttr('style');
     });
 
-    return $.html();
+    const htmlToBeSanitized = $.html();
+
+    // Sanitize against XSS
+    return DOMPurify.sanitize(htmlToBeSanitized);
 };
 
 export const createEmptyDOI = async (): Promise<I.DOIResponse> => {

--- a/e2e/tests/setup/login.setup.ts
+++ b/e2e/tests/setup/login.setup.ts
@@ -9,14 +9,11 @@ import * as Helpers from '../helpers';
 setup('Log in users', async ({ browser }) => {
     await Promise.all(
         Helpers.users.map(async (user, idx) => {
-            const storageStatePath = `${Helpers.STORAGE_STATE_BASE}user${idx}.json`;
-            if (!existsSync(storageStatePath)) {
-                const page = await browser.newPage();
-                await Helpers.login(page, browser, user);
-                // Minimise feedback popup
-                await page.getByLabel('Open Close icon').click();
-                await page.context().storageState({ path: storageStatePath });
-            }
+            const page = await browser.newPage();
+            await Helpers.login(page, browser, user);
+            // Minimise feedback popup
+            await page.getByLabel('Open Close icon').click();
+            await page.context().storageState({ path: `${Helpers.STORAGE_STATE_BASE}user${idx}.json` });
         })
     );
 });

--- a/ui/src/lib/cookies.ts
+++ b/ui/src/lib/cookies.ts
@@ -1,0 +1,5 @@
+import Cookies from 'js-cookie';
+
+export default Cookies.withAttributes({
+    sameSite: 'Strict'
+});

--- a/ui/src/lib/helpers.tsx
+++ b/ui/src/lib/helpers.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import axios from 'axios';
-import Cookies from 'js-cookie';
 import JWT from 'jsonwebtoken';
 
 import * as cheerio from 'cheerio';
@@ -9,6 +8,7 @@ import * as Config from '@/config';
 import * as Types from '@/types';
 import * as api from '@/api';
 import * as Interfaces from '@/interfaces';
+import Cookies from '@/cookies';
 import { Middleware } from 'swr';
 
 /**

--- a/ui/tsconfig.alias.json
+++ b/ui/tsconfig.alias.json
@@ -2,21 +2,22 @@
     "compilerOptions": {
         "baseUrl": ".",
         "paths": {
+            "@/api": ["./src/lib/api"],
+            "@/assets": ["./src/assets"],
             "@/components": ["./src/components"],
             "@/config": ["./src/config"],
-            "@/layouts": ["./src/layouts"],
-            "@/assets": ["./src/assets"],
-            "@/mocks": ["./src/__tests__/mocks"],
+            "@/contentfulClient": ["./src/lib/contentfulClient"],
+            "@/contexts": ["./src/contexts"],
+            "@/cookies": ["./src/lib/cookies"],
+            "@/documentation": ["./src/lib/documentation"],
+            "@/helpers": ["./src/lib/helpers"],
             "@/hooks": ["./src/hooks"],
+            "@/interfaces": ["./src/lib/interfaces"],
+            "@/layouts": ["./src/layouts"],
+            "@/mocks": ["./src/__tests__/mocks"],
             "@/stores": ["./src/stores"],
             "@/templates": ["./src/templates"],
-            "@/interfaces": ["./src/lib/interfaces"],
-            "@/types": ["./src/lib/types"],
-            "@/helpers": ["./src/lib/helpers"],
-            "@/api": ["./src/lib/api"],
-            "@/documentation": ["./src/lib/documentation"],
-            "@/contexts": ["./src/contexts"],
-            "@/contentfulClient": ["./src/lib/contentfulClient"]
+            "@/types": ["./src/lib/types"]
         }
     }
 }


### PR DESCRIPTION
The purpose of this PR was to put in place XSS mitigations for the main text field. This includes:
- Setting the "SameSite" flag on cookies to "Strict" to help prevent these being misused
- Sanitizing the HTML that is saved to the main text field using OWASP's recommended library, DOM Purify

---

### Acceptance Criteria:
- Cookies are set with "SameSite" = "Strict"
- HTML input is sanitized against XSS attacks

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

API
<img width="461" alt="Screenshot 2024-02-22 084636" src="https://github.com/JiscSD/octopus/assets/132363734/b7c1dc14-2f0f-4cb1-b107-453979ad75d0">

UI
<img width="262" alt="Screenshot 2024-02-21 135353" src="https://github.com/JiscSD/octopus/assets/132363734/f6991e03-d6cc-4907-8cb3-fd1dd86f305a">

E2E
<img width="117" alt="Screenshot 2024-02-21 161301" src="https://github.com/JiscSD/octopus/assets/132363734/da951efd-55e9-4ea1-abf1-fef8fd0307db">


---

### Screenshots:

Existing HTML editor features still work, including code blocks containg code that would be filtered out by DOMPurify
<img width="635" alt="Screenshot 2024-02-22 093856" src="https://github.com/JiscSD/octopus/assets/132363734/81da2b28-2635-4e58-a42f-cbc4768479f1">

