### PR TITLE
OC-854: Route links on int via correct DOI string

### DIFF
--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -713,7 +713,7 @@ export const formatAffiliationName = (affiliation: I.MappedOrcidAffiliation): st
     }${organization.address.country}`;
 };
 
-const doiLinkBase = `https://doi.org/`;
+const doiLinkBase = `https://${process.env.STAGE === 'prod' ? 'doi.org' : 'handle.test.datacite.org'}/`;
 
 export const createPublicationHTMLTemplate = (
     publicationVersion: I.PublicationVersion,

--- a/e2e/tests/PageModel.ts
+++ b/e2e/tests/PageModel.ts
@@ -92,7 +92,7 @@ export const PageModel = {
             // coi
             'h2:has-text("Conflict of interest")'
         ],
-        doiLink: 'aside [aria-label="DOI link: https://doi.org/10.82259/cl3fz14dr0001es6i5ji51rq4"]',
+        doiLink: 'aside [aria-label="DOI link: https://handle.test.datacite.org/10.82259/cl3fz14dr0001es6i5ji51rq4"]',
         authorLink: 'a[href="/authors/octopus"]:has-text("S. Octopus")',
         signInForMoreButton: 'text=Sign in for more actions',
         verifyEmailForMoreButton: 'text=Verify your email for more actions',

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -179,7 +179,7 @@ export const checkLivePublicationLayout = async (page: Page, id: string, loggedI
     // Expect DOI link
     await expect(page.locator(PageModel.livePublication.doiLink)).toHaveAttribute(
         'href',
-        `https://doi.org/10.82259/${id}`
+        `https://handle.test.datacite.org/10.82259/${id}`
     );
 
     if (loggedIn) {

--- a/ui/src/__tests__/components/Publication/SidebarCard/General.test.tsx
+++ b/ui/src/__tests__/components/Publication/SidebarCard/General.test.tsx
@@ -1,10 +1,11 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 
 import * as Components from '@/components';
 import * as Config from '@/config';
 import * as Helpers from '@/helpers';
 import * as TestUtils from '@/testUtils';
+
+const versionlessDoiUrl = Config.values.doiBaseUrl + TestUtils.testPublicationVersion.publication.doi;
 
 describe('Basic tests', () => {
     beforeEach(() => {
@@ -42,9 +43,9 @@ describe('Basic tests', () => {
         expect(screen.getByText('DOI:')).toBeInTheDocument();
         expect(
             screen.getByRole('link', {
-                name: `DOI link: https://doi.org/${TestUtils.testPublicationVersion.publication.doi}`
+                name: `DOI link: ${versionlessDoiUrl}`
             })
-        ).toHaveAttribute('href', `https://doi.org/${TestUtils.testPublicationVersion.publication.doi}`);
+        ).toHaveAttribute('href', `${versionlessDoiUrl}`);
     });
     it('Shows no peer reviews', () => {
         expect(screen.getByText('Peer Reviews (This Version): (0)')).toBeInTheDocument();
@@ -57,6 +58,9 @@ describe('Basic tests', () => {
     });
 });
 
+const versionDoi = 'testversiondoi';
+const versionDoiUrl = Config.values.doiBaseUrl + versionDoi;
+
 describe('Multi-version publication with Peer Reviews, Flags and version DOI', () => {
     beforeEach(() => {
         render(
@@ -64,7 +68,7 @@ describe('Multi-version publication with Peer Reviews, Flags and version DOI', (
                 publicationVersion={{
                     ...TestUtils.testPublicationVersion,
                     versionNumber: 2,
-                    doi: 'testversiondoi'
+                    doi: versionDoi
                 }}
                 linkedFrom={[
                     {
@@ -92,17 +96,17 @@ describe('Multi-version publication with Peer Reviews, Flags and version DOI', (
         expect(screen.getByText('DOI (This Version):')).toBeInTheDocument();
         expect(
             screen.getByRole('link', {
-                name: `DOI link: https://doi.org/testversiondoi`
+                name: `DOI link: ${versionDoiUrl}`
             })
-        ).toHaveAttribute('href', `https://doi.org/testversiondoi`);
+        ).toHaveAttribute('href', versionDoiUrl);
     });
     it('Shows "versionless" DOI link', () => {
         expect(screen.getByText('DOI (All Versions):')).toBeInTheDocument();
         expect(
             screen.getByRole('link', {
-                name: `DOI link: https://doi.org/${TestUtils.testPublicationVersion.publication.doi}`
+                name: `DOI link: ${versionlessDoiUrl}`
             })
-        ).toHaveAttribute('href', `https://doi.org/${TestUtils.testPublicationVersion.publication.doi}`);
+        ).toHaveAttribute('href', versionlessDoiUrl);
     });
     it('Shows 1 peer review for this version', () => {
         expect(screen.getByText('Peer Reviews (This Version): (1)')).toBeInTheDocument();

--- a/ui/src/components/Publication/Creation/MainText.tsx
+++ b/ui/src/components/Publication/Creation/MainText.tsx
@@ -43,7 +43,7 @@ const getTransformedReference = (reference: Interfaces.Reference, textContent: s
                     ...reference,
                     type: 'DOI',
                     text: reference.text.replace(lastDoiString, ''), // remove DOI string
-                    location: `https://doi.org/${doi}` // convert to DOI url
+                    location: Config.values.doiBaseUrl + doi // convert to DOI url
                 };
             }
         }

--- a/ui/src/components/Publication/SidebarCard/General/index.tsx
+++ b/ui/src/components/Publication/SidebarCard/General/index.tsx
@@ -22,7 +22,9 @@ const General: React.FC<Props> = (props): React.ReactElement => {
 
     const activeFlags = React.useMemo(() => props.flags.filter((flag) => !flag.resolved), [props.flags]);
 
-    const showVersionDOI = props.publicationVersion.doi && props.publicationVersion.publication.type !== 'PEER_REVIEW';
+    const showVersionDoi = props.publicationVersion.doi && props.publicationVersion.publication.type !== 'PEER_REVIEW';
+    const versionDoiUrl = Config.values.doiBaseUrl + props.publicationVersion.doi;
+    const versionlessDoiUrl = Config.values.doiBaseUrl + props.publicationVersion.publication.doi;
 
     const uniqueRedFlagCategoryList = React.useMemo(
         () => Array.from(new Set(activeFlags.map((flag) => flag.category))),
@@ -80,18 +82,18 @@ const General: React.FC<Props> = (props): React.ReactElement => {
                     </div>
                 </Components.Link>
             </div>
-            {showVersionDOI && (
+            {showVersionDoi && (
                 <div className="flex w-full flex-wrap whitespace-normal">
                     <span className="mr-2 whitespace-nowrap text-sm font-semibold text-grey-800 transition-colors duration-500 dark:text-grey-100">
                         DOI (This Version):
                     </span>
                     <Components.Link
-                        href={`https://doi.org/${props.publicationVersion.doi}`}
-                        ariaLabel={`DOI link: https://doi.org/${props.publicationVersion.doi}`}
+                        href={versionDoiUrl}
+                        ariaLabel={`DOI link: ${versionDoiUrl}`}
                         className="flex items-center text-sm font-medium text-teal-600 transition-colors duration-500 hover:underline dark:text-teal-400"
                         openNew={true}
                     >
-                        <p className="break-words break-all">https://doi.org/{props.publicationVersion.doi}</p>
+                        <p className="break-words break-all">{versionDoiUrl}</p>
                         <OutlineIcons.ArrowTopRightOnSquareIcon className="ml-1 h-4 w-4 flex-shrink-0" />
                     </Components.Link>
                 </div>
@@ -99,15 +101,15 @@ const General: React.FC<Props> = (props): React.ReactElement => {
 
             <div className={`flex w-full ${props.publicationVersion.doi ? 'flex-wrap' : ''} whitespace-normal`}>
                 <span className="mr-2 whitespace-nowrap text-sm font-semibold text-grey-800 transition-colors duration-500 dark:text-grey-100">
-                    {showVersionDOI ? 'DOI (All Versions):' : 'DOI:'}
+                    {showVersionDoi ? 'DOI (All Versions):' : 'DOI:'}
                 </span>
                 <Components.Link
-                    href={`https://doi.org/${props.publicationVersion.publication.doi}`}
-                    ariaLabel={`DOI link: https://doi.org/${props.publicationVersion.publication.doi}`}
+                    href={versionlessDoiUrl}
+                    ariaLabel={`DOI link: ${versionlessDoiUrl}`}
                     className="flex items-center text-sm font-medium text-teal-600 transition-colors duration-500 hover:underline dark:text-teal-400"
                     openNew={true}
                 >
-                    <p className="break-words break-all">https://doi.org/{props.publicationVersion.publication.doi}</p>
+                    <p className="break-words break-all">{versionlessDoiUrl}</p>
                     <OutlineIcons.ArrowTopRightOnSquareIcon className="ml-1 h-4 w-4 flex-shrink-0" />
                 </Components.Link>
             </div>

--- a/ui/src/config/values.ts
+++ b/ui/src/config/values.ts
@@ -923,3 +923,5 @@ export const topicDescription =
     'This is a research topic created to provide authors with a place to attach new problem publications.';
 
 export const blogContentType = 'octopusBlog';
+
+export const doiBaseUrl = `https://${process.env.NEXT_PUBLIC_STAGE === 'prod' ? 'doi.org' : 'handle.test.datacite.org'}/`;

--- a/ui/src/pages/index.tsx
+++ b/ui/src/pages/index.tsx
@@ -6,7 +6,6 @@ import * as Config from '@/config';
 import * as Types from '@/types';
 
 const Home: Types.NextPage = (props): React.ReactElement => {
-    console.log({ branch: process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF });
     return (
         <>
             <Head>


### PR DESCRIPTION
The purpose of this PR was to ensure that DOI links point to the actual DOI address, rather than to Octopus directly, to provide persistence if Octopus were to go down. On int (and locally), these DOI links should be to [https://handle.test.datacite.org/](https://handle.test.datacite.org/) to avoid 404ing.

---

### Acceptance Criteria:

- DOI links on int in the publication metadata box and on PDFs point to DOI URLs beginning with https://handle.test.datacite.org/, following by the DOI ID string
---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
![Screenshot 2024-04-15 105436](https://github.com/JiscSD/octopus/assets/132363734/0f9108c3-0d0b-4ad5-a40d-ddf5aa5c143c)

API
<img width="134" alt="Screenshot 2024-04-15 110311" src="https://github.com/JiscSD/octopus/assets/132363734/20c156ba-0c63-4c2d-bfcb-35dced2dac16">

E2E
![Screenshot 2024-04-15 105408](https://github.com/JiscSD/octopus/assets/132363734/4fbec902-8778-45fc-a005-7b5a12a2770f)

---

### Screenshots:

DOI links will appear like this on int.
![Screenshot 2024-04-15 112339](https://github.com/JiscSD/octopus/assets/132363734/4fc3afca-d0fd-453b-9105-d04ba7d546ef)
