### PR TITLE
OC-503: Spike: run serverless on int account

### DIFF
--- a/api/nodemon.json
+++ b/api/nodemon.json
@@ -1,5 +1,5 @@
 {
     "verbose": true,
     "ignore": ["*.test.js", "*.test.ts", "thunder-tests/*"],
-    "exec": "sls offline start --reloadHandler --httpPort 4003 --host 0.0.0.0 --stage local --aws-profile octopus-dev"
+    "exec": "sls offline start -c serverless-offline.yml --reloadHandler --httpPort 4003 --host 0.0.0.0 --stage local --aws-profile octopus-dev"
 }

--- a/api/serverless-config-default.yml
+++ b/api/serverless-config-default.yml
@@ -1,0 +1,494 @@
+service: octopus-api
+
+frameworkVersion: '3'
+
+useDotenv: true
+
+functions:
+    # App
+    healthcheck:
+        handler: src/components/application/routes.healthcheck
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/healthcheck
+                method: GET
+                cors: true
+    seedOpenSearch:
+        handler: src/lib/testUtils.openSearchSeed
+    # Publications
+    getPublication:
+        handler: src/components/publication/routes.get
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publications/{publicationId}
+                method: GET
+                cors: true
+    getSeedDataPublications:
+        handler: src/components/publication/routes.getSeedDataPublications
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publications/seed-data-publications
+                method: GET
+                cors: true
+    createPublication:
+        handler: src/components/publication/routes.create
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publications
+                method: POST
+                cors: true
+    getPublicationLinks:
+        handler: src/components/publication/routes.getPublicationLinks
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publications/{publicationId}/links
+                method: GET
+                cors: true
+    getPDF:
+        handler: src/components/publication/routes.getPDF
+        memorySize: 2048 # https://github.com/alixaxel/chrome-aws-lambda#:~:text=You%20should%20allocate%20at%20least%20512%20MB%20of%20RAM%20to%20your%20Lambda%2C%20however%201600%20MB%20(or%20more)%20is%20recommended
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publications/{publicationId}/pdf
+                method: GET
+                cors: true
+    # Publication Versions
+    createPublicationVersion:
+        handler: src/components/publicationVersion/routes.create
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publications/{publicationId}/publication-versions
+                method: POST
+                cors: true
+    getPublicationVersion:
+        handler: src/components/publicationVersion/routes.get
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publications/{publicationId}/publication-versions/{version} # {version} can be a version id, number, "latest" or "latestLive"
+                method: GET
+                cors: true
+    getIndexedPublicationVersions:
+        handler: src/components/publicationVersion/routes.getAll
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publication-versions
+                method: GET
+                cors: true
+    updatePublicationVersion:
+        handler: src/components/publicationVersion/routes.update
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publication-versions/{publicationVersionId}
+                method: PATCH
+                cors: true
+    updateStatus:
+        handler: src/components/publicationVersion/routes.updateStatus
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publication-versions/{publicationVersionId}/status/{status}
+                method: PUT
+                cors: true
+    deleteVersion:
+        handler: src/components/publicationVersion/routes.deleteVersion
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publication-versions/{publicationVersionId}
+                method: DELETE
+                cors: true
+    requestControl:
+        handler: src/components/publicationVersion/routes.requestControl
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publications/{publicationId}/publication-versions/{version}/request-control
+                method: GET
+                cors: true
+    approveControlRequest:
+        handler: src/components/publicationVersion/routes.approveControlRequest
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publications/{publicationId}/publication-versions/{version}/approve-control-request
+                method: POST
+                cors: true
+    # Users
+    getUsers:
+        handler: src/components/user/routes.getAll
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/users
+                method: GET
+                cors: true
+    getUser:
+        handler: src/components/user/routes.get
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/users/{id}
+                method: GET
+                cors: true
+    getUserPublications:
+        handler: src/components/user/routes.getPublications
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/users/{id}/publications
+                method: GET
+                cors: true
+    getUserList:
+        handler: src/components/user/routes.getUserList
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/user-list
+                method: GET
+                cors: true
+    getUserControlRequests:
+        handler: src/components/user/routes.getUserControlRequests
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/users/me/control-requests
+                method: GET
+                cors: true
+    # Auth
+    authorization:
+        handler: src/components/authorization/routes.authorize
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/authorization
+                method: POST
+                cors: true
+    getDecodedUserToken:
+        handler: src/components/authorization/routes.getDecodedUserToken
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/decode-user-token
+                method: GET
+                cors: true
+    verifyOrcidAccess:
+        handler: src/components/authorization/routes.verifyOrcidAccess
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/verify-orcid-access
+                method: GET
+                cors: true
+    revokeOrcidAccess:
+        handler: src/components/authorization/routes.revokeOrcidAccess
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/revoke-orcid-access
+                method: DELETE
+                cors: true
+    # Links
+    createLink:
+        handler: src/components/link/routes.create
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/links
+                method: POST
+                cors: true
+    deleteLink:
+        handler: src/components/link/routes.deleteLink
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/links/{id}
+                method: DELETE
+                cors: true
+    # CoAuthors
+    getCoAuthors:
+        handler: src/components/coauthor/routes.get
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publication-versions/{publicationVersionId}/coauthors
+                method: GET
+                cors: true
+    updateAll:
+        handler: src/components/coauthor/routes.updateAll
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publication-versions/{publicationVersionId}/coauthors
+                method: PUT
+                cors: true
+    deleteCoAuthor:
+        handler: src/components/coauthor/routes.remove
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publication-versions/{publicationVersionId}/coauthors/{coauthorId}
+                method: DELETE
+                cors: true
+    linkCoAuthor:
+        handler: src/components/coauthor/routes.link
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publication-versions/{publicationVersionId}/link-coauthor
+                method: PATCH
+                cors: true
+    updateCoAuthorConfirmation:
+        handler: src/components/coauthor/routes.updateConfirmation
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publication-versions/{publicationVersionId}/coauthor-confirmation
+                method: PATCH
+                cors: true
+    requestApproval:
+        handler: src/components/coauthor/routes.requestApproval
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publication-versions/{publicationVersionId}/coauthors/request-approval
+                method: PUT
+                cors: true
+    sendApprovalReminder:
+        handler: src/components/coauthor/routes.sendApprovalReminder
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publication-versions/{publicationVersionId}/coauthors/{coauthorId}/approval-reminder
+                method: POST
+                cors: true
+    # Flags
+    getFlag:
+        handler: src/components/flag/routes.get
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/flags/{id}
+                method: GET
+                cors: true
+    createFlag:
+        handler: src/components/flag/routes.createFlag
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publications/{publicationId}/flags
+                method: POST
+                cors: true
+    createFlagComment:
+        handler: src/components/flag/routes.createFlagComment
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/flags/{id}/comment
+                method: POST
+                cors: true
+    resolveFlag:
+        handler: src/components/flag/routes.resolveFlag
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/flags/{id}/resolve
+                method: POST
+                cors: true
+    getPublicationFlags:
+        handler: src/components/flag/routes.getPublicationFlags
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publications/{publicationId}/flags
+                method: GET
+                cors: true
+    getUserFlags:
+        handler: src/components/flag/routes.getUserFlags
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/user/{userId}/flags
+                method: GET
+                cors: true
+    # Images
+    createImage:
+        handler: src/components/image/routes.create
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/images
+                method: POST
+                cors: true
+    deleteImage:
+        handler: src/components/image/routes.destroy
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/images/{id}
+                method: DELETE
+                cors: true
+    getAllImages:
+        handler: src/components/image/routes.getAll
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/images
+                method: GET
+                cors: true
+    # Bookmarks
+    createBookmark:
+        handler: src/components/bookmark/routes.create
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/bookmarks
+                method: POST
+                cors: true
+    deleteBookmark:
+        handler: src/components/bookmark/routes.deleteBookmark
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/bookmarks/{id}
+                method: DELETE
+                cors: true
+    getAllBookmarks:
+        handler: src/components/bookmark/routes.getAll
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/bookmarks
+                method: GET
+                cors: true
+    # Verification
+    requestVerification:
+        handler: src/components/verification/routes.requestCode
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/verification/{id}
+                method: GET
+                cors: true
+    confirmVerification:
+        handler: src/components/verification/routes.confirmCode
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/verification/{id}
+                method: POST
+                cors: true
+    # Funders
+    createFunder:
+        handler: src/components/funder/routes.create
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publication-versions/{publicationVersionId}/funders
+                method: POST
+                cors: true
+    deleteFunder:
+        handler: src/components/funder/routes.destroy
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publication-versions/{publicationVersionId}/funders/{funderId}
+                method: DELETE
+                cors: true
+    # References
+    getReferences:
+        handler: src/components/reference/routes.get
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publication-versions/{publicationVersionId}/references
+                method: get
+                cors: true
+    updateAllReference:
+        handler: src/components/reference/routes.updateAll
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publication-versions/{publicationVersionId}/references
+                method: put
+                cors: true
+    # Affiliations
+    updateAffiliations:
+        handler: src/components/affiliations/routes.updateAffiliations
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publication-versions/{publicationVersionId}/my-affiliations
+                method: PUT
+                cors: true
+    getORCIDAffiliations:
+        handler: src/components/affiliations/routes.getORCIDAffiliations
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/orcid-affiliations
+                method: GET
+                cors: true
+    # Topics
+    createTopic:
+        handler: src/components/topic/routes.create
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/topics
+                method: POST
+                cors: true
+    getTopic:
+        handler: src/components/topic/routes.get
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/topics/{id}
+                method: GET
+                cors: true
+    getTopics:
+        handler: src/components/topic/routes.getTopics
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/topics
+                method: GET
+                cors: true
+    # Events
+    dailyEventCheck:
+        handler: src/components/event/routes.dailyEventCheck
+        events:
+            - schedule: cron(0 8 * * ? *) # Every day at 8 a.m.
+    # Additional Information
+    createAdditionalInformation:
+        handler: src/components/additionalInformation/routes.create
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publication-versions/{publicationVersionId}/additional-information
+                method: POST
+                cors: true
+    deleteAdditionalInformation:
+        handler: src/components/additionalInformation/routes.deleteAdditionalInformation
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publication-versions/{publicationVersionId}/additional-information/{additionalInformationId}
+                method: DELETE
+                cors: true
+    # Sitemaps
+    generateSitemaps:
+        handler: src/components/sitemap/routes.generate
+        events:
+            - schedule: cron(0 5 ? * * *) # Every day at 5 a.m.
+
+    getSitemapPaths:
+        handler: src/components/sitemap/routes.getPaths
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/sitemaps/paths
+                method: GET
+                cors: true
+
+    # Crosslinks
+    createCrosslink:
+        handler: src/components/crosslink/routes.create
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/crosslinks
+                method: POST
+                cors: true
+    deleteCrosslink:
+        handler: src/components/crosslink/routes.deleteCrosslink
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/crosslinks/{id}
+                method: DELETE
+                cors: true
+    setCrosslinkVote:
+        handler: src/components/crosslink/routes.setVote
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/crosslinks/{id}/vote
+                method: PUT
+                cors: true
+    resetCrosslinkVote:
+        handler: src/components/crosslink/routes.resetVote
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/crosslinks/{id}/vote
+                method: DELETE
+                cors: true
+    getCrosslinkVote:
+        handler: src/components/crosslink/routes.getVote
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/crosslinks/{id}/vote
+                method: GET
+                cors: true
+    getCrosslink:
+        handler: src/components/crosslink/routes.get
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/crosslinks/{id}
+                method: GET
+                cors: true
+    getPublicationCrosslinks:
+        handler: src/components/crosslink/routes.getPublicationCrosslinks
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publications/{publicationId}/crosslinks
+                method: GET
+                cors: true

