### PR TITLE
OC-848: Octopus links on PDFs as DOIs

### DIFF
--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -713,6 +713,8 @@ export const formatAffiliationName = (affiliation: I.MappedOrcidAffiliation): st
     }${organization.address.country}`;
 };
 
+const doiLinkBase = `https://doi.org/`;
+
 export const createPublicationHTMLTemplate = (
     publicationVersion: I.PublicationVersion,
     references: I.Reference[],
@@ -1025,7 +1027,7 @@ export const createPublicationHTMLTemplate = (
             </p>
             <p class="metadata">
                 <strong>DOI:</strong> 
-                <a href="${process.env.BASE_URL}/publications/${publicationVersion.publication.id}">
+                <a href="${doiLinkBase + publicationVersion.publication.doi}">
                     ${publicationVersion.publication.doi}
                 </a>
             </p>
@@ -1101,7 +1103,9 @@ export const createPublicationHTMLTemplate = (
                             ${linkedTo
                                 .map(
                                     (link) =>
-                                        `<p style="margin-bottom: 1rem"><a href="${process.env.BASE_URL}/publications/${link.id}">${link.title}</a></p>`
+                                        `<p style="margin-bottom: 1rem"><a href="${doiLinkBase + link.doi}">${
+                                            link.title
+                                        }</a></p>`
                                 )
                                 .join('')}
                         </div>`
@@ -1301,14 +1305,18 @@ export const createPublicationFooterTemplate = (publicationVersion: I.Publicatio
     </style>
     <div class="footer">            
         <div>
-            <span>DOI: <a href="${process.env.BASE_URL}/publications/${publicationVersion.publication.id}">${publicationVersion.publication.doi}</a></span>
+            <span>DOI: <a href="${doiLinkBase + publicationVersion.publication.doi}">${
+        publicationVersion.publication.doi
+    }</a></span>
         </div>
         <div>
             Page <span class="pageNumber"></span> of <span class="totalPages"></span>
         </div>        
         <div>
             Published on <a href="${process.env.BASE_URL}">Octopus.ac</a>
-            <a href="${process.env.BASE_URL}"><img id="octopus-logo" src="data:image/svg+xml;base64,${base64OctopusLogo}"/></a>
+            <a href="${
+                process.env.BASE_URL
+            }"><img id="octopus-logo" src="data:image/svg+xml;base64,${base64OctopusLogo}"/></a>
         </div>
     </div>`;
 };


### PR DESCRIPTION
The purpose of this PR was to link to Octopus publications via their DOI link instead of the direct Octopus link, because PDFs generated by Octopus are intended to be persistent documents separate from the system itself.

---

### Acceptance Criteria:

- On PDFs, the following links use the DOI (instead of linking directly to the Octopus URL):
    - Parent publications
    - Footer DOI link
    - DOI link in the metadata section at the top of the PDF

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

API
![Screenshot 2024-04-04 090736](https://github.com/JiscSD/octopus/assets/132363734/dbfc5b99-1673-473f-9581-10fff231ca99)

E2E
<img width="109" alt="Screenshot 2024-04-03 161546" src="https://github.com/JiscSD/octopus/assets/132363734/c9c6d6e4-99a0-4e38-83ac-0cf307aeafff">