### PR TITLE
OC-837: New front page text

### DIFF
--- a/ui/src/pages/about.tsx
+++ b/ui/src/pages/about.tsx
@@ -59,7 +59,7 @@ const About: NextPage = (): React.ReactElement => (
             <PageSection>
                 <>
                     <div className="mx-auto block lg:w-9/12 xl:w-10/12 2xl:w-7/12">
-                        <h1 className="mb-5 mt-5 block text-center font-montserrat text-3xl font-black !leading-tight tracking-tight text-grey-700 transition-colors duration-500 dark:text-white-50 lg:text-5xl">
+                        <h1 className="mb-5 mt-5 block text-center font-montserrat text-3xl font-bold !leading-tight tracking-tight text-grey-700 transition-colors duration-500 dark:text-white-50 lg:text-5xl">
                             Learn about Octopus.
                         </h1>
                         <h2 className="text-l mx-auto mb-5 block text-center font-montserrat font-medium leading-relaxed text-grey-700 transition-colors duration-500 dark:text-grey-100 lg:text-xl">

--- a/ui/src/pages/get-involved.tsx
+++ b/ui/src/pages/get-involved.tsx
@@ -54,7 +54,7 @@ const GetInvolved: NextPage = (): React.ReactElement => (
             <PageSection>
                 <>
                     <div className="mx-auto block lg:w-9/12 xl:w-10/12 2xl:w-7/12">
-                        <h1 className="mb-8 block text-center font-montserrat text-3xl font-black !leading-tight tracking-tight text-grey-700 transition-colors duration-500 dark:text-white-50 lg:text-5xl">
+                        <h1 className="mb-8 block text-center font-montserrat text-3xl font-bold !leading-tight tracking-tight text-grey-700 transition-colors duration-500 dark:text-white-50 lg:text-5xl">
                             Get involved with Octopus
                         </h1>
                         <article className="mt-10">

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -20,18 +20,31 @@ const Home: Types.NextPage = (props): React.ReactElement => {
             <Layouts.Standard fixedHeader={false}>
                 <section className="container mx-auto px-8 pt-8 lg:pt-24">
                     <div className="mx-auto block lg:w-9/12 xl:w-10/12 2xl:max-w-5xl">
-                        <h1 className="mb-8 block text-center font-montserrat text-2xl font-black !leading-tight tracking-tight text-grey-700 transition-colors duration-500 dark:text-white-50 lg:text-5xl ">
-                            Free, fast and fair: the global primary research record where researchers publish their work
-                            in full detail
+                        <h1 className="mb-8 block text-center font-montserrat text-2xl font-bold !leading-tight tracking-tight text-grey-700 transition-colors duration-500 dark:text-white-50 lg:text-5xl ">
+                            Free, fast and fair
                         </h1>
-                        <p className="mx-auto mb-10 block text-center font-montserrat text-base font-medium leading-relaxed text-grey-700 transition-colors duration-500 dark:text-grey-100 lg:w-8/12 lg:text-lg">
-                            Octopus is a new publishing platform for scholarly research. Funded by UKRI – the UK
+                        <p className="mx-auto mb-4 block text-center font-montserrat text-base font-medium leading-relaxed text-grey-700 transition-colors duration-500 dark:text-grey-100 lg:w-10/12 lg:text-lg">
+                            The place for researchers to publish their work in full detail. Funded by UKRI – the UK
                             government research funder.
                         </p>
-                        <p className="mx-auto mb-10 block text-center font-montserrat text-base font-medium leading-relaxed text-grey-700 transition-colors duration-500 dark:text-grey-100 lg:w-8/12 lg:text-lg">
-                            Here researchers can publish all their work for free, in full detail, enabling peer review
-                            and quality assessment, gaining credit for what they have done, and allowing the research
-                            community to build upon it.
+                        <p className="mx-auto mb-4 block text-center font-montserrat text-base font-medium leading-relaxed text-grey-700 transition-colors duration-500 dark:text-grey-100 lg:w-10/12 lg:text-lg">
+                            Octopus is a free scholarly publication platform designed to make it easier to share work of
+                            all kinds. A place for open peer review, quality assessment, and collaboration.
+                        </p>
+                        <p className="mx-auto mb-4 block text-center font-montserrat text-base font-medium leading-relaxed text-grey-700 transition-colors duration-500 dark:text-grey-100 lg:w-10/12 lg:text-lg">
+                            Work on Octopus is not published as ‘papers’ or ‘monographs’ but in smaller units which are
+                            linked together.
+                        </p>
+                        <p className="mx-auto mb-12 block text-center font-montserrat text-base font-medium leading-relaxed text-grey-700 transition-colors duration-500 dark:text-grey-100 lg:w-10/12 lg:text-lg">
+                            To see an example chain of Octopus publications have a look at{' '}
+                            <a
+                                className="underline"
+                                target="_blank"
+                                href="https://www.octopus.ac/publications/axc8-vs07/versions/latest"
+                            >
+                                this one
+                            </a>
+                            , which looks at the current research culture.
                         </p>
                         <div className="mx-auto flex w-full flex-wrap gap-6 sm:w-fit sm:justify-between">
                             <Components.Link
@@ -62,7 +75,58 @@ const Home: Types.NextPage = (props): React.ReactElement => {
                         </div>
                     </div>
                 </section>
-                <section className="container mx-auto px-8 py-20 text-center">
+                <section className="container mx-auto px-8 pt-20">
+                    <table className="mx-auto border-separate rounded-lg border-2 border-solid border-teal-800 bg-white-50 text-center text-grey-800 dark:bg-grey-700 dark:text-white-50 lg:w-10/12">
+                        <thead>
+                            <tr>
+                                <th className="px-4 py-8 text-xl font-normal">
+                                    Octopus <span className="font-bold">is</span>...
+                                </th>
+                                <th className="px-4 py-8 text-xl font-normal">
+                                    <span className="font-bold">But</span> is different because...
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td className="px-4 pb-4 lg:px-8">
+                                    like a preprint server: publish here quickly and easily, submit to a journal later
+                                </td>
+                                <td className="px-4 pb-4 lg:px-8">
+                                    you don’t publish ‘papers’ but smaller, linked publications
+                                </td>
+                            </tr>
+                            <tr>
+                                <td className="px-4 pb-4 lg:px-8">
+                                    like GitHub: ‘fork’ a chain of publications, take a branch in the direction you want
+                                </td>
+                                <td className="px-4 pb-4 lg:px-8">
+                                    you publish ‘final versions’ of work, rather than day-to-day working
+                                </td>
+                            </tr>
+                            <tr>
+                                <td className="px-4 pb-4 lg:px-8">
+                                    like a preregistration platform: publish your research problem, hypotheses, methods
+                                    before you collect data
+                                </td>
+                                <td className="px-4 pb-4 lg:px-8">
+                                    every publication is linked to another to form a chain, making work findable and
+                                    useful
+                                </td>
+                            </tr>
+                            <tr>
+                                <td className="px-4 pb-8 pt-4 lg:px-8">
+                                    a bit like a repository or OSF: free to publish work of all kinds, each with their
+                                    own DOI
+                                </td>
+                                <td className="px-4 pb-8 pt-4 lg:px-8">
+                                    you can then get peer review on publications before you collect data
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </section>
+                <section className="container mx-auto px-8 pt-20 text-center">
                     <h2 className="mb-8 font-montserrat text-xl font-semibold text-grey-800 transition-colors duration-500 dark:text-white-100 lg:text-3xl">
                         Research Culture Report
                     </h2>
@@ -84,7 +148,7 @@ const Home: Types.NextPage = (props): React.ReactElement => {
                         </span>
                     </Components.Link>
                 </section>
-                <section className="container mx-auto px-8">
+                <section className="container mx-auto px-8 pt-20">
                     <div className="grid grid-cols-1 gap-8 lg:grid-cols-2 lg:gap-12 2xl:grid-cols-3">
                         <Components.ActionCard
                             title="Publish your work"

--- a/ui/src/pages/user-terms.tsx
+++ b/ui/src/pages/user-terms.tsx
@@ -55,7 +55,7 @@ const UserTerms: NextPage = (): React.ReactElement => (
             <PageSection>
                 <>
                     <div className="mx-auto block lg:w-9/12 xl:w-10/12 2xl:w-7/12">
-                        <h1 className="mb-10 mt-5 block text-center font-montserrat text-3xl font-black !leading-tight tracking-tight text-grey-700 transition-colors duration-500 dark:text-white-50 lg:text-5xl">
+                        <h1 className="mb-10 mt-5 block text-center font-montserrat text-3xl font-bold !leading-tight tracking-tight text-grey-700 transition-colors duration-500 dark:text-white-50 lg:text-5xl">
                             Octopus platform user terms
                         </h1>
                         <StandardText>
@@ -610,7 +610,7 @@ const UserTerms: NextPage = (): React.ReactElement => (
                                 </li>
                             </ul>
                         </StandardText>
-                        <h1 className="my-12 block text-center font-montserrat text-3xl font-black !leading-tight tracking-tight text-grey-700 transition-colors duration-500 dark:text-white-50 lg:text-4xl">
+                        <h1 className="my-12 block text-center font-montserrat text-3xl font-bold !leading-tight tracking-tight text-grey-700 transition-colors duration-500 dark:text-white-50 lg:text-4xl">
                             OCTOPUS PLATFORM USER TERMS: SCHEDULE 1 - DATA PROCESSING
                         </h1>
                         <Components.PageSubTitle text="1. DEFINITIONS AND INTERPRETATION" />
@@ -1012,7 +1012,7 @@ const UserTerms: NextPage = (): React.ReactElement => (
                                 </div>
                             </div>
                         </StandardText>
-                        <h1 className="my-12 block text-center font-montserrat text-3xl font-black !leading-tight tracking-tight text-grey-700 transition-colors duration-500 dark:text-white-50 lg:text-4xl">
+                        <h1 className="my-12 block text-center font-montserrat text-3xl font-bold !leading-tight tracking-tight text-grey-700 transition-colors duration-500 dark:text-white-50 lg:text-4xl">
                             OCTOPUS PLATFORM USER TERMS SCHEDULE 1: ANNEX A
                         </h1>
                         <StandardText asDiv={true}>
@@ -1054,7 +1054,7 @@ const UserTerms: NextPage = (): React.ReactElement => (
                             <br />
                             <br />
                         </StandardText>
-                        <h1 className="my-12 block text-center font-montserrat text-3xl font-black !leading-tight tracking-tight text-grey-700 transition-colors duration-500 dark:text-white-50 lg:text-4xl">
+                        <h1 className="my-12 block text-center font-montserrat text-3xl font-bold !leading-tight tracking-tight text-grey-700 transition-colors duration-500 dark:text-white-50 lg:text-4xl">
                             OCTOPUS PLATFORM USER TERMS SCHEDULE 1: ANNEX B
                         </h1>
                         <Components.PageSubTitle text="Appointed Sub-contractors" />


### PR DESCRIPTION
The purpose of this PR was to change the content on the home page so that users can see a quick and easy to understand summary of what Octopus is when they visit the site for the first time.

---

### Acceptance Criteria:

- New copy is present on the front page:
    - A heading of “Free, fast and fair” in large bold text
    - Below the heading, text is present reading (with linebreaks):
        - The place for researchers to publish their work in full detail. Funded by UKRI – the UK government research funder.
        - Octopus is a free scholarly publication platform designed to make it easier to share work of all kinds. A place for open peer review, quality assessment, and collaboration.
        - Work on Octopus is not published as ‘papers’ or ‘monographs’ but in smaller units which are linked together.
        - To see an example chain of Octopus publications have a look at this one, which looks at the current research culture.
            - “this one” is a link to [How can we overcome the barriers to researchers producing high qual...](https://www.octopus.ac/publications/axc8-vs07/versions/latest) 
    - Below this text, the three buttons for “Learn More”, “Author Guide” and “Find publications” are present.
    - Below the three buttons, a two column table is present, with copy defined in a PDF available on the ticket.
        - Each sentence in the left column is linked in some way with the sentence in the right column

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
<img width="261" alt="Screenshot 2024-03-25 160846" src="https://github.com/JiscSD/octopus/assets/132363734/e51c8f50-5b04-43b1-b88f-f59170ba2c63">

E2E
<img width="107" alt="Screenshot 2024-03-25 160630" src="https://github.com/JiscSD/octopus/assets/132363734/84967dd1-396e-4f34-b1a4-1d7397e96814">

---

### Screenshots:

Page - dark mode
<img width="1256" alt="Screenshot 2024-03-25 151037" src="https://github.com/JiscSD/octopus/assets/132363734/fc5bce0c-fb5f-4f03-8ceb-9d2ab545dc7a">

Page - light mode
<img width="1259" alt="Screenshot 2024-03-25 151048" src="https://github.com/JiscSD/octopus/assets/132363734/a657d69e-064b-47e6-92fa-72db89b49a73">

Table - small viewport
<img width="440" alt="Screenshot 2024-03-25 151024" src="https://github.com/JiscSD/octopus/assets/132363734/18b45c0e-1113-4dfe-adcb-d26dbb93e49d">