--- a/api/serverless-config-deploy.yml
+++ b/api/serverless-config-deploy.yml
@@ -1,0 +1,6 @@
+# Config not used locally
+functions:
+    generatePDFsFromQueue:
+        handler: src/components/sqs/handler.generatePDFs
+        events:
+            - sqs: 'arn:aws:sqs:${aws:region}:${aws:accountId}:science-octopus-pdf-queue-${self:provider.stage}'

--- a/api/serverless-offline.yml
+++ b/api/serverless-offline.yml
@@ -5,11 +5,10 @@ frameworkVersion: ${file(./serverless-config-default.yml):frameworkVersion}
 useDotenv: ${file(./serverless-config-default.yml):useDotenv}
 
 plugins:
-    - serverless-domain-manager
+    - serverless-offline-ssm
+    - serverless-offline
     - serverless-webpack
     - serverless-webpack-prisma
-    - serverless-prune-plugin
-    - serverless-plugin-split-stacks
 
 provider:
     name: aws
@@ -17,14 +16,7 @@ provider:
     timeout: 30
     runtime: nodejs18.x
     region: eu-west-1
-    stage: ${opt:stage}
-    vpc:
-        securityGroupIds:
-            - ${ssm:/${self:provider.stage}_octopus_sls_sg}
-        subnetIds:
-            - ${ssm:/${self:provider.stage}_octopus_private_subnet_az1}
-            - ${ssm:/${self:provider.stage}_octopus_private_subnet_az2}
-            - ${ssm:/${self:provider.stage}_octopus_private_subnet_az3}
+    stage: 'local'
     environment:
         STAGE: ${self:provider.stage}
         ELASTICSEARCH_USER: ${ssm:/elasticsearch_user_${self:provider.stage}_octopus}
