### PR TITLE
OC-850: Resolve critical security issue in API docker image

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,8 +1,8 @@
-FROM node:18
+FROM node:18-alpine
 
-RUN apt-get update
+RUN apk update
 
-RUN apt-get install -y \
+RUN apk add \
     ca-certificates \
     curl \
     gnupg \


### PR DESCRIPTION
The purpose of this PR was to change the docker image we use for our API test github action because the current one has an [issue](https://security.snyk.io/vuln/SNYK-DEBIAN12-ZLIB-6008963) flagged as a critical issue by Snyk.

This is the snyk page for the new image used in this PR: https://snyk.io/test/docker/node%3A18-alpine

---

### Acceptance Criteria:

- The docker image we use in /api/Dockerfile does not have any issues flagged as critical by Snyk.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Screenshots:

Results of API tests run locally on this container:
![Screenshot 2024-03-28 154915](https://github.com/JiscSD/octopus/assets/132363734/60686740-e7d0-440c-bfca-1e3b7318a8d7)
