### PR TITLE
OC-831: Make grant ID error banners hide after successful input

### DIFF
--- a/ui/src/components/FunderForm/index.tsx
+++ b/ui/src/components/FunderForm/index.tsx
@@ -138,7 +138,7 @@ const RorIcon: React.FC<IconProps> = (props): React.ReactElement => {
 let timeout: NodeJS.Timeout;
 
 const FunderForm: React.FC = (): React.ReactElement => {
-    const { publicationVersion, updatePublicationVersion, setError } = Stores.usePublicationCreationStore();
+    const { publicationVersion, updatePublicationVersion, error, setError } = Stores.usePublicationCreationStore();
 
     const user = Stores.useAuthStore((state) => state.user);
 
@@ -153,6 +153,17 @@ const FunderForm: React.FC = (): React.ReactElement => {
     const [submitLoading, setSubmitLoading] = React.useState(false);
     const [rorLoading, setRorLoading] = React.useState(false);
     const [rorError, setRorError] = React.useState(false);
+
+    const duplicateFunderError =
+        error === 'This funder already exists on this publication version.' ||
+        error === 'This funder and grant identifier already exist on this publication version.';
+
+    const unsetErrorIfDuplicate = () => {
+        console.log(error);
+        if (duplicateFunderError) {
+            setError(null);
+        }
+    };
 
     const getRorData = React.useCallback(async (value: string) => {
         const actualRor = value.split('/')[value.split('/').length - 1];
@@ -256,7 +267,10 @@ const FunderForm: React.FC = (): React.ReactElement => {
                                 }`}
                                 placeholder="01rv9gx86 or https://ror.org/01rv9gx86"
                                 value={ror}
-                                onChange={(e) => getRorData(e.target.value)}
+                                onChange={(e) => {
+                                    unsetErrorIfDuplicate();
+                                    getRorData(e.target.value);
+                                }}
                             />
                         </div>
                         <div>
@@ -268,7 +282,10 @@ const FunderForm: React.FC = (): React.ReactElement => {
                                 }`}
                                 placeholder="Grant Identifier"
                                 value={grantId}
-                                onChange={(e) => setGrantId(e.target.value)}
+                                onChange={(e) => {
+                                    unsetErrorIfDuplicate();
+                                    setGrantId(e.target.value);
+                                }}
                             />
                             <Components.Button
                                 className="pl-5"
@@ -344,6 +361,7 @@ const FunderForm: React.FC = (): React.ReactElement => {
                             type="url"
                             value={link}
                             onChange={(e) => {
+                                unsetErrorIfDuplicate();
                                 setLink(e.target.value);
                                 if (!isLinkValid) {
                                     setIsLinkValid(true);
@@ -367,7 +385,10 @@ const FunderForm: React.FC = (): React.ReactElement => {
                             }`}
                             placeholder="Grant Identifier"
                             value={grantId}
-                            onChange={(e) => setGrantId(e.target.value)}
+                            onChange={(e) => {
+                                unsetErrorIfDuplicate();
+                                setGrantId(e.target.value);
+                            }}
                         />
                         <Components.Button
                             className="pl-5"

--- a/ui/src/components/FunderForm/index.tsx
+++ b/ui/src/components/FunderForm/index.tsx
@@ -159,7 +159,6 @@ const FunderForm: React.FC = (): React.ReactElement => {
         error === 'This funder and grant identifier already exist on this publication version.';
 
     const unsetErrorIfDuplicate = () => {
-        console.log(error);
         if (duplicateFunderError) {
             setError(null);
         }


### PR DESCRIPTION
The purpose of this PR was to avoid showing error banners to users unless they refer to a currently unresolved issue. In the funder form, the grant ID error banners, informing me that I have attempted to enter a duplicate funder, duplicate grant ID or improperly formatted funder should disappear when the user modifies the text in the ROR ID, grant ID, or link fields, as changing any of these fields has the potential to resolve the error (which would reappear on submit, if applicable).

---

### Acceptance Criteria:

- If either of these error messages are present:
    - “This funder already exists on this publication version”
    - “This funder and grant identifier already exist on this publication version.”
- And the user edits any of these fields:
    - ROR ID
    - Grant ID
    - Link
- The error message is cleared

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
<img width="165" alt="Screenshot 2024-03-12 123900" src="https://github.com/JiscSD/octopus/assets/132363734/863b0db9-14e1-448f-b7e0-22d4eaa69ea9">

E2E
<img width="70" alt="Screenshot 2024-03-12 123802" src="https://github.com/JiscSD/octopus/assets/132363734/bde8d46d-026f-448c-964a-a100c2616d99">