@@ -74,29 +66,7 @@ provider:
         - Effect: 'Allow'
           Resource: 'arn:aws:s3:::science-octopus-publishing-sitemaps-${self:provider.stage}'
           Action: 's3:ListBucket'
-        - Effect: 'Allow'
-          Resource: 'arn:aws:sqs:${aws:region}:${aws:accountId}:science-octopus-pdf-queue-${self:provider.stage}'
-          Action:
-              - 'lambda:CreateEventSourceMapping'
-              - 'lambda:ListEventSourceMappings'
-              - 'lambda:ListFunctions'
-              - 'sqs:DeleteMessage'
-              - 'sqs:GetQueueAttributes'
-              - 'sqs:ReceiveMessage'
-              - 'sqs:SendMessage'
 custom:
-    splitStacks:
-        perFunction: true
-        perType: false
-        perGroupFunction: false
-    customDomain:
-        domainName: '${self:provider.stage}.api.octopus.ac'
-        basePath: ''
-        hostedZoneId: Z0024644REA9FF3O23MK
-        certificateName: '*.api.octopus.ac'
-        stage: ${self:provider.stage}
-        createRoute53Record: true
-        route53Profile: 'octopus-dev'
     webpack:
         webpackConfig: ./webpack.config.js
         includeModules:
