### PR TITLE
OC-809: New copy for FAQ page

### DIFF
--- a/ui/src/pages/faq.tsx
+++ b/ui/src/pages/faq.tsx
@@ -13,135 +13,192 @@ const faqContents = [
         href: 'what_octopus',
         id: 'what_octopus',
         heading: 'What is Octopus?',
-        content:
-            "<p className='mb-2'>Octopus sets out to be the new primary research record: a place where researchers from all disciplines can freely record all of their research outputs without external requirements unduly shaping their outputs.</p><p className='mb-2'>This complements the traditional paper, which continues to be a good place to disseminate research summaries (and particularly &apos;findings&apos;) to a wider audience: publishing in Octopus doesn't stop you publishing in a journal down the line should you want – but it is the place where you establish your priority for all to see, and document your work in full detail in order to do so, rather like a patent office.</p> <p className='mb-2'>Octopus publications are smaller units. These publications are linked together, reflecting different stages of the research process, allowing each piece of work to be done by different researchers at different times where appropriate. They can be published individually, without needing to fit it into the structure of a traditional journal article. To read more about Octopus' publication types, click <a className='underline' href='faq#pub_type_octopus'>here.</a></p><p className='mb-2'>You can also publish on Octopus any work you have previous published in a journal if you retained the copyright, or published CC-BY. Doing this allows your work to get higher visibility and can help it be recognised by your institution or funders.</p> <p className='mb-2'>Our aim is that the different structure of Octopus will help researchers approach their work differently and allow people to concentrate on intrinsic excellence rather than chasing &apos;impact&apos;.</p>"
+        content: `
+            <p className='mb-2'>Octopus sets out to be the new "primary research record": a place where researchers from all disciplines can freely record all of their research work without pressures such as the need for &apos;high impact&apos; or word counts affecting what they write (or do).</p>
+            <p className='mb-2'>Publishing your work on Octopus establishes your priority immediately, and allows you to document your work in full detail, a bit like a patent office. This record can sit alongside a traditional academic paper or monograph: journals continue to be a good place to disseminate research summaries, particularly &apos;findings&apos;, to a wider audience.</p>
+            <p className='mb-2'>If you want to publish your work in a journal, you can publish on Octopus before you submit (like a preprint), or after you have had a paper accepted (to provide fuller details, like a well-organised supplementary information).</p>
+            <p className='mb-2'>Octopus publications are different from other publications. They are smaller units linked together, reflecting different stages of the research process. They can be published individually (e.g. just publishing data), without needing to fit it into the structure of a traditional journal article. To read more about Octopus' publication types, click <a className='underline' href='#pub_type_octopus' target='_blank'>here</a>.</p>
+            <p>You can find out more about our aims <a className='underline' target='_blank' href='octopus-aims'>here</a>.</p>
+        `
     },
     {
-        title: 'Why record your research on Octopus?',
+        title: 'Who runs Octopus?',
+        href: 'who_octopus',
+        id: 'who_octopus',
+        heading: 'Who runs Octopus?',
+        content: `
+            <p>Octopus is managed in partnership by Jisc and Octopus Publishing CIC. Jisc is a not-for-profit company focused on tertiary education, research and innovation. Octopus Publishing CIC is a community interest company (not-for-profit) run by Alexandra Freeman, who founded Octopus. Through this partnership, Jisc and Octopus publishing CIC aim to deliver the platform as a free service for the benefit of researchers. Neither party stands to nor intends to profit from the provision of the platform.</p>
+        `
+    },
+    {
+        title: 'Why publish my research on Octopus?',
         href: 'why_octopus',
         id: 'why_octopus',
-        heading: 'Why record your research on Octopus?',
-        content:
-            "<p className='mb-2'>Publishing in Octopus is free, fast, and fair.</p><p className='mb-2'>So, you can immediately establish priority on your work, get recognition from peers, and benefit from feedback at all stages of your research.</p> <p className='mb-2'>Octopus is designed to address many of the failings of the current system, which is not only slow and expensive, but also limits the spread of knowledge.</p><p className='mb-2'>Octopus also aims to incentivise good research practice (and minimise pressures for questionable research practices) through the way it is structured and its review and red flag, as well as minimising causes of bias (such as gender or institutional biases)</p> <p className='mb-2'> It recognises that good research is more than a headline-grabbing journal article, it could be a well-thought-out hypothesis or a piece of lateral-thinking that leads to a new rationale that could solve a problem; it could be an intricately-designed protocol, described in such a way that it can be followed precisely by others, ensuring reproducibility; it could be carefully collected data, meticulously recorded with all the details others would need to interrogate it or analyse it in different ways – regardless of what that data reveals; it could be a thorough analysis of some data, or meta-analysis, a re-analysis of existing data using new techniques; it could be an insight into a new interpretation of the findings, or a way in which those findings could be used in the real world to provide benefit. Or, it could be a constructive and insightful critique of the work of others.</p><p className='mb-2'>All of these are research work. All of them should be shared and valued by the research community.</p>"
+        heading: 'Why publish my research on Octopus?',
+        content: `
+            <p className='mb-2'>Publishing on Octopus is free, fast, and fair. You can establish priority on your work, get recognition from peers, and benefit from feedback at all stages of your research process.</p>
+            <p className='mb-2'>Octopus is designed to address many of the current limitations in research publishing, which can be slow, expensive, and reduce effective sharing of work.</p>
+            <p>The platform&apos;s publication structure, open peer review, and flagging function, help incentivise good research practice, minimising pressures for questionable research practices and causes of bias.</p>
+        `
     },
     {
         title: 'Is my discipline supported by Octopus? ',
         href: 'discipline_octopus',
         id: 'discipline_octopus',
         heading: 'Is my discipline supported by Octopus? ',
-        content:
-            "<p className='mb-2'>Initially, Octopus&apos;s 8 publication types are most closely aligned with the scientific research process. These are problem, hypothesis, method, results, analysis, interpretation, real-world application and peer review. However, researchers from all disciplines are welcome to use the platform.</p><p className='mb-2'>As we continue to develop Octopus, we plan to directly support academics who use other research processes. We are planning a discovery period to better understand the requirements of these disciplines and anyone interested in participating can get involved by messaging help@jisc.ac.uk. </p>"
+        content: `<p>Yes. Though Octopus&apos;s eight publication types are most closely aligned with the scientific research process, researchers from all disciplines are welcome to use the platform.</p>`
     },
     {
-        title: 'How do I record my work to Octopus?',
+        title: 'How do I publish my work on Octopus?',
         href: 'how_octopus',
         id: 'how_octopus',
-        heading: 'How do I record my work to Octopus?',
-        content:
-            "<p className='mb-2'>Any logged-in user can publish immediately to Octopus. See <a href='faq#how_account_octopus' className='underline'>how to create an Octopus account</a>.<p className='mb-2'>There are 8 types of publication on Octopus, each aligned with a stage of the scientific process. You can publish each stage as you conduct your research, or at the end of your project. Other users can also link their works to yours – for instance, each stage of a collaborative project might be published by a different member of the team to reflect the work they were most closely involved with, or another researcher might be inspired to respond to your work.</p><p className='mb-2'>All Octopus publications are hierarchically linked in a collaborative chain, which means your publication needs to be linked to at least one other work on Octopus. The start of any chain is a scientific Research Problem, from which can be linked a hypothesis/rationale, and from that a method/protocol, and so on. Most publications can only be linked to the type preceding it in the chain. However problems and reviews can be linked from any of the other publication types.</p>"
+        heading: 'How do I publish my work on Octopus?',
+        content: `
+            <p className='mb-2'>Any logged-in user can publish immediately. See <a href='#how_account_octopus' className='underline' target='_blank'>how do I create an account</a> for more information.</p>
+            <p className='mb-2'>Octopus has eight publication types, each aligned with a stage of the research process.</p>
+            <p className='mb-2'>All publications are hierarchically linked in a branching chain, which means your publication needs to be linked to at least one other work on Octopus. For example, you can&apos;t publish data unless the method/protocol is already published. This ensures that everything shared is easily found, and fully understandable to readers.</p>
+            <p>For a step-by-step guide to publishing on Octopus, please visit our <a href='author-guide' className='underline' target='_blank'>author guide.</a></p>
+        `
     },
