### PR TITLE
OC-800: Link back to parent publication from peer review

### DIFF
--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -804,6 +804,13 @@ export const getDirectLinksForPublication = async (
                 select: {
                     id: true,
                     draft: true,
+                    versionTo: {
+                        select: {
+                            id: true,
+                            isLatestLiveVersion: true,
+                            versionNumber: true
+                        }
+                    },
                     publicationTo: {
                         select: {
                             id: true,
@@ -874,7 +881,7 @@ export const getDirectLinksForPublication = async (
     }
 
     const linkedTo: I.LinkedToPublication[] = publication.linkedTo.map((link) => {
-        const { id: linkId, publicationTo, draft } = link;
+        const { id: linkId, publicationTo, versionTo, draft } = link;
         const { id, type, versions, doi } = publicationTo;
         const { createdBy, user, currentStatus, publishedDate, title } = versions[0];
 
@@ -886,6 +893,9 @@ export const getDirectLinksForPublication = async (
             doi,
             childPublication: publication.id,
             childPublicationType: publication.type,
+            parentVersionId: versionTo.id,
+            parentVersionNumber: versionTo.versionNumber,
+            parentVersionIsLatestLive: versionTo.isLatestLiveVersion,
             title: title || '',
             createdBy,
             authorFirstName: user.firstName,

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -211,6 +211,11 @@ export interface LinkedToPublication extends LinkedPublication {
     draft: boolean;
     childPublication: string;
     childPublicationType: PublicationType;
+    // Only returned with ?direct=true on the getPublicationLinks endpoint.
+    // Just used at present to show, and link to, the version a Peer Review was created against.
+    parentVersionId?: string;
+    parentVersionNumber?: number;
+    parentVersionIsLatestLive?: boolean;
 }
 
 export interface LinkedFromPublication extends LinkedPublication {

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -14,7 +14,7 @@ dotenv.config();
 const config: PlaywrightTestConfig = {
     testDir: './tests',
     /* Maximum time one test can run for. */
-    timeout: 180000, // some of the publication flow and coauthor tests exceed 2 minutes. We should try and streamline them but for now set this to 3 mins
+    timeout: 120000, // some coauthoring tests take longer and are annotated with test.slow() to triple the timeout just for that test.
     expect: {
         /**
          * Maximum time expect() should wait for the condition to be met.

--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -1195,6 +1195,7 @@ test.describe('Publication flow + co-authors', () => {
     });
 
     test('Coauthored publications show on your own profile with correct publication status', async ({ browser }) => {
+        test.slow();
         const publicationTitle = 'account page check';
         const coAuthor = Helpers.user2;
         const page = await Helpers.getPageAsUser(browser);
@@ -1566,6 +1567,7 @@ test.describe('Publication flow + co-authors', () => {
     });
 
     test('Corresponding author and co-authors can create multiple versions for a publication', async ({ browser }) => {
+        test.slow();
         let page = await Helpers.getPageAsUser(browser);
 
         // create v1
@@ -1701,7 +1703,7 @@ test.describe('Publication flow + co-authors', () => {
     });
 
     test('Co-authors can transfer ownership of a new DRAFT version', async ({ browser }) => {
-        const context = await browser.newContext();
+        test.slow();
         const page = await Helpers.getPageAsUser(browser);
 
         // create v1
@@ -1797,6 +1799,7 @@ test.describe('Publication flow + co-authors', () => {
     test('Authors can create/edit and request control over new version from "Versions" dropdown', async ({
         browser
     }) => {
+        test.slow();
         const page = await Helpers.getPageAsUser(browser);
 
         // create v1

--- a/ui/src/lib/interfaces.ts
+++ b/ui/src/lib/interfaces.ts
@@ -126,6 +126,11 @@ export interface LinkedToPublication extends LinkedPublication {
     draft: boolean;
     childPublication: string;
     childPublicationType: Types.PublicationType;
+    // Only returned with ?direct=true on the getPublicationLinks endpoint.
+    // Just used at present to show, and link to, the version a Peer Review was created against.
+    parentVersionId?: string;
+    parentVersionNumber?: number;
+    parentVersionIsLatestLive?: boolean;
 }
 
 export interface LinkedFromPublication extends LinkedPublication {

--- a/ui/src/pages/publications/[id]/versions/[versionId].tsx
+++ b/ui/src/pages/publications/[id]/versions/[versionId].tsx
@@ -555,6 +555,44 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                         />
                     )}
 
+                    {
+                        // Show details of publication version Peer Review is linked to.
+                        publication?.type === 'PEER_REVIEW' &&
+                            linkedTo.length === 1 &&
+                            (linkedTo[0].parentVersionIsLatestLive ? (
+                                <Components.Alert severity="INFO" className="mb-4 text-white-100  dark:text-grey-50">
+                                    This is a peer review of the latest version of the following publication:{' '}
+                                    <Components.Link
+                                        href={`/publications/${linkedTo[0].id}`}
+                                        className="underline decoration-white-100 dark:decoration-grey-50"
+                                    >
+                                        {linkedTo[0].title}
+                                    </Components.Link>
+                                </Components.Alert>
+                            ) : (
+                                linkedTo[0].parentVersionNumber &&
+                                linkedTo[0].parentVersionId && (
+                                    <Components.Alert
+                                        severity="INFO"
+                                        className="mb-4 text-white-100  dark:text-grey-50"
+                                        details={[
+                                            'This peer review covers content that has been replaced by a newer version, and is therefore potentially outdated.'
+                                        ]}
+                                    >
+                                        This is a peer review of version {linkedTo[0].parentVersionNumber} of the
+                                        following publication:{' '}
+                                        <Components.Link
+                                            href={`/publications/${linkedTo[0].id}/versions/${linkedTo[0].parentVersionId}`}
+                                            className="underline decoration-white-100 dark:decoration-grey-50"
+                                        >
+                                            {linkedTo[0].title}
+                                        </Components.Link>
+                                        .
+                                    </Components.Alert>
+                                )
+                            ))
+                    }
+
                     {showApprovalsTracker && (
                         <Components.ActionBar
                             publicationVersion={publicationVersion}


### PR DESCRIPTION
The purpose of this PR was to give users a way to know which publication a Peer Review is reviewing. This is to be done by adding a banner to the peer review's page with information about the reviewed publication.

---

### Acceptance Criteria:

- On a peer review page that reviews the latest version of a publication, a banner is present with the text “This is a peer review of the latest version of the following publication: <publication title>”, where the publication title is a link to the specific version of the parent publication that the peer review relates to
- On a peer review page that reviews an older version of a publication, a banner is present with the text “This is a peer review of version <version #> of the following publication: <publication title>”, where the publication title is a link to the specific version of the parent publication that the peer review relates to
    - Additional text is present reading “This peer review covers content that has been replaced by a newer version, and is therefore potentially outdated.”

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

API
![Screenshot 2024-02-28 162010](https://github.com/JiscSD/octopus/assets/132363734/f2dc37ad-ddb5-4a3e-8209-837c1f82a072)

UI
![Screenshot 2024-02-28 161205](https://github.com/JiscSD/octopus/assets/132363734/c0bf41b2-7bd5-4c18-affb-13a497628b8c)

E2E
<img width="116" alt="Screenshot 2024-02-29 092227" src="https://github.com/JiscSD/octopus/assets/132363734/616cc47b-7c4c-4251-9035-d5331c2567e3">

---

### Screenshots:

<img width="831" alt="Screenshot 2024-02-29 094056" src="https://github.com/JiscSD/octopus/assets/132363734/a8ad6ea1-894f-4908-9847-681b2d346cbb">
<img width="853" alt="Screenshot 2024-02-29 094327" src="https://github.com/JiscSD/octopus/assets/132363734/67a4a635-3cc1-49dc-82ae-4fe68c7ca1e6">