@@ -109,9 +79,36 @@ custom:
         packager: 'npm'
     versions:
         v1: v1
-    prune:
-        automatic: true
-        number: 3
+    serverless-offline:
+        useChildProcesses: true
+    serverless-offline-ssm:
+        stages:
+            - local
+        ssm:
+            /local_octopus_sls_sg: '1'
+            /local_octopus_private_subnet_az1: '1'
+            /local_octopus_private_subnet_az2: '2'
+            /local_octopus_private_subnet_az3: '3'
+            /elasticsearch_user_local_octopus: ${env:ELASTICSEARCH_USER}
+            /elasticsearch_password_local_octopus: ${env:ELASTICSEARCH_PASSWORD}
+            /elasticsearch_endpoint_local_octopus: ${env:ELASTICSEARCH_ENDPOINT}
+            /elastic_search_protocol_local_octopus: ${env:ELASTICSEARCH_PROTOCOL}
+            /db_connection_string_local_octopus: ${env:DATABASE_URL}
+            /jwt_secret_local_octopus: ${env:JWT_SECRET}
+            /orcid_secret_key_local_octopus: ${env:ORCID_SECRET}
+            /orcid_app_id_local_octopus: ${env:ORCID_ID}
+            /orcid_auth_url_local_octopus: ${env:ORCID_AUTH_URL}
+            /orcid_member_api_url_local_octopus: ${env:ORCID_MEMBER_API_URL}
+            /doi_prefix_local_octopus: ${env:DOI_PREFIX}
+            /datacite_endpoint_local_octopus: ${env:DATACITE_ENDPOINT}
+            /datacite_user_local_octopus: ${env:DATACITE_USER}
+            /datacite_password_local_octopus: ${env:DATACITE_PASSWORD}
+            /email_sender_address_local_octopus: ${env:EMAIL_SENDER_ADDRESS}
+            /base_url_local_octopus: ${env:BASE_URL}
+            /authorization_callback_url_local_octopus: ${env:AUTHORISATION_CALLBACK_URL}
+            /list_users_api_key_local_octopus: ${env:LIST_USERS_API_KEY}
+            /queue_url_local_octopus: ${env:QUEUE_URL}
+            /sqs_endpoint_local_octopus: ${env:SQS_ENDPOINT}
+            /mail_server_local_octopus: ${env:MAIL_SERVER}
 functions:
     - ${file(./serverless-config-default.yml):functions}