-
     {
         title: 'Which publication type should I use?',
         href: 'pub_type_octopus',
         id: 'pub_type_octopus',
         heading: 'Which publication type should I use?',
-        content:
-            "<p className='mb-2'>There are eight types of publication in Octopus align with the stages of scientific research. You should select the one which matches where you are in your research.</p><p className='mb-2'>The 8 publication types are:</p><p className='mb-2 font-bold'>Research Problem</p><p className='mb-2'>A Research Problem publication defines a research problem or question. You will need to explain what is known so far about the problem – rather like the ‘Introduction’ to a traditional paper.</p><p className='mb-2 font-bold'>Rationale/Hypothesis:</p><p className='mb-2'>A Rationale/Hypothesis publication sets out the theoretical basis for a potential solution, or partial solution, to the Research Problem it is linked to. In some fields a formal hypothesis is appropriate, and in some fields it will be more a description of an approach that might be taken.</p><p className='mb-2 font-bold'>Method:</p><p className='mb-2'>A Method publication describes in detail a way of testing a hypothesis, or carrying out a theoretical rationale. You can include links to sites such as protocols.io to give more detail of the method if that would be helpful to readers.</p><p className='mb-2 font-bold'>Results:<p><p className='mb-2'>A Results publication comprises raw data or summarised results collected according to an existing published Method. It should only describe the data or results themselves, without any analysis, along with details of the exact conditions under which the method was carried out – anything that might be needed for an analysis or interpretation of the results. You can include links to the raw data files.</p><p className='mb-2 font-bold'>Analysis:</p><p className='mb-2'>An Analysis publication describes manipulations of results to help conclusions be drawn from them. For example, thematic or statistical analysis.</p><p className='mb-2 font-bold'>Interpretation:<p><p className='mb-2'>An Interpretation publication describes conclusions drawn from an Analysis of results.</p><p className='mb-2 font-bold'>Real World Application:<p><p className='mb-2'>An Application publication describes how findings might have (or have had) an impact in the real world. This might be through a practical or policy application, and would be the appropriate publication type for Case Studies.<p><p className='mb-2 font-bold'>Peer Review:</p><p className='mb-2 '>Octopus Reviews are open and post-publication. A Review publication should be a carefully considered and constructive critique of an existing publication by someone else. Your review should help other readers assess the publication, and should be written in the same style as any other kind of publication (with relevant references). Authors may reversion publications in the light of reviews.</p>"
+        content: `
+            <p className='mb-2'>Below are the eight publication types. You should select the one which matches where you are in the research process.</p>
+            <p className='mb-2 font-bold'>Research problem</p>
+            <p className='mb-2'>A &apos;research problem&apos; publication defines a research problem or question. You will need to explain what is known so far about the problem, rather like the &apos;introduction&apos; to a traditional paper.</p>
+            <p className='mb-2 font-bold'>Rationale/Hypothesis:</p>
+            <p className='mb-2'>A &apos;rationale/hypothesis&apos; publication sets out the theoretical basis for a potential solution, or partial solution, to the &apos;research problem&apos; it is linked to. In some fields a formal hypothesis is appropriate, in other fields it might be a description of an approach that might be taken.</p>
+            <p className='mb-2 font-bold'>Method:</p>
+            <p className='mb-2'>A &apos;method&apos; publication is a detailed description of ways of testing a hypothesis, or carrying out a theoretical rationale. You can include links to sites such as <a href='https://protocols.io' className='underline' target='_blank'>protocols.io</a> to give more detail of the method if that would be helpful to readers.</p>
+            <p className='mb-2 font-bold'>Results:</p>
+            <p className='mb-2'>A &apos;results&apos; publication comprises raw data or summarised results collected according to an existing published &apos;method&apos;. It should describe the data or results themselves, without any analysis. It should provide details of the exact conditions under which the method was carried out and anything needed for an analysis or interpretation of the results. You can include links to the raw data files if they are in a specialist repository. Octopus is not a data repository itself.</p>
+            <p className='mb-2 font-bold'>Analysis:</p>
+            <p className='mb-2'>An &apos;analysis&apos; publication describes manipulations of results to help draw conclusions from them. For example, thematic or statistical analysis.</p>
+            <p className='mb-2 font-bold'>Interpretation:</p>
+            <p className='mb-2'>An &apos;interpretation&apos; publication describes conclusions drawn from an &apos;analysis&apos; of results.</p>
+            <p className='mb-2 font-bold'>Real World Application:</p>
+            <p className='mb-2'>A &apos;real world application&apos; publication describes how findings might have (or have had) an impact in the real world. This might be through a practical or policy application, and would be the appropriate publication type for case studies.</p>
+            <p className='mb-2 font-bold'>Peer Review:</p>
+            <p>A &apos;peer review&apos; publication is open and post-publication. It should be a carefully considered and constructive critique of an existing publication by someone else. Your review should help other readers assess the publication, and should be written in the same style as any other kind of publication, with relevant references. Authors may reversion publications in the light of reviews.</p>
+        `
     },
     {
         title: 'How do I format my publications?',
         href: 'how_format_octopus',
         id: 'how_format_octopus',
         heading: 'How do I format my publications?',
-        content:
-            "<p className='mb-2'>Because each publication in Octopus is smaller than an old-fashioned paper, you will no longer need to spend time writing an Introduction etc. for each publication. What you will now publish as a Research Problem will be roughly the equivalent to a traditional papers Introduction. A Rationale/Hypothesis directly following that will therefore no longer need to include all the information in that Research Problem, though may refer to other publications that support the scientific basis for the hypothesis. Similarly, publishing Results will no longer require you to write out the Method, merely link to the published Method you followed, and add only relevant specific details (such as the dates of data collection, batch numbers of reagents, model numbers of equipment etc).</p><p className='mb-2'>Where possible, references should include direct embedded permanent URLs (eg. DOIs).</p><p className='mb-2'>Similarly, funding statements and publication affiliations should use ROR identifiers to ensure that consistent, accurate organisational data is displayed. This also enables the more efficient discovery and tracking of research outputs across institutions and funding bodies.</p><p className='mb-2'>Acknowledgements should still be given at the end of a publication.</p><p className='mb-2'>For researchers whose fields already have reporting guidelines (such as the EQUATOR guidelines for the biomedical sciences), these should still be followed.</p><p className='mb-2'>You can format your own publications in the online editor within Octopus to be sure that you get it to look exactly as you want. No more enforced styles, word limits, or restrictions on the number of figures and tables. And no more time/money wasted proof-reading and sending comments back to Editors.</p>"
+        content: `
+            <p className='mb-2'>Each publication on Octopus is smaller than a traditional paper. They are linked together, meaning you do not need to include all the information from your &apos;research problem&apos; in your &apos;rationale/hypothesis&apos;, for example. You can format each publication how you like, and there are no minimum or maximum word counts on Octopus.</p>
+            <p className='mb-2'>There is no &apos;abstract&apos; or formal sections within an Octopus publication. Acknowledgements should be given at the end of the main text.</p>
+            <p className='mb-2'>You will be asked to enter the title and author information separately from the main text.</p>
+            <p className='mb-2'>You will need to add references for each publication, including direct embedded permanent URLs (such as a DOI) where possible. You will add these in a separate box from your main text using any reference format you like. DOIs will be automatically recognised and made into links.</p>
+            <p className='mb-2'>You will be asked for your institutional affiliations, in order to help institutions report on the work of their staff. You will also be asked for a funding statement and you&apos;ll be encouraged to look up your funder&apos;s ROR identifier to help funders track research outputs.</p>
+            <p>Researchers working in fields with existing reporting guidelines (such as the EQUATOR guidelines for the biomedical sciences) should follow these to help them ensure readers have all the information they need.</p>
+        `
     },
     {
         title: 'How do I create an account?',
         href: 'how_account_octopus',
         id: 'how_account_octopus',
         heading: 'How do I create an account?',
-        content: `<p className='mb-2'>Every Octopus account is linked to a valid <a className='underline' href='https://orcid.org/' target="_blank">ORCID®</a> account. You can login using your ORCID credentials. See our <a href='${Config.urls.privacy.path}' className='underline'>Privacy Notice</a> for more information on the data we collect and process in order to provide this platform.</p><p className="mb-2"> ORCID is an independent non-profit organization that provides a persistent identifier – an ORCID iD – that distinguishes you from other researchers and a mechanism for linking your research outputs and activities to your iD. ORCID is integrated into many systems used by publishers, funders, institutions, and other research-related services. Learn more at <a className='underline' href='https://orcid.org/' target="_blank">ORCID.org</a></p><p className='mb-2'>If you do not yet have an ORCID account, we encourage you to consider using this unique, persistent digital identifier developed specifically for researchers.</p><p className='mb-2'>Note that you must be logged-in to an Octopus account in order to share your own work, or to interact with the work of others.</p>`
+        content: `
+            <p className='mb-2'>Every Octopus account is linked to a valid <a className='underline' href='https://orcid.org/' target="_blank">ORCID®</a> account. You can login using your ORCID credentials. See our <a href='${Config.urls.privacy.path}' className='underline' target='_blank'>privacy notice</a> for more information on the data we collect and process in order to provide this platform.</p>
+            <p className="mb-2">ORCID is an independent non-profit organisation that provides a persistent identifier that distinguishes you from other researchers. It is a mechanism for linking your research outputs and activities to your iD. ORCID is integrated into many systems used by publishers, funders, institutions, and other research-related services. Learn more at <a href='https://orcid.org' className='underline' target='_blank'>ORCID.org.</a></p>
+            <p>You must log in to Octopus using you ORCID iD to share your own work, or to interact with the work of others.</p>
+        `
     },
     {
         title: 'Does each publication get a DOI?',
         href: 'how_doi_octopus',
         id: 'how_doi_octopus',
         heading: 'Does each publication get a DOI?',
-        content: "<p className='mb-2'>Yes, Octopus mints a DataCite DOI for each new publication.</p>"
+        content: `<p>Yes, Octopus mints a DataCite DOI for each new publication.</p>`
     },
     {
         title: 'Is everything on Octopus open access?',
         href: 'open_access_octopus',
         id: 'open_access_octopus',
         heading: 'Is everything on Octopus open access?',
-        content: `<p className='mb-2'>All research recorded on Octopus is made available under an open access license, and anyone can read this content without creating an account.</p><p className='mb-2'>However, authors retain the copyright to their work and can select which license they publish under. So, be sure to check on a case-by-case basis before you share, adapt, or build upon another’s work.</p><p className='mb-2'>The platform itself is published under the open-source license GPLv3. The platform code is available via our public <a href='https://github.com/JiscSD/octopus' className='underline'>Github repository</a>, and we invite any interested parties to participate in the ongoing development of the service and its features. See our <a href='${Config.urls.terms.path}' className='underline'>Terms page</a> for more information.</p>`
+        content: `
+            <p className='mb-2'>Yes. All research published on Octopus is made available under an open access license. Authors retain the copyright to their work.</p>
+            <p className='mb-2'>Anyone can read publications without creating an account, but please check the license terms before you share, adapt, or build upon another&apos;s work.</p>
+            <p>The platform is published under the open source license GPLv3. The platform code is available via our public <a href='https://github.com/JiscSD/octopus' className='underline' target='_blank'>Github repository</a>. We invite any interested parties to participate in the ongoing development of the service and its features. See our <a href='${Config.urls.terms.path}' className='underline' target='_blank'>terms page</a> for more information.</p>
+        `
     },
     {
-        title: 'What about copyright?',
+        title: 'Which copyright license is used for Octopus publication?',
         href: 'copyright_octopus',
         id: 'copyright_octopus',
-        heading: 'What about copyright?',
-        content:
-            "<p className='mb-2'>When Octopus allows you to select a Creative Commons copyright license. This will ensure that you can retain your intellectual property rights as the author, but that others can use your work in the way that you want.</p>"
+        heading: 'Which copyright license is used for Octopus publication?',
+        content: `
+            <p>All Octopus publications have a CC-BY 4.0 license. For more information, please visit the <a href='https://creativecommons.org/' className='underline' target='_blank'>Creative Commons website</a>. This is to ensure that Octopus publications fulfil the Open Access criteria of all funders.</p>
+        `
     },
     {
-        title: 'Won’t people steal my ideas/data if I publish it?',
+        title: 'Will people steal my idea/data if I publish it?',
         href: 'steal_data_octopus',
         id: 'steal_data_octopus',
-        heading: 'Won’t people steal my ideas/data if I publish it?',
-        content:
-            "<p className='mb-2'>Publishing to Octopus establishes your priority quickly. Once you've published something, it can't be stolen – it's yours. If your hypothesis is later supported by data, it doesn't matter whether that data is collected by you or someone else, or by many people: it's you that published the hypothesis and you that gets the credit for that. Similarly, if you have published the data, that's a publication already under your belt. You can also publish an analysis of that data if you like – and so can other people.</p>"
+        heading: 'Will people steal my idea/data if I publish it?',
+        content: `
+            <p>Publishing on Octopus establishes your priority instantly to protect you against &apos;scooping&apos;. Once published your work can't be stolen. For example, you might publish a hypothesis which is later supported by data. If that data is collected by you, someone else, or many people, you still get credit for the hypothesis as the person who published it.</p>
+        `
     },
     {
         title: 'Can I publish in both Octopus and a journal?',
         href: 'publish_octopus',
         id: 'publish_octopus',
         heading: 'Can I publish in both Octopus and a journal?',
-        content:
-            "<p className='mb-2'>Octopus is designed to sit alongside journals and other dissemination outlets, allowing these channels to specialise in delivering key findings to their audiences while Octopus acts like a ‘patent office’ to record who has done what and when, and ensure the quality, integrity and accessibility of all primary research, in full.</p><p className='mb-2'>Recording work to Octopus should be no barrier to publishing a traditional paper. However please note that journal policies differ in how they treat material that has been previously published, such as on a preprint server. If in doubt, we recommend that you check with your intended journal before publishing in Octopus.</p><p classname='mb-2'><em>Royal Society Open Science</em> will consider for publication manuscripts based on work that has been previously recorded in Octopus. To learn more about publishing with Royal Society Open Science, please visit <a target='blank' href='https://royalsocietypublishing.org/rsos/for-authors' class='underline'>https://royalsocietypublishing.org/rsos/for-authors</a>.</p>"
+        content: `
+            <p className='mb-2'>Octopus is designed to sit alongside journals and other dissemination outlets, allowing these channels to specialise in delivering key findings to their audiences. Octopus acts like a &apos;patent office&apos; to record who has done what and when, and ensure the quality, integrity, and accessibility of all primary research.</p>
+            <p className='mb-2'>Publishing work on Octopus shouldn&apos;t be barrier to publishing a traditional paper, just as publishing a preprint isn&apos;t. However, journal policies differ in how they treat material that has been previously published. <a href='https://beta.sherpa.ac.uk/' className='underline' target='_blank'>Sherpa</a> allows you to check the preprint policy of any journal. If in doubt, please check with the journal before publishing on Octopus.</p>
+            <p>Royal Society Open Science has a specific partnership with Octopus, publishing manuscripts based on work that has been previously recorded on Octopus. To learn more about publishing with Royal Society Open Science, please visit their <a href='https://royalsocietypublishing.org/rsos/for-authors' className='underline' target='_blank'>information for authors page</a>.</p>
+        `
     },
     {
         title: 'Why would I write a public review?',
         href: 'public_review_octopus',
         id: 'public_review_octopus',
         heading: 'Why would I write a public review?',
-        content:
-            "<p className='mb-2'>Reviewing is critical to good research, and encouraging good research is at the heart of Octopus.</p> <p className='mb-2'>All reviews are publicly available on Octopus. This enriches the scientific record, allowing readers to see the views and opinions raised by other experts and learn from varied perspectives on a topic. It is also a resource for those just beginning to participate in research, providing ways of thinking about a subject, and guiding good research practice. For the authors of the publication being reviewed, they always have the option to reversion their work taking into account major points raised by early reviewers, and might even choose to invite those reviewers as co-authors on the new version. This new version of a publication may affect all the work done subsequently in the chain.</p><p className='mb-2'>Open peer review, where reviewers’ names are published alongside their comments, contributes to the principles of openness, accountability, and collaboration which underpin the platform. In Octopus, a review is treated as an equal type of publication to any other, so every review you write will itself appear attached to your individual publication list. Treat it as carefully as any other piece of work you publish – and enjoy the credit you will get as a result.</p>"
+        content: `
+            <p className='mb-2'>Reviewing is critical to good research, and encouraging good research is at the heart of Octopus.</p>
+            <p className='mb-2'>All reviews are publicly available on Octopus. This enriches the research record, allowing readers to see the views and opinions raised by other experts and learn from varied perspectives on a topic. It is also a resource for those just beginning to participate in research, providing ways of thinking about a subject, and guiding good research practice. The authors of the publication being reviewed have the option to reversion their work taking into account major points raised by reviewers, and might even choose to invite those reviewers as co-authors on the new version.</p>
+            <p>Open peer review, where reviewers&apos; names are published alongside their comments, contributes to the principles of openness, accountability, and collaboration which underpin the platform. But, more than that, on Octopus, a review is treated as an equal type of publication to any other. Every review you write will itself appear attached to your individual publication list. Treat it as carefully as any other piece of work you publish – and enjoy the credit you will get as a result.</p>
+        `
     },
     {
-        title: 'Someone has pointed out a really important issue in a review – can I edit my publication?',
+        title: 'Can I edit my publication?',
         href: 'edit_octopus',
         id: 'edit_octopus',
-        heading: 'Someone has pointed out a really important issue in a review – can I edit my publication?',
-        content:
-            "<p className='mb-2'>Once a publication goes live it cannot be deleted unless it breaks our contribution guidelines.</p><p className='mb-2'>We will shortly introduce the functionality that allows you to create a new version of your publication. The old version will still exist on the platform, but will be linked to the new one.</p>"
+        heading: 'Can I edit my publication?',
+        content: `
+            <p className='mb-2'>Yes, you can create a new version of work. The old version will still be visible on the platform, but the newest publication will show first. You can find out more about reversioning your work by visiting our <a href='author-guide' className='underline' target='_blank'>author guide</a>.</p>
+            <p>Once a publication goes live it cannot be deleted unless there is a breach of our <a href='user-terms' className='underline' target='_blank'>user terms</a>.</p>
+        `
     },
     {
-        title: 'I think a publication should be removed!',
+        title: 'I think a publication should be removed, what do I do?',
         href: 'removed_octopus',
         id: 'removed_octopus',
-        heading: 'I think a publication should be removed!',
-        content:
-            "<p className='mb-2'>If you suspect plagiarism, copyright issues, ethical or scientific misconduct then you can use the Red Flag system to raise your concerns. Select which issue to highlight from a list of predefined criteria and add explanatory comments to explain your concerns to the authors and other readers. You can submit red flags for multiple criteria if you need to.</p><p className='mb-2'>The red flag will immediately appear on the publication page to highlight your concern to other readers. Each red flag will also generate an automated email to all the publication’s authors, who will be able to respond to the issues raised through the platform. All comments will be available to be read alongside red flag.</p><p className='mb-2'>The user who raised the red flag can also remove it, once they feel the issue has been resolved</p>"
+        heading: 'I think a publication should be removed, what do I do?',
+        content: `
+            <p className='mb-2'>If you suspect plagiarism, copyright issues, ethical or scientific misconduct then you can use the &apos;red flag&apos; system to raise your concerns. You will select which issue to highlight from a list of predefined criteria and add comments to explain your concerns to the authors and other readers. You can submit red flags for multiple criteria if you need to.</p>
+            <p className='mb-2'>The red flag will appear on the publication page immediately, highlighting your concern to other readers. Each red flag will generate an automated email to the publication&apos;s author(s), who will be able to respond to the issues raised via the platform. All comments will be available to be read alongside the red flag.</p>
+            <p>The user who raised the red flag can also remove it, once they feel the issue has been resolved.</p>
+        `
     },
     {
-        title: "How do I revoke Octopus's access to my ORCID record?",
+        title: "How do I revoke Octopus's access to my ORCID account?",
         href: 'revoke_orcid_access',
         id: 'revoke_orcid_access',
-        heading: "How do I revoke Octopus's access to my ORCID record?",
+        heading: "How do I revoke Octopus's access to my ORCID account?",
         content: `
-            <p className="mb-2">If you are logged into Octopus you can revoke access by clicking the 'Revoke ORCID Access' button next to your ORCID record on your account.</p>
-            <p className="mb-2">
-                You can also revoke access to your ORCID record, on the ORCID website. To do this go to 'Trusted parties' and delete Octopus from the list of 'Trusted organizations'. 
-            </p>
-            <p className="mb-2">
-                Both of these methods will log you out of Octopus. If you attempt to log in again after revoking access you'll be offered the chance to "Give Octopus Permission To Access Your ORCID Record" again.
-            </p>
-            <p>
-                You will not be able to log into Octopus again without granting permission to access your ORCID record.</p>
-            </p>
+            <p className="mb-2">If you are logged into Octopus you can revoke access by clicking the &apos;Revoke ORCID Access&apos; button next to your ORCID record on your account.</p>
+            <p className="mb-2">You can also revoke access to your ORCID record, on the ORCID website. To do this go to &apos;Trusted parties&apos; and delete Octopus from the list of trusted organizations.</p>
+            <p className="mb-2">Both of these methods will log you out of Octopus. If you attempt to log in again after revoking access you&apos;ll be asked to "give Octopus permission to access your ORCID record" again.</p>
+            <p>You will not be able to log into Octopus again without granting permission to access your ORCID record.</p>
         `
     }
 ];

