### PR TITLE
OC-789: Require name visibility to create publications, publish, confirm involvement and red flag

### DIFF
--- a/api/prisma/seeds/users.ts
+++ b/api/prisma/seeds/users.ts
@@ -100,6 +100,15 @@ const userSeeds: Prisma.UserCreateInput[] = [
         email: 'test-user-10@jisc.ac.uk',
         locked: false,
         apiKey: '000000010'
+    },
+    {
+        id: 'test-user-11',
+        orcid: '0000-0000-0000-0011',
+        firstName: '',
+        lastName: '',
+        email: 'test-user-11@jisc.ac.uk',
+        locked: false,
+        apiKey: '000000011'
     }
 ];
 

--- a/api/src/components/authorization/__tests__/authorization.test.ts
+++ b/api/src/components/authorization/__tests__/authorization.test.ts
@@ -1,0 +1,23 @@
+import * as testUtils from 'lib/testUtils';
+
+describe('Authorization tests', () => {
+    beforeAll(async () => {
+        await testUtils.clearDB();
+        await testUtils.testSeed();
+    });
+
+    test('User without firstName or lastName cannot use an endpoint that requires a name', async () => {
+        const createPublicationRequest = await testUtils.agent
+            .post('/publications')
+            .query({ apiKey: '000000011' })
+            .send({
+                type: 'PROBLEM',
+                title: 'My anonymous publication'
+            });
+
+        expect(createPublicationRequest.status).toEqual(403);
+        expect(createPublicationRequest.body.message).toEqual(
+            'No name detected. Please ensure your name visibility is set to "Everyone" or "Trusted parties" on your ORCiD account, then re-authorize at /authorization.'
+        );
+    });
+});

--- a/api/src/components/authorization/controller.ts
+++ b/api/src/components/authorization/controller.ts
@@ -87,9 +87,12 @@ export const authorize = async (event: I.APIRequest<I.AuthorizeRequestBody>): Pr
             console.log(error);
         }
 
+        const existingUser = await userService.getByOrcid(orcidUserId);
+
+        // If names aren't visible on orcid record and we have previously saved values, keep those.
         const user = await userService.upsertUser(orcidUserId, {
-            firstName: userInformation?.person?.name?.['given-names']?.value || '',
-            lastName: userInformation?.person?.name?.['family-name']?.value || '',
+            firstName: userInformation?.person?.name?.['given-names']?.value || existingUser?.firstName || '',
+            lastName: userInformation?.person?.name?.['family-name']?.value || existingUser?.lastName || '',
             employment,
             education,
             works,

--- a/api/src/components/authorization/routes.ts
+++ b/api/src/components/authorization/routes.ts
@@ -12,12 +12,12 @@ export const authorize = middy(authorizationController.authorize)
 
 export const getDecodedUserToken = middy(authorizationController.getDecodedUserToken)
     .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))
-    .use(middleware.authentication());
+    .use(middleware.authentication(false, false));
 
 export const verifyOrcidAccess = middy(authorizationController.verifyOrcidAccess)
     .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))
-    .use(middleware.authentication());
+    .use(middleware.authentication(false, false));
 
 export const revokeOrcidAccess = middy(authorizationController.revokeOrcidAccess)
     .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))
-    .use(middleware.authentication());
+    .use(middleware.authentication(false, false));

--- a/api/src/components/crosslink/routes.ts
+++ b/api/src/components/crosslink/routes.ts
@@ -18,13 +18,13 @@ export const deleteCrosslink = middy(crosslinkController.deleteCrosslink)
 export const setVote = middy(crosslinkController.setVote)
     .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))
     .use(middleware.httpJsonBodyParser())
-    .use(middleware.authentication())
+    .use(middleware.authentication(false, false))
     .use(middleware.validator(crosslinkSchema.setVote, 'body'));
 
 export const resetVote = middy(crosslinkController.resetVote)
     .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))
     .use(middleware.httpJsonBodyParser())
-    .use(middleware.authentication());
+    .use(middleware.authentication(false, false));
 
 export const get = middy(crosslinkController.get)
     .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))