-    - ${file(./serverless-config-deploy.yml):functions}

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -77,7 +77,7 @@ provider:
           Resource: 'arn:aws:s3:::science-octopus-publishing-sitemaps-${self:provider.stage}'
           Action: 's3:ListBucket'
         - Effect: 'Allow'
-          Resource: 'arn:aws:sqs:eu-west-1:948306873545:science-octopus-pdf-queue-${self:provider.stage}'
+          Resource: 'arn:aws:sqs:${aws:region}:${aws:accountId}:science-octopus-pdf-queue-${self:provider.stage}'
           Action:
               - 'lambda:CreateEventSourceMapping'
               - 'lambda:ListEventSourceMappings'
@@ -98,6 +98,7 @@ custom:
         certificateName: '*.api.octopus.ac'
         stage: ${self:provider.stage}
         createRoute53Record: true
+        route53Profile: 'octopus-dev'
     webpack:
         webpackConfig: ./webpack.config.js
         includeModules:
@@ -149,7 +150,7 @@ functions:
     generatePDFsFromQueue:
         handler: src/components/sqs/handler.generatePDFs
         events:
-            - sqs: 'arn:aws:sqs:eu-west-1:948306873545:science-octopus-pdf-queue-${self:provider.stage}'
+            - sqs: 'arn:aws:sqs:${aws:region}:${aws:accountId}:science-octopus-pdf-queue-${self:provider.stage}'
     healthcheck:
         handler: src/components/application/routes.healthcheck
         events:

--- a/infra/README.md
+++ b/infra/README.md
@@ -29,7 +29,7 @@ projects. This project has set up its modules so that they never have to be chan
 
 ## Workspaces
 
