### PR TITLE
OC-842: Strategy to avoid cloudformation resource limit

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -60,6 +60,7 @@
                 "serverless-domain-manager": "^7.1.2",
                 "serverless-offline": "^12.0.4",
                 "serverless-offline-ssm": "^6.2.0",
+                "serverless-plugin-split-stacks": "^1.13.0",
                 "serverless-prune-plugin": "^2.0.2",
                 "serverless-webpack": "^5.13.0",
                 "serverless-webpack-prisma": "^1.2.0",
@@ -10386,6 +10387,12 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/aws-info": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/aws-info/-/aws-info-1.2.0.tgz",
+            "integrity": "sha512-24q5Rh3bno7ldoyCq99d6hpnLI+PAMocdeVaaGt/5BTQMprvDwQToHfNnruqN11odCHZZIQbRBw+nZo1lTCH9g==",
+            "dev": true
+        },
         "node_modules/aws-lambda": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/aws-lambda/-/aws-lambda-1.0.7.tgz",
@@ -19383,6 +19390,42 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/serverless-plugin-split-stacks": {
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/serverless-plugin-split-stacks/-/serverless-plugin-split-stacks-1.13.0.tgz",
+            "integrity": "sha512-svavmBF+58PcZN97ijsZwUv35MDnumoYIKcdPaK11v/1QHpwl0POJmuPaPjbL2uubSrzY3viZ6yMBYNmnfqp9g==",
+            "dev": true,
+            "dependencies": {
+                "aws-info": "^1.2.0",
+                "lodash": "^4.17.21",
+                "semver": "^7.3.5",
+                "throat": "^6.0.1"
+            },
+            "peerDependencies": {
+                "serverless": "1 || 2 || 3"
+            }
+        },
+        "node_modules/serverless-plugin-split-stacks/node_modules/semver": {
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+            "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/serverless-plugin-split-stacks/node_modules/throat": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.2.tgz",
+            "integrity": "sha512-WKexMoJj3vEuK0yFEapj8y64V0A6xcuPuK9Gt1d0R+dzCSJc0lHqQytAbSB4cDAK0dWh4T0E2ETkoLE2WZ41OQ==",
+            "dev": true
         },
         "node_modules/serverless-prune-plugin": {
             "version": "2.0.2",

--- a/api/package.json
+++ b/api/package.json
@@ -80,6 +80,7 @@
         "serverless-domain-manager": "^7.1.2",
         "serverless-offline": "^12.0.4",
         "serverless-offline-ssm": "^6.2.0",
+        "serverless-plugin-split-stacks": "^1.13.0",
         "serverless-prune-plugin": "^2.0.2",
         "serverless-webpack": "^5.13.0",
         "serverless-webpack-prisma": "^1.2.0",

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -11,6 +11,7 @@ plugins:
     - serverless-webpack
     - serverless-webpack-prisma
     - serverless-prune-plugin
+    - serverless-plugin-split-stacks
 
 provider:
     name: aws
@@ -86,6 +87,10 @@ provider:
               - 'sqs:ReceiveMessage'
               - 'sqs:SendMessage'
 custom:
+    splitStacks:
+        perFunction: true
+        perType: false
+        perGroupFunction: false
     customDomain:
         domainName: '${self:provider.stage}.api.octopus.ac'
         basePath: ''


### PR DESCRIPTION
The purpose of this PR was to explore ways of changing our use of the serverless framework to avoid running into the CloudFormation limit of 500 resources per application (or stack).

In this investigation I learned of quite a simple way to automatically spread resources across nested cloudformation stacks using a serverless plugin. It's a good stop gap solution for the time being, while we might consider re-architecting octopus to consist of micro services in the longer term.

A test deploy has successfully run on the int environment, which required removing the old stack and creating this new one afresh.

---

### Acceptance Criteria:

- A workable way forward to avoid the cloudformation resource limit is found.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

N/A

---

### Screenshots:

Relevant selection from deployment output:
![Screenshot 2024-04-08 105822](https://github.com/JiscSD/octopus/assets/132363734/ba153029-d59b-4662-bb2e-ea280367f912)
