### PR TITLE
Further correction to OC-820

### DIFF
--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -101,6 +101,7 @@ custom:
                 - '@aws-sdk/client-ses'
                 - '@aws-sdk/client-sqs'
                 - 'puppeteer'
+                - 'prisma'
         packager: 'npm'
     versions:
         v1: v1


### PR DESCRIPTION
Prisma needs to be excluded from the serverless webpack build, otherwise an error happens on deploy.

This isn't an immediate blocker because we can correct it ad-hoc at deployment time, but needs to be in the codebase.