### PR TITLE
Corrections to OC-820

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -55,6 +55,7 @@
                 "lint-staged": "^13.3.0",
                 "nodemon": "^2.0.22",
                 "prettier": "^2.8.8",
+                "prisma": "^5.11.0",
                 "puppeteer": "^20.9.0",
                 "serverless-domain-manager": "^7.1.2",
                 "serverless-offline": "^12.0.4",
@@ -7553,13 +7554,50 @@
                 }
             }
         },
+        "node_modules/@prisma/debug": {
+            "version": "5.11.0",
+            "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.11.0.tgz",
+            "integrity": "sha512-N6yYr3AbQqaiUg+OgjkdPp3KPW1vMTAgtKX6+BiB/qB2i1TjLYCrweKcUjzOoRM5BriA4idrkTej9A9QqTfl3A==",
+            "devOptional": true
+        },
         "node_modules/@prisma/engines": {
-            "version": "4.14.1",
-            "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.14.1.tgz",
-            "integrity": "sha512-APqFddPVHYmWNKqc+5J5SqrLFfOghKOLZxobmguDUacxOwdEutLsbXPVhNnpFDmuQWQFbXmrTTPoRrrF6B1MWA==",
+            "version": "5.11.0",
+            "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.11.0.tgz",
+            "integrity": "sha512-gbrpQoBTYWXDRqD+iTYMirDlF9MMlQdxskQXbhARhG6A/uFQjB7DZMYocMQLoiZXO/IskfDOZpPoZE8TBQKtEw==",
+            "devOptional": true,
             "hasInstallScript": true,
-            "optional": true,
-            "peer": true
+            "dependencies": {
+                "@prisma/debug": "5.11.0",
+                "@prisma/engines-version": "5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102",
+                "@prisma/fetch-engine": "5.11.0",
+                "@prisma/get-platform": "5.11.0"
+            }
+        },
+        "node_modules/@prisma/engines-version": {
+            "version": "5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102",
+            "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102.tgz",
+            "integrity": "sha512-WXCuyoymvrS4zLz4wQagSsc3/nE6CHy8znyiMv8RKazKymOMd5o9FP5RGwGHAtgoxd+aB/BWqxuP/Ckfu7/3MA==",
+            "devOptional": true
+        },
+        "node_modules/@prisma/fetch-engine": {
+            "version": "5.11.0",
+            "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.11.0.tgz",
+            "integrity": "sha512-994viazmHTJ1ymzvWugXod7dZ42T2ROeFuH6zHPcUfp/69+6cl5r9u3NFb6bW8lLdNjwLYEVPeu3hWzxpZeC0w==",
+            "devOptional": true,
+            "dependencies": {
+                "@prisma/debug": "5.11.0",
+                "@prisma/engines-version": "5.11.0-15.efd2449663b3d73d637ea1fd226bafbcf45b3102",
+                "@prisma/get-platform": "5.11.0"
+            }
+        },
+        "node_modules/@prisma/get-platform": {
+            "version": "5.11.0",
+            "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.11.0.tgz",
+            "integrity": "sha512-rxtHpMLxNTHxqWuGOLzR2QOyQi79rK1u1XYAVLZxDGTLz/A+uoDnjz9veBFlicrpWjwuieM4N6jcnjj/DDoidw==",
+            "devOptional": true,
+            "dependencies": {
+                "@prisma/debug": "5.11.0"
+            }
         },
         "node_modules/@puppeteer/browsers": {
             "version": "1.4.6",
@@ -17937,21 +17975,19 @@
             }
         },
         "node_modules/prisma": {
-            "version": "4.14.1",
-            "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.14.1.tgz",
-            "integrity": "sha512-z6hxzTMYqT9SIKlzD08dhzsLUpxjFKKsLpp5/kBDnSqiOjtUyyl/dC5tzxLcOa3jkEHQ8+RpB/fE3w8bgNP51g==",
+            "version": "5.11.0",
+            "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.11.0.tgz",
+            "integrity": "sha512-KCLiug2cs0Je7kGkQBN9jDWoZ90ogE/kvZTUTgz2h94FEo8pczCkPH7fPNXkD1sGU7Yh65risGGD1HQ5DF3r3g==",
+            "devOptional": true,
             "hasInstallScript": true,
-            "optional": true,
-            "peer": true,
             "dependencies": {
-                "@prisma/engines": "4.14.1"
+                "@prisma/engines": "5.11.0"
             },
             "bin": {
-                "prisma": "build/index.js",
-                "prisma2": "build/index.js"
+                "prisma": "build/index.js"
             },
             "engines": {
-                "node": ">=14.17"
+                "node": ">=16.13"
             }
         },
         "node_modules/process-nextick-args": {

--- a/api/package.json
+++ b/api/package.json
@@ -75,6 +75,7 @@
         "lint-staged": "^13.3.0",
         "nodemon": "^2.0.22",
         "prettier": "^2.8.8",
+        "prisma": "^5.11.0",
         "puppeteer": "^20.9.0",
         "serverless-domain-manager": "^7.1.2",
         "serverless-offline": "^12.0.4",

--- a/ui/src/components/Publication/Creation/LinkedItems/LinkedPublicationsCombobox.tsx
+++ b/ui/src/components/Publication/Creation/LinkedItems/LinkedPublicationsCombobox.tsx
@@ -152,8 +152,8 @@ const LinkedPublicationsCombobox: React.FC<LinkedPublicationsComboboxProps> = (p
                                                     hasFlagAndPeerReview
                                                         ? 'sm:w-1/2'
                                                         : hasOneOfFlagOrPeerReview
-                                                        ? 'sm:w-3/4'
-                                                        : ''
+                                                          ? 'sm:w-3/4'
+                                                          : ''
                                                 }`}
                                             >
                                                 <span className="text-xs leading-none text-grey-700">


### PR DESCRIPTION
The purpose of this PR was to fix a couple of issues preventing deployment after the merge of #624 :
- Prisma CLI package was in package-lock but not package.json, and the version didn't match the client version, causing a warning
- A whitespace difference found its way into main branch that prettier is flagging as an issue