-We use [Terraform workspaces](https://learn.hashicorp.com/tutorials/terraform/organize-configuration?in=terraform/modules) to separate our environments. The reason for this is because the infrastructure composition between environments doesn't change, but some attributes may - e.g. RDS instance size. This is handled by having a separate variables file per environment - e.g. `int.tfvars` - and passing that in as a flag when we `terraform apply` within a particular workspace. 
+We use [Terraform workspaces](https://learn.hashicorp.com/tutorials/terraform/organize-configuration?in=terraform/modules) to separate our environments. The reason for this is because the infrastructure composition between environments doesn't change, but some attributes may - e.g. RDS instance size. This is handled by having a separate variables file per environment - e.g. `int.tfvars` - and passing that in as a flag when we `terraform apply` within a particular workspace.
 
 The infrastructure is created/updated by simply switching to the correct workspace and applying, passing in the correct variables file:
 
@@ -40,8 +40,9 @@ $ terraform apply --var-file=int.tfvars
 
 Workspaces currently in use:
 
--   **`int`**
--   **`prod`**
+- **`int`**
+- **`prod`**
+- **`new-int`** (temporarily until int environment has finished being moved to its own account)
 
 ## Create application
 
@@ -50,7 +51,7 @@ Workspaces currently in use:
 Location: `~/infra/create-app`
 
 The `create-app` Terraform sets up the main project's int & prod environments on AWS. Details can be found in `~/infra/create-app/main.tf` which contains the used modules and the information passed to those modules.
-As this project uses workspaces, there are **two** tfvars files, one per environment. This way, the environments are 1:1 and their only differences are value related - i.e the technology behind stays the same, just the values are different. An example of this may be that the int environment has a smaller allocated size for the database, whereas production would be larger.
+As this project uses workspaces, there one tfvars file per environment. This way, the environments are 1:1 and their only differences are value related - i.e the technology behind stays the same, just the values are different. An example of this may be that the int environment has a smaller allocated size for the database, whereas production would be larger.
 
 To run this Terraform, follow the below:
 
@@ -67,13 +68,17 @@ There are some parts of this project's infrastructure that are **not** managed/c
 
 - An `AWS S3 Bucket`, for hosting the Terraform State file **(octopus-tfstate)**.
 - Configuration to increase the limit of allowed VPCs for a single region (default 5) to 50.
-- Most Route 53 config
+- Most Route 53 config, including certificates in Certificate Manager
 - AWS Amplify config
 
-## Migration to prod AWS account
-We are in the process of moving the prod environment to a separate AWS account. Until this is done, there are the following additional things to note:
-- There is a new workspace called `new-prod` with its own `.tfvars` file. We will remove this after the migration. For now, it allows us to provision prod-like resources in parallel to the currently running prod environment.
+## Migration to separate int AWS account
+
+We are in the process of moving the int environment to a separate AWS account. Until this is done, there are the following additional things to note:
+
+- There is a new workspace called `new-int` with its own `.tfvars` file. We will remove this after the migration. For now, it allows us to provision int-like resources in parallel to the currently running int environment.
 - Terraform will expect a number of profiles to be defined in your `~/.aws/credentials` file when running commands, depending on the account you're working with:
-    - `octopus-tfstate`: a separate account to store terraform state for all environments, and other centralised things TBD
-    - `octopus-prod`: the account for the prod environment (where new-prod currently lives, and where prod will eventually live)
-    - `octopus-dev`: the account for the int environment (where prod and int currently live, and eventually will only contain int)
+  - `octopus-tfstate`: a separate account to store terraform state for all environments, and other centralised things TBD
+  - `octopus-int`: the account for the int environment (where new-int currently lives, and where int will eventually live)
+    - Please note that on the AWS sign-in page, this account was provisioned with the name OctopusProjectProd, which unfortunately can't be changed.
+  - `octopus-dev`: the account for the prod environment (where prod and int currently live, and eventually will only contain prod)
+    - This profile name will likely be changed to `octopus-prod` when the migration is done.

--- a/infra/README.md
+++ b/infra/README.md
@@ -51,7 +51,7 @@ Workspaces currently in use:
 Location: `~/infra/create-app`
 
 The `create-app` Terraform sets up the main project's int & prod environments on AWS. Details can be found in `~/infra/create-app/main.tf` which contains the used modules and the information passed to those modules.
-As this project uses workspaces, there one tfvars file per environment. This way, the environments are 1:1 and their only differences are value related - i.e the technology behind stays the same, just the values are different. An example of this may be that the int environment has a smaller allocated size for the database, whereas production would be larger.
+As this project uses workspaces, there is one tfvars file per environment. This way, the environments are 1:1 and their only differences are value related - i.e the technology behind stays the same, just the values are different. An example of this may be that the int environment has a smaller allocated size for the database, whereas production would be larger.
 
 To run this Terraform, follow the below:
 

--- a/infra/create-app/new-int.tfvars
+++ b/infra/create-app/new-int.tfvars
@@ -1,11 +1,11 @@
-profile = "octopus-prod"
+profile = "octopus-int"
 
 rds_allocated_storage                     = 50
 rds_max_allocated_storage                 = 100
-rds_instance                              = "db.m5.large"
+rds_instance                              = "db.t4g.medium"
 rds_db_version                            = "14.8"
-rds_backup_retention_period               = 35
+rds_backup_retention_period               = 1
 rds_monitoring_interval                   = 60
 rds_performance_insights_retention_period = 7
 
-elasticsearch_instance_size = "t3.medium.elasticsearch"
+elasticsearch_instance_size = "t3.small.elasticsearch"


### PR DESCRIPTION
The purpose of this PR was to try to deploy our serverless application to the separate int account and do what we can to get it working in a reasonable timeframe. We now have a working API in the new environment: https://new-int.api.octopus.ac/v1/

This was enabled by the code changes in this PR and some manual changes outside of the code:

- Remove resources labelled "new-prod" from account now that we have decided to move the int account instead.
- Provision as much as we can of the terraform infrastructure with the workspace "new-int" in the new account.
    - This is everything apart from 4 SES identities that can't be deployed without an error (we already knew this was an issue).
- Run a serverless deploy with the "new-int" stage.
    - This required creating a new certificate in certificate manager for *.api.octopus.ac in the new account. With this, serverless was able to provision "new-int.api.octopus.ac" in the current account's Route 53 hosted zone.
- Import data from the most recent system snapshot of the current int environment into the new-int RDS instance
- Index this data in the new-int opensearch instance

---

### Acceptance Criteria:

- Serverless has been used to deploy the lambda functions to the new int account
- We know whether our way of achieving this will be good enough for the real thing or whether there’s anything else we need to consider, or other changes needed to enable this

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [x] Documentation updated

---

### Tests:

N/A

---

### Screenshots:

Successful response from new API
![Screenshot 2024-04-17 155332](https://github.com/JiscSD/octopus/assets/132363734/fb524e1a-7ca0-4348-9286-1f331d1dc932)