--- a/ui/src/pages/faq.tsx
+++ b/ui/src/pages/faq.tsx
@@ -158,10 +158,10 @@ const faqContents = [
         `
     },
     {
-        title: 'Why would I write a public review?',
+        title: 'Why would I write an open peer review?',
         href: 'public_review_octopus',
         id: 'public_review_octopus',
-        heading: 'Why would I write a public review?',
+        heading: 'Why would I write an open peer review?',
         content: `
             <p className='mb-2'>Reviewing is critical to good research, and encouraging good research is at the heart of Octopus.</p>
             <p className='mb-2'>All reviews are publicly available on Octopus. This enriches the research record, allowing readers to see the views and opinions raised by other experts and learn from varied perspectives on a topic. It is also a resource for those just beginning to participate in research, providing ways of thinking about a subject, and guiding good research practice. The authors of the publication being reviewed have the option to reversion their work taking into account major points raised by reviewers, and might even choose to invite those reviewers as co-authors on the new version.</p>

--- a/ui/src/pages/user-terms.tsx
+++ b/ui/src/pages/user-terms.tsx
@@ -67,6 +67,7 @@ const UserTerms: NextPage = (): React.ReactElement => (
                                 <br /> These Terms form a legal agreement between the User, as applicable (
                                 <span className="font-bold">you and your</span>), and Jisc (
                                 <span className="font-bold">Jisc, us, we and our</span>) as the provider of the Service.
+                                See section 1 for details about Jisc.
                                 <br />
                                 <br />
                                 By using the Service in any way, you agree to be bound by these Terms. Use of the

--- a/ui/src/pages/user-terms.tsx
+++ b/ui/src/pages/user-terms.tsx
@@ -13,6 +13,7 @@ type PageSectionProps = {
 
 type TextProps = {
     children: React.ReactNode;
+    asDiv?: Boolean; // Render as a div to prevent hydration errors due to <ul>, <div> etc. nested in <p>.
 };
 
 const PageSection: React.FC<PageSectionProps> = (props): React.ReactElement => {
@@ -29,11 +30,13 @@ const PageSection: React.FC<PageSectionProps> = (props): React.ReactElement => {
     );
 };
 
+const standardTextClasses =
+    'mx-auto mb-5 block font-montserrat text-lg font-medium leading-relaxed text-grey-700 transition-colors duration-500 dark:text-grey-100';
 const StandardText: React.FC<TextProps> = (props): React.ReactElement => {
-    return (
-        <p className="mx-auto mb-5 block font-montserrat text-lg font-medium leading-relaxed text-grey-700 transition-colors duration-500 dark:text-grey-100">
-            {props.children}
-        </p>
+    return props.asDiv ? (
+        <div className={standardTextClasses}>{props.children}</div>
+    ) : (
+        <p className={standardTextClasses}>{props.children}</p>
     );
 };
 
@@ -78,7 +81,7 @@ const UserTerms: NextPage = (): React.ReactElement => (
                             </>
                         </StandardText>
                         <Components.PageSubTitle text="SECTION 1: GENERAL" className="mt-8" />
-                        <div className="mx-auto mb-5 block font-montserrat text-lg font-medium leading-relaxed text-grey-700 transition-colors duration-500 dark:text-grey-100">
+                        <StandardText asDiv={true}>
                             <ul className="ml-8 list-disc">
                                 <li className="mb-6">
                                     <span className="font-bold">About the service:</span> To see more information on the
@@ -159,7 +162,7 @@ const UserTerms: NextPage = (): React.ReactElement => (
                                     protection software.
                                 </li>
                             </ul>
-                        </div>
+                        </StandardText>
                         <Components.PageSubTitle text="SECTION 2: USERS" className="mt-8" />
                         <StandardText>
                             <>
@@ -168,7 +171,7 @@ const UserTerms: NextPage = (): React.ReactElement => (
                                 types of Users:
                             </>
                         </StandardText>
-                        <div className="mx-auto mb-5 block font-montserrat text-lg font-medium leading-relaxed text-grey-700 transition-colors duration-500 dark:text-grey-100">
+                        <StandardText asDiv={true}>
                             <ul className="ml-8 mt-6 list-disc">
                                 <li className="mb-6">
                                     An <span className="font-bold">Ordinary User </span> is a user anywhere in the world
@@ -186,7 +189,7 @@ const UserTerms: NextPage = (): React.ReactElement => (
                                     can use all of the resources on the Service website in accordance with these Terms.
                                 </li>
                             </ul>
-                        </div>
+                        </StandardText>
                         <Components.PageSubTitle text="SECTION 3: BECOMING A REGISTERED USER" className="mt-8" />
                         <StandardText>
                             <>
@@ -292,12 +295,12 @@ const UserTerms: NextPage = (): React.ReactElement => (
                         <StandardText>
                             <span className="font-bold">All Users shall:</span>
                         </StandardText>
-                        <div className="mx-auto mb-5 block font-montserrat text-lg font-medium leading-relaxed text-grey-700 transition-colors duration-500 dark:text-grey-100">
+                        <StandardText asDiv={true}>
                             <ul className="ml-8 list-disc">
                                 <li className="mb-6">only access and use the Service on these Terms</li>
                             </ul>
-                        </div>
-                        <div className="mx-auto mb-5 block font-montserrat text-lg font-medium leading-relaxed text-grey-700 transition-colors duration-500 dark:text-grey-100">
+                        </StandardText>
+                        <StandardText asDiv={true}>
                             <span className="font-bold">Users shall not:</span>
                             <ul className="ml-8 list-disc">
                                 <li className="mb-6">
@@ -350,14 +353,14 @@ const UserTerms: NextPage = (): React.ReactElement => (
                                     use the Service or the Service website unlawfully or fraudulently at any time.
                                 </li>
                             </ul>
-                        </div>
+                        </StandardText>
                         <Components.PageSubTitle text="SECTION 8: BREACH OF THESE TERMS" className="mt-8" />
                         <StandardText>
                             Where Jisc reasonably believes or suspects that a User is in breach of these Terms (or any
                             other terms reference herein), Jisc may take such action as it deems appropriate (at its
                             discretion), including:
                         </StandardText>
-                        <div className="mx-auto mb-5 block font-montserrat text-lg font-medium leading-relaxed text-grey-700 transition-colors duration-500 dark:text-grey-100">
+                        <StandardText asDiv={true}>
                             <ul className="ml-8 list-disc">
                                 <li className="mb-6">issuing a warning;</li>
                                 <li className="mb-6">
@@ -375,7 +378,7 @@ const UserTerms: NextPage = (): React.ReactElement => (
                                     necessary.
                                 </li>
                             </ul>
-                        </div>
+                        </StandardText>
                         <Components.PageSubTitle text="SECTION 9: OTHER JISC MATERIAL" className="mt-8" />
                         <StandardText>
                             <>
@@ -442,7 +445,7 @@ const UserTerms: NextPage = (): React.ReactElement => (
                             guidance and resources made available on it, whether express or implied. In particular, Jisc
                             excludes all conditions, warranties, representations or other terms:
                         </StandardText>
-                        <div className="mx-auto mb-5 block font-montserrat text-lg font-medium leading-relaxed text-grey-700 transition-colors duration-500 dark:text-grey-100">
+                        <StandardText asDiv={true}>
                             <ul className="ml-8 list-disc">
                                 <li className="mb-6">
                                     that any User Content, guidance or resource will be of satisfactory quality or fit
@@ -473,7 +476,7 @@ const UserTerms: NextPage = (): React.ReactElement => (
                                 </li>
                                 <li className="mb-6">that defects in Service or Service website will be corrected</li>
                             </ul>
-                        </div>
+                        </StandardText>
                         <StandardText>
                             <>
                                 If Jisc is liable to you in relation to your use of the Service for any cause whatever,
@@ -526,7 +529,7 @@ const UserTerms: NextPage = (): React.ReactElement => (
                             </>
                         </StandardText>
                         <Components.PageSubTitle text="SECTION 15: MISCELLANEOUS" className="mt-8" />
-                        <div className="mx-auto mb-5 block font-montserrat text-lg font-medium leading-relaxed text-grey-700 transition-colors duration-500 dark:text-grey-100">
+                        <StandardText asDiv={true}>
                             <ul className="ml-8 list-disc">
                                 <li className="mb-6">
                                     <span className="font-bold">No partnership: </span> Users acknowledge that these
@@ -605,12 +608,12 @@ const UserTerms: NextPage = (): React.ReactElement => (
                                     these Terms or use of the Service and/or Service website
                                 </li>
                             </ul>
-                        </div>
+                        </StandardText>
                         <h1 className="my-12 block text-center font-montserrat text-3xl font-black !leading-tight tracking-tight text-grey-700 transition-colors duration-500 dark:text-white-50 lg:text-4xl">
                             OCTOPUS PLATFORM USER TERMS: SCHEDULE 1 - DATA PROCESSING
                         </h1>
                         <Components.PageSubTitle text="1. DEFINITIONS AND INTERPRETATION" />
-                        <StandardText>
+                        <StandardText asDiv={true}>
                             <div className="grid grid-cols-12">
                                 <div className="col-span-1">1.1</div>{' '}
                                 <div className="col-span-11">
@@ -664,7 +667,7 @@ const UserTerms: NextPage = (): React.ReactElement => (
                                     <br />
                                     means, in relation to any Processing under these Terms:
                                     <br />
-                                    <div className="mx-auto mb-5 block font-montserrat text-lg font-medium leading-relaxed text-grey-700 transition-colors duration-500 dark:text-grey-100">
+                                    <StandardText asDiv={true}>
                                         <ol className="list-none">
                                             <li className="ml-6">
                                                 (a) the subject matter and duration of the Processing;
@@ -787,307 +790,299 @@ const UserTerms: NextPage = (): React.ReactElement => (
                                         has the meaning as set out in Section 5 of the Terms;
                                         <br />
                                         <br />
-                                    </div>
+                                    </StandardText>
                                 </div>
                             </div>
                         </StandardText>
-                        <StandardText>
-                            <>
-                                <Components.PageSubTitle text="2. DATA PROTECTION ARRANGEMENTS" className="my-8" />
-                                <div className="grid grid-cols-12">
-                                    <div className="col-span-1">2.1</div>
-                                    <div className="col-span-11 mb-6">
-                                        Both you and we acknowledge that the factual arrangements in respect of the
-                                        processing of Personal Data dictates the classification of each party in respect
-                                        of the Data Protection Legislation. Notwithstanding the foregoing, it is
-                                        anticipated and agreed that you shall act as a Controller and Jisc shall act as
-                                        a Processor in respect of Processing of any Personal Data in your User Content
-                                        that you make available in connection with your use of the Service.
-                                    </div>
-                                    <div className="col-span-1">2.2</div>
-                                    <div className="col-span-11 mb-6">
-                                        Both you and we acknowledge and agree that Annex A contains an accurate
-                                        description of the Data Protection Particulars.
-                                    </div>
-                                    <div className="col-span-1">3</div>
-                                    <div className="col-span-11 mb-6 font-bold">CONTROLLER OBLIGATIONS</div>
-                                    <div className="col-span-1">3.1</div>
-                                    <div className="col-span-11 mb-6 ">
-                                        You, in your capacity as Controller in respect of the Processing of the Personal
-                                        Data in your User Content, shall:
-                                    </div>
-                                    <div className="col-span-2"> </div>
-                                    <div className="col-span-10 mb-6 ">
-                                        <ul>
-                                            <li className="mb-6">
-                                                (a) comply with your obligations as Controller under the Data Protection
-                                                Legislation;
-                                            </li>
-                                            <li className="mb-6">
-                                                (b) ensure that you are not subject to any prohibition or restriction
-                                                which would:
-                                                <ul className="ml-6 mt-6">
-                                                    <li className="mb-6">
-                                                        (i) prevent or restrict you from disclosing or transferring the
-                                                        Personal Data to Jisc, as required under these Terms or
-                                                    </li>
-                                                    <li>
-                                                        (ii) prevent or restrict you from granting Jisc access to the
-                                                        Personal Data, as required under these Terms;
-                                                    </li>
-                                                </ul>
-                                            </li>
-                                            <li className="mb-8">
-                                                (c) ensure that all fair processing notices have been given (and/or, as
-                                                applicable, consents obtained) and are sufficient in scope to enable
-                                                each Jisc to Process the Personal Data as required in order to obtain
-                                                the benefit of its rights and to fulfil its obligations under these
-                                                Terms accordance with the Data Protection Legislation; and
-                                            </li>
-                                            <li>
-                                                (d) notify Jisc promptly (and in any event within forty-eight (48)
-                                                hours) following its receipt of any Regulator Correspondence.
-                                            </li>
-                                        </ul>
-                                    </div>
-                                    <div className="col-span-1">4.</div>
-                                    <div className="col-span-11 mb-6 font-bold"> PROCESSOR OBLIGATIONS</div>
-                                    <div className="col-span-1">4.1</div>
-                                    <div className="col-span-11 mb-6">
-                                        Jisc, as a Processor in relation to any Personal Data Processed on your behalf
-                                        pursuant to these Terms undertakes that it shall:
-                                    </div>
-                                    <div className="col-span-2">4.1.1</div>
-                                    <div className="col-span-10 mb-6 ">
-                                        process the Personal Data for and on your behalf in connection with the
-                                        Permitted Purpose only and for no other purpose in accordance with these Terms,
-                                        and any instructions from you;
-                                    </div>
-                                    <div className="col-span-2">4.1.2</div>
-                                    <div className="col-span-10 mb-6 ">
-                                        unless prohibited by law, promptly notify you (and in any event within
-                                        forty-eight (48) hours of becoming aware of the same) if it considers, in its
-                                        opinion (acting reasonably) that it is required by Applicable Law to act other
-                                        than in accordance with your instructions, including where it believes that any
-                                        of your instructions under Clause 4.1.1 infringes any of the Data Protection
-                                        Legislation;
-                                    </div>
-                                    <div className="col-span-2">4.1.3</div>
-                                    <div className="col-span-10 mb-6 ">
-                                        implement and maintain appropriate technical and organisational security
-                                        measures to comply with at least the obligations imposed on a Controller by the
-                                        Security Requirements;
-                                    </div>
-                                    <div className="col-span-2">4.1.4</div>
-                                    <div className="col-span-10 mb-6 ">
-                                        take all reasonable steps to ensure the reliability and integrity of any of the
-                                        Personnel who shall have access to the Personal Data, and ensure that each
-                                        member of Personnel shall have entered into appropriate contractually-binding
-                                        confidentiality undertakings;
-                                    </div>
-                                    <div className="col-span-2">4.1.5</div>
-                                    <div className="col-span-10 mb-6 ">
-                                        notify you promptly, and in any event within forty-eight (48) hours, upon
-                                        becoming aware of any actual or suspected, threatened or &apos;near miss&apos;
-                                        Personal Data Breach, and:
-                                    </div>
-                                    <div className="col-span-3"></div>
-                                    <div className="col-span-9 mb-6 ">
-                                        (a) implement any measures necessary to restore the security of compromised
-                                        Personal Data
-                                    </div>
-                                    <div className="col-span-3"></div>
-                                    <div className="col-span-9 mb-6 ">
-                                        (b) assist you to make any notifications to the ICO and affected Data Subjects
-                                    </div>
-                                    <div className="col-span-2">4.1.6</div>
-                                    <div className="col-span-10 mb-6 ">
-                                        notify you promptly (and in any event within forty-eight (48) hours) following
-                                        its receipt of any Data Subject Request or Regulator Correspondence and shall:
-                                    </div>
-
-                                    <div className="col-span-3"></div>
-                                    <div className="col-span-9 mb-6 ">
-                                        (a) not disclose any of the Personal Data in response to any Data Subject
-                                        Request or Regulator Correspondence without your prior written consent; and
-                                    </div>
-                                    <div className="col-span-3"></div>
-                                    <div className="col-span-9 mb-6 ">
-                                        (b) provide you with all reasonable co-operation and assistance you require in
-                                        relation to any such Data Subject Request or Regulator Correspondence;
-                                    </div>
-
-                                    <div className="col-span-2">4.1.7</div>
-                                    <div className="col-span-10 mb-6 ">
-                                        not disclose the Personal Data to a third party in any circumstances without
-                                        your prior written consent, other than:
-                                    </div>
-                                    <div className="col-span-3"></div>
-                                    <div className="col-span-9 mb-6 ">
-                                        (a) in relation to Third Party Requests where Jisc is required by law to make
-                                        such a disclosure, in which case it shall use reasonable endeavours to advise
-                                        you in advance of such disclosure and in any event as soon as practicable
-                                        thereafter, unless prohibited by law or regulation from notifying you;
-                                    </div>
-                                    <div className="col-span-3"></div>
-                                    <div className="col-span-9 mb-6 ">
-                                        (b) to Jisc&apos;s employees, officers, representatives and advisers who need to
-                                        know such information for the purposes of Jisc performing its obligations under
-                                        these Terms and in this respect Jisc shall ensure that its employees, officers,
-                                        representatives and advisers to whom it discloses the Personal Data are made
-                                        aware of their obligations with regard to the use and security of Personal Data
-                                        under these Terms; and
-                                    </div>
-                                    <div className="col-span-3"></div>
-                                    <div className="col-span-9 mb-6 ">(c) to an Appointed Sub-contractor;</div>
-                                    <div className="col-span-2">4.1.8</div>
-                                    <div className="col-span-10 mb-6 ">
-                                        not Process or transfer the Personal Data outside of a Permitted Country without
-                                        putting in place measures to ensure compliance with Data Protection Legislation;
-                                    </div>
-                                    <div className="col-span-2">4.1.9</div>
-                                    <div className="col-span-10 mb-6 ">
-                                        on the written request from you, allow you or your representatives to audit Jisc
-                                        in order to ascertain compliance with the terms of this Clause 4.1 and/ or to
-                                        provide the you with reasonable information to demonstrate compliance with the
-                                        requirements of this Clause 4.1, provided that:
-                                    </div>
-                                    <div className="col-span-3"></div>
-                                    <div className="col-span-9 mb-6 ">
-                                        (a) you shall only be permitted to exercise your rights under this Clause 4.1.9
-                                        no more frequently than once in any 12 month period (other than where an audit
-                                        is being undertaken in connection with an actual or &apos;near miss&apos;
-                                        Personal Data Breach, in which case, an additional audit may be undertaken
-                                        within thirty (30) days of us having notified you of actual or &apos;near
-                                        miss&apos; Personal Data Breach);
-                                    </div>
-                                    <div className="col-span-3"></div>
-                                    <div className="col-span-9 mb-6 ">
-                                        (b) each such audit shall be performed at your sole expense;
-                                    </div>
-                                    <div className="col-span-3"></div>
-                                    <div className="col-span-9 mb-6 ">
-                                        (c) you shall not, in your performance of each such audit, unreasonably disrupt
-                                        the business operations of Jisc;
-                                    </div>
-                                    <div className="col-span-3"></div>
-                                    <div className="col-span-9 mb-6 ">
-                                        (d) you shall comply with Jisc&apos;s health and safety, security, conduct and
-                                        other rules, procedures and requirements in relation to Jisc&apos;s property and
-                                        systems which have been notified by Jisc to you in advance; and
-                                    </div>
-                                    <div className="col-span-3"></div>
-                                    <div className="col-span-9 mb-6 ">
-                                        (e) in no case shall you be permitted to access any data, information or records
-                                        relating to any other customer of Jisc;
-                                    </div>
-                                    <div className="col-span-2">4.1.10</div>
-                                    <div className="col-span-10 mb-6 ">
-                                        except to the extent required by Applicable Law, on the earlier of:
-                                    </div>
-                                    <div className="col-span-3"></div>
-                                    <div className="col-span-9 mb-6 ">
-                                        (a) the date of termination or expiry of these Terms (as applicable); and/or
-                                    </div>
-                                    <div className="col-span-2"></div>
-                                    <div className="col-span-10 mb-6 ">
-                                        cease Processing any of the Personal Data and, within sixty (60) days of the
-                                        date being applicable under this Clause 4.1.10, return or destroy (as directed,
-                                        in writing, by you) the Personal Data belonging to, or under your control and
-                                        ensure that all such data is securely and permanently deleted from its systems,
-                                        provided that Jisc shall be entitled to retain copies of the Personal Data for
-                                        evidential purposes and to comply with legal and/or regulatory requirements;
-                                    </div>
-                                    <div className="col-span-2">4.1.11</div>
-                                    <div className="col-span-10 mb-6 ">
-                                        comply with the obligations imposed upon a Processor under the Data Protection
-                                        Legislation; and
-                                    </div>
-                                    <div className="col-span-1">4.2</div>
-                                    <div className="col-span-11 mb-6 ">
-                                        Notwithstanding anything in these Terms to the contrary, this Clause 4 shall
-                                        continue in full force and effect for so long as Jisc Processes the Personal
-                                        Data in your User Content.
-                                    </div>
+                        <StandardText asDiv={true}>
+                            <Components.PageSubTitle text="2. DATA PROTECTION ARRANGEMENTS" className="my-8" />
+                            <div className="grid grid-cols-12">
+                                <div className="col-span-1">2.1</div>
+                                <div className="col-span-11 mb-6">
+                                    Both you and we acknowledge that the factual arrangements in respect of the
+                                    processing of Personal Data dictates the classification of each party in respect of
+                                    the Data Protection Legislation. Notwithstanding the foregoing, it is anticipated
+                                    and agreed that you shall act as a Controller and Jisc shall act as a Processor in
+                                    respect of Processing of any Personal Data in your User Content that you make
+                                    available in connection with your use of the Service.
                                 </div>
-                            </>
+                                <div className="col-span-1">2.2</div>
+                                <div className="col-span-11 mb-6">
+                                    Both you and we acknowledge and agree that Annex A contains an accurate description
+                                    of the Data Protection Particulars.
+                                </div>
+                                <div className="col-span-1">3</div>
+                                <div className="col-span-11 mb-6 font-bold">CONTROLLER OBLIGATIONS</div>
+                                <div className="col-span-1">3.1</div>
+                                <div className="col-span-11 mb-6 ">
+                                    You, in your capacity as Controller in respect of the Processing of the Personal
+                                    Data in your User Content, shall:
+                                </div>
+                                <div className="col-span-2"> </div>
+                                <div className="col-span-10 mb-6 ">
+                                    <ul>
+                                        <li className="mb-6">
+                                            (a) comply with your obligations as Controller under the Data Protection
+                                            Legislation;
+                                        </li>
+                                        <li className="mb-6">
+                                            (b) ensure that you are not subject to any prohibition or restriction which
+                                            would:
+                                            <ul className="ml-6 mt-6">
+                                                <li className="mb-6">
+                                                    (i) prevent or restrict you from disclosing or transferring the
+                                                    Personal Data to Jisc, as required under these Terms or
+                                                </li>
+                                                <li>
+                                                    (ii) prevent or restrict you from granting Jisc access to the
+                                                    Personal Data, as required under these Terms;
+                                                </li>
+                                            </ul>
+                                        </li>
+                                        <li className="mb-8">
+                                            (c) ensure that all fair processing notices have been given (and/or, as
+                                            applicable, consents obtained) and are sufficient in scope to enable each
+                                            Jisc to Process the Personal Data as required in order to obtain the benefit
+                                            of its rights and to fulfil its obligations under these Terms accordance
+                                            with the Data Protection Legislation; and
+                                        </li>
+                                        <li>
+                                            (d) notify Jisc promptly (and in any event within forty-eight (48) hours)
+                                            following its receipt of any Regulator Correspondence.
+                                        </li>
+                                    </ul>
+                                </div>
+                                <div className="col-span-1">4.</div>
+                                <div className="col-span-11 mb-6 font-bold"> PROCESSOR OBLIGATIONS</div>
+                                <div className="col-span-1">4.1</div>
+                                <div className="col-span-11 mb-6">
+                                    Jisc, as a Processor in relation to any Personal Data Processed on your behalf
+                                    pursuant to these Terms undertakes that it shall:
+                                </div>
+                                <div className="col-span-2">4.1.1</div>
+                                <div className="col-span-10 mb-6 ">
+                                    process the Personal Data for and on your behalf in connection with the Permitted
+                                    Purpose only and for no other purpose in accordance with these Terms, and any
+                                    instructions from you;
+                                </div>
+                                <div className="col-span-2">4.1.2</div>
+                                <div className="col-span-10 mb-6 ">
+                                    unless prohibited by law, promptly notify you (and in any event within forty-eight
+                                    (48) hours of becoming aware of the same) if it considers, in its opinion (acting
+                                    reasonably) that it is required by Applicable Law to act other than in accordance
+                                    with your instructions, including where it believes that any of your instructions
+                                    under Clause 4.1.1 infringes any of the Data Protection Legislation;
+                                </div>
+                                <div className="col-span-2">4.1.3</div>
+                                <div className="col-span-10 mb-6 ">
+                                    implement and maintain appropriate technical and organisational security measures to
+                                    comply with at least the obligations imposed on a Controller by the Security
+                                    Requirements;
+                                </div>
+                                <div className="col-span-2">4.1.4</div>
+                                <div className="col-span-10 mb-6 ">
+                                    take all reasonable steps to ensure the reliability and integrity of any of the
+                                    Personnel who shall have access to the Personal Data, and ensure that each member of
+                                    Personnel shall have entered into appropriate contractually-binding confidentiality
+                                    undertakings;
+                                </div>
+                                <div className="col-span-2">4.1.5</div>
+                                <div className="col-span-10 mb-6 ">
+                                    notify you promptly, and in any event within forty-eight (48) hours, upon becoming
+                                    aware of any actual or suspected, threatened or &apos;near miss&apos; Personal Data
+                                    Breach, and:
+                                </div>
+                                <div className="col-span-3"></div>
+                                <div className="col-span-9 mb-6 ">
+                                    (a) implement any measures necessary to restore the security of compromised Personal
+                                    Data
+                                </div>
+                                <div className="col-span-3"></div>
+                                <div className="col-span-9 mb-6 ">
+                                    (b) assist you to make any notifications to the ICO and affected Data Subjects
+                                </div>
+                                <div className="col-span-2">4.1.6</div>
+                                <div className="col-span-10 mb-6 ">
+                                    notify you promptly (and in any event within forty-eight (48) hours) following its
+                                    receipt of any Data Subject Request or Regulator Correspondence and shall:
+                                </div>
+
+                                <div className="col-span-3"></div>
+                                <div className="col-span-9 mb-6 ">
+                                    (a) not disclose any of the Personal Data in response to any Data Subject Request or
+                                    Regulator Correspondence without your prior written consent; and
+                                </div>
+                                <div className="col-span-3"></div>
+                                <div className="col-span-9 mb-6 ">
+                                    (b) provide you with all reasonable co-operation and assistance you require in
+                                    relation to any such Data Subject Request or Regulator Correspondence;
+                                </div>
+
+                                <div className="col-span-2">4.1.7</div>
+                                <div className="col-span-10 mb-6 ">
+                                    not disclose the Personal Data to a third party in any circumstances without your
+                                    prior written consent, other than:
+                                </div>
+                                <div className="col-span-3"></div>
+                                <div className="col-span-9 mb-6 ">
+                                    (a) in relation to Third Party Requests where Jisc is required by law to make such a
+                                    disclosure, in which case it shall use reasonable endeavours to advise you in
+                                    advance of such disclosure and in any event as soon as practicable thereafter,
+                                    unless prohibited by law or regulation from notifying you;
+                                </div>
+                                <div className="col-span-3"></div>
+                                <div className="col-span-9 mb-6 ">
+                                    (b) to Jisc&apos;s employees, officers, representatives and advisers who need to
+                                    know such information for the purposes of Jisc performing its obligations under
+                                    these Terms and in this respect Jisc shall ensure that its employees, officers,
+                                    representatives and advisers to whom it discloses the Personal Data are made aware
+                                    of their obligations with regard to the use and security of Personal Data under
+                                    these Terms; and
+                                </div>
+                                <div className="col-span-3"></div>
+                                <div className="col-span-9 mb-6 ">(c) to an Appointed Sub-contractor;</div>
+                                <div className="col-span-2">4.1.8</div>
+                                <div className="col-span-10 mb-6 ">
+                                    not Process or transfer the Personal Data outside of a Permitted Country without
+                                    putting in place measures to ensure compliance with Data Protection Legislation;
+                                </div>
+                                <div className="col-span-2">4.1.9</div>
+                                <div className="col-span-10 mb-6 ">
+                                    on the written request from you, allow you or your representatives to audit Jisc in
+                                    order to ascertain compliance with the terms of this Clause 4.1 and/ or to provide
+                                    the you with reasonable information to demonstrate compliance with the requirements
+                                    of this Clause 4.1, provided that:
+                                </div>
+                                <div className="col-span-3"></div>
+                                <div className="col-span-9 mb-6 ">
+                                    (a) you shall only be permitted to exercise your rights under this Clause 4.1.9 no
+                                    more frequently than once in any 12 month period (other than where an audit is being
+                                    undertaken in connection with an actual or &apos;near miss&apos; Personal Data
+                                    Breach, in which case, an additional audit may be undertaken within thirty (30) days
+                                    of us having notified you of actual or &apos;near miss&apos; Personal Data Breach);
+                                </div>
+                                <div className="col-span-3"></div>
+                                <div className="col-span-9 mb-6 ">
+                                    (b) each such audit shall be performed at your sole expense;
+                                </div>
+                                <div className="col-span-3"></div>
+                                <div className="col-span-9 mb-6 ">
+                                    (c) you shall not, in your performance of each such audit, unreasonably disrupt the
+                                    business operations of Jisc;
+                                </div>
+                                <div className="col-span-3"></div>
+                                <div className="col-span-9 mb-6 ">
+                                    (d) you shall comply with Jisc&apos;s health and safety, security, conduct and other
+                                    rules, procedures and requirements in relation to Jisc&apos;s property and systems
+                                    which have been notified by Jisc to you in advance; and
+                                </div>
+                                <div className="col-span-3"></div>
+                                <div className="col-span-9 mb-6 ">
+                                    (e) in no case shall you be permitted to access any data, information or records
+                                    relating to any other customer of Jisc;
+                                </div>
+                                <div className="col-span-2">4.1.10</div>
+                                <div className="col-span-10 mb-6 ">
+                                    except to the extent required by Applicable Law, on the earlier of:
+                                </div>
+                                <div className="col-span-3"></div>
+                                <div className="col-span-9 mb-6 ">
+                                    (a) the date of termination or expiry of these Terms (as applicable); and/or
+                                </div>
+                                <div className="col-span-2"></div>
+                                <div className="col-span-10 mb-6 ">
+                                    cease Processing any of the Personal Data and, within sixty (60) days of the date
+                                    being applicable under this Clause 4.1.10, return or destroy (as directed, in
+                                    writing, by you) the Personal Data belonging to, or under your control and ensure
+                                    that all such data is securely and permanently deleted from its systems, provided
+                                    that Jisc shall be entitled to retain copies of the Personal Data for evidential
+                                    purposes and to comply with legal and/or regulatory requirements;
+                                </div>
+                                <div className="col-span-2">4.1.11</div>
+                                <div className="col-span-10 mb-6 ">
+                                    comply with the obligations imposed upon a Processor under the Data Protection
+                                    Legislation; and
+                                </div>
+                                <div className="col-span-1">4.2</div>
+                                <div className="col-span-11 mb-6 ">
+                                    Notwithstanding anything in these Terms to the contrary, this Clause 4 shall
+                                    continue in full force and effect for so long as Jisc Processes the Personal Data in
+                                    your User Content.
+                                </div>
+                            </div>
                         </StandardText>
                         <h1 className="my-12 block text-center font-montserrat text-3xl font-black !leading-tight tracking-tight text-grey-700 transition-colors duration-500 dark:text-white-50 lg:text-4xl">
                             OCTOPUS PLATFORM USER TERMS SCHEDULE 1: ANNEX A
                         </h1>
-                        <StandardText>
-                            <>
-                                <span className="font-bold">Purpose of Processing</span>
-                                <br /> To provide the Service <br />
-                                <br />
-                                <Components.PageSubTitle text="Data Protection Particulars" />
-                                <span className="font-bold">The subject matter and duration of the Processing</span>
-                                <br />
-                                The Octopus platform provides a primary research record for recording and appraising
-                                research &apos;as it happens&apos;. It breaks down the publication of scientific
-                                research into eight elements.
-                                <br />
-                                <br />
-                                The eight elements are:
-                                <ul className="ml-8 mt-2 list-disc">
-                                    <li className="mb-2">Research Problem</li>
-                                    <li className="mb-2">Rationale/Hypothesis</li>
-                                    <li className="mb-2">Method</li>
-                                    <li className="mb-2">Results</li>
-                                    <li className="mb-2">Analysis</li>
-                                    <li className="mb-2">Interpretation</li>
-                                    <li className="mb-2">Real World Application</li>
-                                    <li className="mb-2">Peer Review</li>
-                                </ul>
-                                <span className="font-bold">The nature and purpose of the Processing</span>
-                                <br />
-                                To provide the Octopus Service.
-                                <br />
-                                <br />
-                                <span className="font-bold">The type of Personal Data being Processed</span>
-                                <br />
-                                Any Personal Data that the Registered Users includes in their User Content
-                                <br />
-                                <br />
-                                <span className="font-bold">The categories of Data Subjects</span>
-                                <br />
-                                We expect this to be academics (staff and students)
-                                <br />
-                                <br />
-                            </>
+                        <StandardText asDiv={true}>
+                            <span className="font-bold">Purpose of Processing</span>
+                            <br /> To provide the Service <br />
+                            <br />
+                            <Components.PageSubTitle text="Data Protection Particulars" />
+                            <span className="font-bold">The subject matter and duration of the Processing</span>
+                            <br />
+                            The Octopus platform provides a primary research record for recording and appraising
+                            research &apos;as it happens&apos;. It breaks down the publication of scientific research
+                            into eight elements.
+                            <br />
+                            <br />
+                            The eight elements are:
+                            <ul className="ml-8 mt-2 list-disc">
+                                <li className="mb-2">Research Problem</li>
+                                <li className="mb-2">Rationale/Hypothesis</li>
+                                <li className="mb-2">Method</li>
+                                <li className="mb-2">Results</li>
+                                <li className="mb-2">Analysis</li>
+                                <li className="mb-2">Interpretation</li>
+                                <li className="mb-2">Real World Application</li>
+                                <li className="mb-2">Peer Review</li>
+                            </ul>
+                            <span className="font-bold">The nature and purpose of the Processing</span>
+                            <br />
+                            To provide the Octopus Service.
+                            <br />
+                            <br />
+                            <span className="font-bold">The type of Personal Data being Processed</span>
+                            <br />
+                            Any Personal Data that the Registered Users includes in their User Content
+                            <br />
+                            <br />
+                            <span className="font-bold">The categories of Data Subjects</span>
+                            <br />
+                            We expect this to be academics (staff and students)
+                            <br />
+                            <br />
                         </StandardText>
                         <h1 className="my-12 block text-center font-montserrat text-3xl font-black !leading-tight tracking-tight text-grey-700 transition-colors duration-500 dark:text-white-50 lg:text-4xl">
                             OCTOPUS PLATFORM USER TERMS SCHEDULE 1: ANNEX B
                         </h1>
                         <Components.PageSubTitle text="Appointed Sub-contractors" />
-                        <StandardText>
-                            <>
-                                <span className="font-bold">Current list of Jisc Appointed Sub-contractors</span>
-                                <ul className="ml-8 mt-3 list-disc">
-                                    <li className="mb-3">Amazon Web Services</li>
-                                    <li className="mb-3">Octopus Publishing CIC</li>
-                                    <li className="mb-3">
-                                        DataCite:{' '}
-                                        <Components.Link
-                                            href="https://datacite.org/"
-                                            openNew={true}
-                                            className="rounded text-teal-600 outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400 dark:text-teal-300"
-                                        >
-                                            https://datacite.org/
-                                        </Components.Link>
-                                    </li>
-                                    <li className="mb-3">
-                                        ORCID:{' '}
-                                        <Components.Link
-                                            href="https://orcid.org/"
-                                            openNew={true}
-                                            className="rounded text-teal-600 outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400 dark:text-teal-300"
-                                        >
-                                            https://orcid.org/
-                                        </Components.Link>
-                                    </li>
-                                </ul>
-                            </>
+                        <StandardText asDiv={true}>
+                            <span className="font-bold">Current list of Jisc Appointed Sub-contractors</span>
+                            <ul className="ml-8 mt-3 list-disc">
+                                <li className="mb-3">Amazon Web Services</li>
+                                <li className="mb-3">Octopus Publishing CIC</li>
+                                <li className="mb-3">
+                                    DataCite:{' '}
+                                    <Components.Link
+                                        href="https://datacite.org/"
+                                        openNew={true}
+                                        className="rounded text-teal-600 outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400 dark:text-teal-300"
+                                    >
+                                        https://datacite.org/
+                                    </Components.Link>
+                                </li>
+                                <li className="mb-3">
+                                    ORCID:{' '}
+                                    <Components.Link
+                                        href="https://orcid.org/"
+                                        openNew={true}
+                                        className="rounded text-teal-600 outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400 dark:text-teal-300"
+                                    >
+                                        https://orcid.org/
+                                    </Components.Link>
+                                </li>
+                            </ul>
                         </StandardText>
                     </div>
                 </>


### PR DESCRIPTION
The purpose of this PR was to update the copy on the FAQ page.

In addition to this I saw some hydration errors when viewing the user terms page so have made some changes on it to prevent those.

---

### Acceptance Criteria:

1. FAQ page copy updated to include copy from attached word doc
2. Side nav bar updated with:
    2.1. A new entry for “Who runs Octopus”
    2.2. “Why record your research on Octopus?” changed to “Why publish my research on Octopus?”
    2.3. “How to I record my work to Octopus” changed to “How do I publish my work on Octopus”
    2.4. “What about copyright?” changed to “Which copyright license is used for Octopus publication?”
    2.5. “Won’t people steal my ideas/data if I publish it?” changed to “Will people steal my idea/data if I publish it?”
    2.6. “Why would I write a public review?” changed to “Why would I write an open peer review?”
    2.7. “Someone has pointed out a really important issue in a review – can I edit my publication?” changed to “Can I edit my publication?”
    2.8. “I think a publication should be removed!” changed to “I think a publication should be removed, what do I do?”
    2.9. “How do I revoke Octopus's access to my ORCID record?” changed to “How do I revoke Octopus’s access to my ORCID account?”
3. Jisc should also be clarified in the user terms. The second line of the /user-terms page should be changed to read “These Terms form a legal agreement between the User, as applicable (you and your), and Jisc (Jisc, us, we and our) as the provider of the Service. See section 1 for details about Jisc.”.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

