### PR TITLE
OC-847: Sanitise input for create publication endpoint

### DIFF
--- a/api/src/components/publication/controller.ts
+++ b/api/src/components/publication/controller.ts
@@ -81,6 +81,10 @@ export const create = async (
             });
         }
 
+        if (event.body.content) {
+            event.body.content = helpers.getSafeHTML(event.body.content);
+        }
+
         const doi = await helpers.createEmptyDOI();
 
         const publication = await publicationService.create(event.body, event.user, doi);


### PR DESCRIPTION
The purpose of this PR was to cover an issue where field values could be provided when creating a publication, and weren't being validated or sanitized correctly before being saved. The scope of this work was to address this for the content field, which takes HTML.

---

### Acceptance Criteria:

- Content sent to Octopus using the create publication endpoint’s “content” field is sanitised

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

API
![Screenshot 2024-04-03 125806](https://github.com/JiscSD/octopus/assets/132363734/b14b6838-0559-4579-9f19-db7bb86a8dd3)

E2E
![Screenshot 2024-04-03 121619](https://github.com/JiscSD/octopus/assets/132363734/8ff230d1-ec12-4652-b8a0-d79f6c97abe7)

