### PR TITLE
OC-324: Implement Content Security Policy (CSP)

### DIFF
--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -1,4 +1,18 @@
 /** @type {import('next').NextConfig} */
+const CSPDirectives = [
+    "default-src 'self';",
+    "script-src 'self' 'unsafe-eval' 'unsafe-inline';",
+    "style-src 'self' 'unsafe-inline';",
+    `connect-src 'self' *.api.octopus.ac http://127.0.0.1:4003 https://api.octopus.ac https://api.ror.org https://cdn.contentful.com;`,
+    'img-src https:;',
+    'media-src https://octopus-promo-video.s3.eu-west-1.amazonaws.com https://www.youtube.com;',
+    "font-src 'self';",
+    "object-src 'none';",
+    "base-uri 'self';",
+    "form-action 'self';",
+    "frame-ancestors 'none';",
+    'upgrade-insecure-requests;'
+];
 const nextConfig = {
     reactStrictMode: true,
 
@@ -13,6 +27,19 @@ const nextConfig = {
                 source: '/documentation/api',
                 destination: 'https://jiscsd.github.io/octopus',
                 permanent: true
+            }
+        ];
+    },
+    async headers() {
+        return [
+            {
+                source: '/(.*)',
+                headers: [
+                    {
+                        key: 'Content-Security-Policy',
+                        value: CSPDirectives.join(' ')
+                    }
+                ]
             }
         ];
     }

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -1,18 +1,48 @@
 /** @type {import('next').NextConfig} */
 const CSPDirectives = [
-    "default-src 'self';",
-    "script-src 'self' 'unsafe-eval' 'unsafe-inline';",
+    "default-src 'none';",
+    `script-src 'self' ${process.env.NODE_ENV === 'development' ? "'unsafe-eval'" : ''};`,
     "style-src 'self' 'unsafe-inline';",
-    `connect-src 'self' *.api.octopus.ac http://127.0.0.1:4003 https://api.octopus.ac https://api.ror.org https://cdn.contentful.com;`,
-    'img-src https:;',
+    `connect-src 'self' https://*.api.octopus.ac http://127.0.0.1:4003 https://api.octopus.ac https://api.ror.org https://cdn.contentful.com;`,
+    'img-src https: data:;',
     'media-src https://octopus-promo-video.s3.eu-west-1.amazonaws.com https://www.youtube.com;',
     "font-src 'self';",
     "object-src 'none';",
     "base-uri 'self';",
     "form-action 'self';",
     "frame-ancestors 'none';",
-    'upgrade-insecure-requests;'
+    'upgrade-insecure-requests;',
+    "manifest-src 'self';",
+    'frame-src https://www.youtube.com'
 ];
+
+const securityHeaders = [
+    {
+        key: 'X-DNS-Prefetch-Control',
+        value: 'on'
+    },
+    {
+        key: 'Strict-Transport-Security',
+        value: 'max-age=31536000 ; includeSubDomains'
+    },
+    {
+        key: 'X-Frame-Options',
+        value: 'DENY'
+    },
+    {
+        key: 'X-Content-Type-Options',
+        value: 'nosniff'
+    },
+    {
+        key: 'Referrer-Policy',
+        value: 'no-referrer-when-downgrade'
+    },
+    {
+        key: 'Content-Security-Policy',
+        value: CSPDirectives.join(' ')
+    }
+];
+
 const nextConfig = {
     reactStrictMode: true,
 
@@ -34,12 +64,7 @@ const nextConfig = {
         return [
             {
                 source: '/(.*)',
-                headers: [
-                    {
-                        key: 'Content-Security-Policy',
-                        value: CSPDirectives.join(' ')
-                    }
-                ]
+                headers: securityHeaders
             }
         ];
     }


### PR DESCRIPTION
The purpose of this PR was to send a Content Security Policy to the Octopus front end application, as an added layer of security that helps to detect and mitigate certain types of attacks, including Cross Site Scripting (XSS) and data injection attacks.

---

### Acceptance Criteria:

- A CSP response header is sent on Octopus and is restrictive as we can make it without breaking parts of the application.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

E2E:
![Screenshot 2024-03-28 115923](https://github.com/JiscSD/octopus/assets/132363734/6b391c03-dc0e-436c-886b-7c5d31fadef6)