@@ -33,7 +33,7 @@ export const get = middy(crosslinkController.get)
 export const getVote = middy(crosslinkController.getVote)
     .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))
     .use(middleware.httpJsonBodyParser())
-    .use(middleware.authentication());
+    .use(middleware.authentication(false, false));
 
 export const getPublicationCrosslinks = middy(crosslinkController.getPublicationCrosslinks)
     .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))

--- a/api/src/components/user/service.ts
+++ b/api/src/components/user/service.ts
@@ -47,12 +47,11 @@ export const updateEmail = (orcid: string, email: string) =>
     });
 
 export const getAll = async (filters: I.UserFilters) => {
-    const query = {};
+    let where: Prisma.UserWhereInput = {};
 
     if (filters.search) {
         const searchQuery = helpers.sanitizeSearchQuery(filters.search);
-        // @ts-ignore
-        query.where = {
+        where = {
             firstName: {
                 search: searchQuery
             },
@@ -60,16 +59,24 @@ export const getAll = async (filters: I.UserFilters) => {
                 search: searchQuery
             }
         };
+    } else {
+        where = {
+            firstName: {
+                not: ''
+            },
+            lastName: {
+                not: ''
+            }
+        };
     }
 
-    // @ts-ignore
     const users = await client.prisma.user.findMany({
         take: Number(filters.limit) || 10,
         skip: Number(filters.offset) || 0,
         orderBy: {
             [filters.orderBy || 'updatedAt']: filters.orderDirection || 'desc'
         },
-        ...query,
+        where,
         select: {
             id: true,
             firstName: true,
@@ -79,8 +86,7 @@ export const getAll = async (filters: I.UserFilters) => {
         }
     });
 
-    // @ts-ignore
-    const totalUsers = await client.prisma.user.count(query);
+    const totalUsers = await client.prisma.user.count({ where });
 
     return {
         data: users,
@@ -96,6 +102,13 @@ export const getByApiKey = (apiKey: string) =>
     client.prisma.user.findFirst({
         where: {
             apiKey
+        }
+    });
+
+export const getByOrcid = (orcid: string) =>
+    client.prisma.user.findFirst({
+        where: {
+            orcid
         }
     });
 

--- a/ui/src/__tests__/pages/verify.test.tsx
+++ b/ui/src/__tests__/pages/verify.test.tsx
@@ -55,7 +55,7 @@ describe('Verify email tests', () => {
     });
 
     it('Error alert is not rendered initially', () => {
-        expect(screen.queryByTestId('alert-box')).not.toBeInTheDocument();
+        expect(screen.queryByText('Please enter a valid email address')).not.toBeInTheDocument();
     });
 
     it('Error alert appears when invalid email is entered into input field', () => {
@@ -63,7 +63,7 @@ describe('Verify email tests', () => {
         const sendInviteButton = screen.getByTitle('Send code');
         fireEvent.change(emailInput, { target: { value: 'invalidemail.com' } });
         fireEvent.click(sendInviteButton);
-        expect(screen.getByTestId('alert-box')).toBeInTheDocument();
+        expect(screen.getByText('Please enter a valid email address')).toBeInTheDocument();
     });
 
     it('Alert is removed on invalid email when input is changed', () => {
@@ -71,9 +71,9 @@ describe('Verify email tests', () => {
         const sendInviteButton = screen.getByTitle('Send code');
         fireEvent.change(emailInput, { target: { value: 'invalidemail.com' } });
         fireEvent.click(sendInviteButton);
-        expect(screen.getByTestId('alert-box')).toBeInTheDocument();
+        expect(screen.getByText('Please enter a valid email address')).toBeInTheDocument();
 
         fireEvent.change(emailInput, { target: { value: 'valid@email.com' } });
-        expect(screen.queryByTestId('alert-box')).not.toBeInTheDocument();
+        expect(screen.queryByText('Please enter a valid email address')).not.toBeInTheDocument();
     });
 });

--- a/ui/src/components/Avatar/index.tsx
+++ b/ui/src/components/Avatar/index.tsx
@@ -7,13 +7,14 @@ type Props = {
     className?: string;
 };
 
+// Render a circle with the user's initials, or AU (Anonymous User) if their names are hidden at orcid level.
 const Avatar: React.FC<Props> = (props): React.ReactElement => (
     <div
         className={`flex h-12 w-12 items-center justify-center rounded-full border-2 border-teal-500 font-montserrat font-semibold leading-none tracking-tighter text-grey-800 transition-colors duration-500 dark:text-white-50 ${
             props.className ? props.className : ''
         }`}
     >
-        {props.user.firstName[0]} {props.user.lastName[0]}
+        {!props.user.firstName && !props.user.lastName ? 'AU' : `${props.user.firstName[0]} ${props.user.lastName[0]}`}
     </div>
 );
 

--- a/ui/src/components/Header/index.tsx
+++ b/ui/src/components/Header/index.tsx
@@ -17,6 +17,10 @@ const Header: React.FC<Props> = (props): React.ReactElement => {
     const isDarkMode = Stores.usePreferencesStore((state) => state.darkMode);
     const router = NextRouter.useRouter();
 
+    const showConfirmEmailBanner = user && !user?.email && router.pathname !== Config.urls.verify.path;
+    const showMissingNamesBanner =
+        user && !user?.firstName && !user?.lastName && router.pathname !== Config.urls.verify.path;
+
     return (
         <>
             <Components.Banner>
@@ -34,15 +38,18 @@ const Header: React.FC<Props> = (props): React.ReactElement => {
                 </Components.Link>
             </Components.Banner>
             {/* Confirm email banner */}
-            {user && !user?.email && router.pathname !== Config.urls.verify.path && (
+            {(showConfirmEmailBanner || showMissingNamesBanner) && (
                 <div className="bg-yellow-200 text-sm text-grey-800 dark:bg-yellow-500">
                     <div className="container mx-auto flex items-center gap-2 px-8 py-3">
                         <OutlineIcons.ExclamationCircleIcon className="h-5 w-5 text-grey-800" />
                         <Components.Link
-                            href={`${Config.urls.verify.path}`}
-                            className="w-fit underline decoration-2 underline-offset-4"
+                            href={showConfirmEmailBanner ? Config.urls.verify.path : Config.urls.orcidAccountPage.path}
+                            className="w-fit underline underline-offset-4"
+                            openNew={true}
                         >
-                            Please confirm your email address to publish content
+                            {showConfirmEmailBanner
+                                ? 'Please confirm your email address to be able to publish content.'
+                                : 'Your name is not visible on your ORCiD account. Please change this setting to "Everyone" or "Trusted parties" to be able to publish content.'}
                         </Components.Link>
                     </div>
                 </div>

--- a/ui/src/components/Nav/index.tsx
+++ b/ui/src/components/Nav/index.tsx
@@ -103,7 +103,7 @@ const Nav: React.FC = (): React.ReactElement => {
 
         if (user) {
             menuItems.push({
-                label: `${user?.firstName} ${user?.lastName}`,
+                label: user.firstName || user.lastName ? `${user?.firstName} ${user?.lastName}` : 'Anonymous User',
                 value: `${Config.urls.viewUser.path}/${user.id}`,
                 dataTestId: 'username-button',
                 subItems: [

--- a/ui/src/components/Publication/SidebarCard/Actions/index.tsx
+++ b/ui/src/components/Publication/SidebarCard/Actions/index.tsx
@@ -188,7 +188,26 @@ const Actions: React.FC<ActionProps> = (props): React.ReactElement => {
                         </button>
                     </div>
                     {props.publicationVersion.isLatestLiveVersion ? (
-                        user && user.email ? (
+                        user && !user.email ? (
+                            <>
+                                <Components.Link
+                                    href={`${Config.urls.verify.path}?state=${encodeURIComponent(
+                                        `${Config.urls.viewPublication.path}/${props.publicationVersion.versionOf}`
+                                    )}`}
+                                    className="flex items-center rounded border-transparent text-sm font-medium text-teal-600 outline-0 transition-colors duration-500 hover:underline focus:overflow-hidden focus:ring-2 focus:ring-yellow-400 dark:text-teal-400"
+                                >
+                                    Verify your email for more actions
+                                </Components.Link>
+                            </>
+                        ) : user && !(user.firstName || user.lastName) ? (
+                            <Components.Link
+                                href={Config.urls.orcidAccountPage.path}
+                                className="flex items-center rounded border-transparent text-sm font-medium text-teal-600 outline-0 transition-colors duration-500 hover:underline focus:overflow-hidden focus:ring-2 focus:ring-yellow-400 dark:text-teal-400"
+                                openNew={true}
+                            >
+                                Make your name visible on your ORCiD profile for more actions
+                            </Components.Link>
+                        ) : user && user.email ? (
                             <>
                                 {/* if the publication is a peer review, no options shall be given to write a linked publication */}
                                 {props.publicationVersion.publication.type !== 'PEER_REVIEW' && (
@@ -235,17 +254,6 @@ const Actions: React.FC<ActionProps> = (props): React.ReactElement => {
                                         )}
                                     </>
                                 )}
-                            </>
-                        ) : user && !user.email ? (
-                            <>
-                                <Components.Link
-                                    href={`${Config.urls.verify.path}?state=${encodeURIComponent(
-                                        `${Config.urls.viewPublication.path}/${props.publicationVersion.versionOf}`
-                                    )}`}
-                                    className="flex items-center rounded border-transparent text-sm font-medium text-teal-600 outline-0 transition-colors duration-500 hover:underline focus:overflow-hidden focus:ring-2 focus:ring-yellow-400 dark:text-teal-400"
-                                >
-                                    Verify your email for more actions
-                                </Components.Link>
                             </>
                         ) : (
                             <>

--- a/ui/src/config/urls.ts
+++ b/ui/src/config/urls.ts
@@ -246,6 +246,9 @@ const urls = {
         keywords: '',
         canonical: `${base.host}/login`
     },
+    orcidAccountPage: {
+        path: 'https://orcid.org/my-orcid'
+    },
     orcidLogin: {
         path: `${orcidAuthUrl}/authorize?client_id=${orcidAppId}&response_type=code&scope=openid%20/read-limited&prompt=login&redirect_uri=${base.host}/login`
     },

--- a/ui/src/lib/helpers.tsx
+++ b/ui/src/lib/helpers.tsx
@@ -523,15 +523,25 @@ export const withServerSession = (
             };
         }
 
-        const { email } = decodedToken;
+        const { email, firstName, lastName } = decodedToken;
         const isVerifyEmailPage = resolvedUrl.startsWith(Config.urls.verify.path);
+        const isHomePage = context.req.url === '/';
 
-        // Only allow users with a verified email to access protected routes
+        // Only allow users with a verified email and visible name to access protected routes
         if (!email && !isVerifyEmailPage) {
             // redirect to /verify page
             return {
                 redirect: {
                     destination: `${Config.urls.verify.path}?state=${encodeURIComponent(resolvedUrl)}`,
+                    permanent: false
+                }
+            };
+        }
+        if (!(firstName || lastName) && !isHomePage) {
+            // redirect to home page
+            return {
+                redirect: {
+                    destination: `${Config.urls.home.path}`,
                     permanent: false
                 }
             };

--- a/ui/src/pages/authors/[id]/index.tsx
+++ b/ui/src/pages/authors/[id]/index.tsx
@@ -89,6 +89,7 @@ const Author: Types.NextPage<Props> = (props): React.ReactElement => {
         }
     );
 
+    const missingNames = !props.user.firstName && !props.user.lastName;
     const userPublications = useMemo(() => data?.map((data) => data.results).flat() || [], [data]);
 
     const pageTitle = `Author: ${props.user.orcid} - ${Config.urls.viewUser.title}`;
@@ -107,7 +108,7 @@ const Author: Types.NextPage<Props> = (props): React.ReactElement => {
                     <div className="mb-8 flex items-center">
                         <Components.Avatar user={props.user} className="text-xl lg:h-16 lg:w-16" />
                         <h1 className="ml-4 block font-montserrat text-2xl font-bold leading-tight text-grey-800 transition-colors duration-500 dark:text-white-50 md:text-3xl xl:text-3xl xl:leading-tight">
-                            {props.user.firstName} {props.user.lastName}
+                            {missingNames ? 'Anonymous User' : `${props.user.firstName} ${props.user.lastName}`}
                         </h1>
                     </div>
                     <div className="font-montserrat text-lg font-medium text-grey-800 transition-colors duration-500 dark:text-white-50">

--- a/ui/src/pages/publications/[id]/versions/[versionId].tsx
+++ b/ui/src/pages/publications/[id]/versions/[versionId].tsx
@@ -154,6 +154,8 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
     const [isEditingAffiliations, setIsEditingAffiliations] = React.useState(false);
     const [isUnlocking, setIsUnlocking] = React.useState(false);
 
+    const isVerifiedWithName = user?.email && (user.firstName || user.lastName);
+
     useEffect(() => {
         setBookmarkId(props.bookmarkId);
     }, [props.bookmarkId, props.publicationId]);
@@ -195,7 +197,8 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
     );
 
     const { data: controlRequests = [], isLoading: isLoadingControlRequests } = useSWR<Interfaces.ControlRequest[]>(
-        user ? `${Config.endpoints.users}/me/control-requests` : null
+        // Only bother fetching if user is verified
+        isVerifiedWithName ? `${Config.endpoints.users}/me/control-requests` : null
     );
 
     const hasAlreadyRequestedControl = controlRequests.some(
@@ -213,7 +216,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
     // Problems linked from this publication (shown on any type)
     const childProblems = linkedFrom.filter((link) => link.type === 'PROBLEM');
 
-    const isBookmarkButtonVisible = user && publicationVersion?.currentStatus === 'LIVE';
+    const isBookmarkButtonVisible = isVerifiedWithName && publicationVersion?.currentStatus === 'LIVE';
 
     const list = [];
 

--- a/ui/src/pages/verify.tsx
+++ b/ui/src/pages/verify.tsx
@@ -40,6 +40,8 @@ const Verify: Types.NextPage<Props> = (props): React.ReactElement => {
     const [success, setSuccess] = React.useState(false);
     const [emailValidated, setEmailValidated] = React.useState(true);
 
+    const missingNames = !user?.firstName && !user?.lastName;
+
     const handleEmailChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
         setEmailValidated(true);
         setEmail(event.target.value);
@@ -164,11 +166,26 @@ const Verify: Types.NextPage<Props> = (props): React.ReactElement => {
                         no longer wish to hold an account. You can update your email address at any time from your user
                         account page.
                     </p>
+                    {missingNames && (
+                        <Components.Alert
+                            severity="ERROR"
+                            title="Names are not visible on ORCiD account"
+                            details={[
+                                'Please set your name visibility to "Everyone" or "Trusted parties" on your ORCiD account, log out of Octopus, then log back in again to continue.'
+                            ]}
+                            supportLink={{
+                                text: 'ORCiD account page',
+                                url: Config.urls.orcidAccountPage.path,
+                                external: true
+                            }}
+                            className="mb-6"
+                        />
+                    )}
                     <form className="flex-column gap-4 space-y-6" data-testid="update-email-form">
                         {!!error && <Components.Alert severity="ERROR" title={error} />}
                         <label htmlFor="fullName" className="flex flex-col gap-1">
-                            <span className="mb-1 flex items-center gap-1 text-xxs font-bold uppercase tracking-widest text-grey-600 transition-colors duration-500 dark:text-grey-300">
-                                <SolidIcons.CheckBadgeIcon className="h-5 w-5 text-green-400" />
+                            <span className="mb-1 flex items-center gap-1 text-xxs font-bold uppercase tracking-widest text-grey-700 transition-colors duration-500 dark:text-grey-300">
+                                <SolidIcons.CheckBadgeIcon className="h-5 w-5 text-green-600 dark:text-green-400" />
                                 Your ORCID iD
                             </span>
                             <input
@@ -181,7 +198,11 @@ const Verify: Types.NextPage<Props> = (props): React.ReactElement => {
                         </label>
                         <label htmlFor="fullName" className="flex flex-col gap-1">
                             <span className="mb-1 flex items-center gap-1 text-xxs font-bold uppercase tracking-widest text-grey-700 transition-colors duration-500 dark:text-grey-300">
-                                <SolidIcons.CheckBadgeIcon className="h-5 w-5 text-green-400" />
+                                {missingNames ? (
+                                    <SolidIcons.ExclamationCircleIcon className="h-5 w-5 text-red-600 dark:text-red-400" />
+                                ) : (
+                                    <SolidIcons.CheckBadgeIcon className="h-5 w-5 text-green-600 dark:text-green-400" />
+                                )}
                                 Your name
                             </span>
                             <input
@@ -202,7 +223,7 @@ const Verify: Types.NextPage<Props> = (props): React.ReactElement => {
                             leaveTo="opacity-0"
                         >
                             <label htmlFor="email" className="mb-4 flex flex-col gap-1">
-                                <span className="mb-1 flex items-center gap-1 text-xxs font-bold uppercase tracking-widest text-grey-700 transition-colors duration-500 dark:text-grey-100">
+                                <span className="mb-1 flex items-center gap-1 text-xxs font-bold uppercase tracking-widest text-grey-700 transition-colors duration-500 dark:text-grey-300">
                                     <SolidIcons.QuestionMarkCircleIcon className="h-5 w-5 text-teal-700 dark:text-teal-400" />
                                     Your{!props.newUser && ' new'} email address
                                 </span>
@@ -215,7 +236,7 @@ const Verify: Types.NextPage<Props> = (props): React.ReactElement => {
                                     onChange={handleEmailChange}
                                     disabled={loading}
                                 />
-                                <span className="mt-1 flex items-center gap-1 text-xs font-semibold tracking-widest text-grey-500 transition-colors duration-500 dark:text-grey-300">
+                                <span className="mt-1 flex items-center gap-1 text-xs font-semibold tracking-widest text-grey-700 transition-colors duration-500 dark:text-grey-300">
                                     Please confirm your{!props.newUser && ' new'} email address.
                                 </span>
                                 {!emailValidated && (
@@ -291,7 +312,7 @@ const Verify: Types.NextPage<Props> = (props): React.ReactElement => {
                                     leaveFrom="opacity-100"
                                     leaveTo="opacity-0"
                                 >
-                                    <OutlineIcons.CheckBadgeIcon className="h-5 w-5 text-green-400 transition-colors duration-500" />
+                                    <OutlineIcons.CheckBadgeIcon className="h-5 w-5 text-green-600 transition-colors duration-500 dark:text-green-400" />
                                 </HeadlessUI.Transition>
                             </span>
                             <div className="mt-4 text-xs font-medium leading-relaxed text-grey-500 transition-colors duration-500 dark:text-grey-300">


### PR DESCRIPTION
The purpose of this PR was to ensure that users have a value for firstName and lastName before they are allowed to make actions that associate them with data in Octopus. Users can set visibility of their name in ORCiD to "only me", which means octopus can't access it.

---

### Acceptance Criteria:
- When a user red flags, creates a new publication, publishes, confirms involvement, or approves, if Octopus cannot detect a name for that user, the request is rejected
- Every time a user logs in, their current name is saved against their Octopus account if it can be found on their ORCiD profile.
    - If Octopus is unable to find a name from the user’s ORCiD profile in future, the saved name is used instead.
        - For example, for displaying on author lists, their profile page, red flag records, data sent to datacite, etc.
- On the author search, if the user has no name, they are omitted from author search results
---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
![Screenshot 2024-03-27 103820](https://github.com/JiscSD/octopus/assets/132363734/c2f2d5c1-de7a-4f00-bd7c-b4187edc4f8e)

API
![Screenshot 2024-03-27 104711](https://github.com/JiscSD/octopus/assets/132363734/bf6caf17-f414-4692-92bb-aee95b2476e2)

E2E
![Screenshot 2024-03-27 150322](https://github.com/JiscSD/octopus/assets/132363734/ca5d78c8-2528-45b1-bbf8-f8f8f5668385)

