### PR TITLE
OC-820: Corrections following testing

### DIFF
--- a/ui/src/components/Publication/EngagementCounts/index.tsx
+++ b/ui/src/components/Publication/EngagementCounts/index.tsx
@@ -21,6 +21,7 @@ const EngagementCounts: React.FC<Props> = (props): React.ReactElement => {
                     <SolidIcons.FlagIcon
                         className={`${props.narrow ? 'mr-1 md:mr-2' : 'mr-2 md:mr-4'} h-4 w-4 text-red-500`}
                         title="Red flag count"
+                        aria-hidden="false"
                     />
                     {flagCount}
                 </span>
@@ -34,6 +35,7 @@ const EngagementCounts: React.FC<Props> = (props): React.ReactElement => {
                     <SolidIcons.PencilIcon
                         className={`${props.narrow ? 'mr-1 md:mr-2' : 'mr-2 md:mr-4'} h-4 w-4`}
                         title="Peer review count"
+                        aria-hidden="false"
                     />
                     {peerReviewCount}
                 </span>

--- a/ui/src/components/Publication/SimpleResult/index.tsx
+++ b/ui/src/components/Publication/SimpleResult/index.tsx
@@ -204,7 +204,7 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
                                 <p>You are not listed as an author on the latest published version</p>
                             )}
                         </div>
-                        <div className="mt-5 flex w-full justify-between">
+                        <div className="mt-5 flex w-full justify-between space-x-4">
                             <Components.Button
                                 href={`/publications/${props.publication.id}`}
                                 endIcon={<OutlineIcons.ArrowTopRightOnSquareIcon className="h-4" />}

--- a/ui/src/pages/authors/[id]/index.tsx
+++ b/ui/src/pages/authors/[id]/index.tsx
@@ -212,7 +212,9 @@ const Author: Types.NextPage<Props> = (props): React.ReactElement => {
                                         id: publication.id,
                                         type: publication.type,
                                         doi: publication.doi,
-                                        url_slug: publication.url_slug
+                                        url_slug: publication.url_slug,
+                                        flagCount: publication.flagCount,
+                                        peerReviewCount: publication.peerReviewCount
                                     };
 
                                     return (


### PR DESCRIPTION
The purpose of this PR was to address 3 issues found when testing OC-820:
- Engagement counts aren't shown in the publications list on the public user page
- Engagement counts could line up right next to the View button on the "my account" page
- The SVG titles of the icons are not read out by screen readers

---

### Acceptance Criteria:

The 3 issues listed above are fixed.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated
