### PR TITLE
OC-815: Reduce RDS size on prod

### DIFF
--- a/infra/create-app/prod.tfvars
+++ b/infra/create-app/prod.tfvars
@@ -2,7 +2,7 @@ profile = "octopus-dev"
 
 rds_allocated_storage                     = 50
 rds_max_allocated_storage                 = 100
-rds_instance                              = "db.m5.large"
+rds_instance                              = "db.t4g.medium"
 rds_db_version                            = "14.8"
 rds_backup_retention_period               = 35
 rds_monitoring_interval                   = 60


### PR DESCRIPTION
The purpose of this PR was to change the instance type of our prod RDS database to something cheaper.

This has been deployed to prod already.

---

### Acceptance Criteria:

- Prod RDS is a db.t4g.medium instance type

---

### Checklist:

- [ ] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

N/A

---

### Screenshots:

N/A
