### PR TITLE
add combined message in header if user has no names or confirmed email

### DIFF
--- a/ui/src/components/Header/index.tsx
+++ b/ui/src/components/Header/index.tsx
@@ -37,7 +37,7 @@ const Header: React.FC<Props> = (props): React.ReactElement => {
                     help@jisc.ac.uk
                 </Components.Link>
             </Components.Banner>
-            {/* Confirm email banner */}
+            {/* Missing info banner */}
             {(showConfirmEmailBanner || showMissingNamesBanner) && (
                 <div className="bg-yellow-200 text-sm text-grey-800 dark:bg-yellow-500">
                     <div className="container mx-auto flex items-center gap-2 px-8 py-3">
@@ -47,9 +47,11 @@ const Header: React.FC<Props> = (props): React.ReactElement => {
                             className="w-fit underline underline-offset-4"
                             openNew={true}
                         >
-                            {showConfirmEmailBanner
-                                ? 'Please confirm your email address to be able to publish content.'
-                                : 'Your name is not visible on your ORCiD account. Please change this setting to "Everyone" or "Trusted parties" to be able to publish content.'}
+                            {showConfirmEmailBanner && showMissingNamesBanner
+                                ? 'Please set your name to be visible on your ORCiD profile, then return to Octopus to verify your email to be able to publish content.'
+                                : showConfirmEmailBanner
+                                  ? 'Please confirm your email address to be able to publish content.'
+                                  : 'Your name is not visible on your ORCiD account. Please change this setting to "Everyone" or "Trusted parties" to be able to publish content.'}
                         </Components.Link>
                     </div>
                 </div>


### PR DESCRIPTION
The purpose of this PR was to add an additional case to the "missing information" messages we display in the header. In the case that the user has both of the following statements apply to them:

- They have no first or last name
- They have not confirmed their email address

A message will be shown that explains both of these situations at once, and the actions they should take in order.

---

### Acceptance Criteria:

If a logged in user has no first or last name against their account and has no confirmed email address, this message is shown in a banner in the site header:
- 'Please set your name to be visible on your ORCiD profile, then return to Octopus to verify your email to be able to publish content.'

