### PR TITLE
OC-813: Avoiding repeated back-navigation when using next/previous options

### DIFF
--- a/ui/src/components/IconButton/index.tsx
+++ b/ui/src/components/IconButton/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 type IconButtonProps = {
+    id?: string;
     className?: string;
     disabled?: boolean;
     icon: React.ReactElement;
@@ -10,6 +11,7 @@ type IconButtonProps = {
 
 const IconButton: React.FC<IconButtonProps> = (props) => (
     <button
+        id={props.id}
         title={props.title}
         disabled={props.disabled}
         className={`${

--- a/ui/src/layouts/BuildPublication.tsx
+++ b/ui/src/layouts/BuildPublication.tsx
@@ -9,7 +9,6 @@ import * as Helpers from '@/helpers';
 import * as Stores from '@/stores';
 import * as Config from '@/config';
 import * as api from '@/api';
-import * as Hooks from '@/hooks';
 
 import ClickAwayListener from 'react-click-away-listener';
 import axios from 'axios';
@@ -45,8 +44,7 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
     const [deleteModalVisibility, setDeleteModalVisibility] = React.useState(false);
     const [deleteModalLoading, setDeleteModalLoading] = React.useState(false);
     const [showSideBar, setShowSideBar] = useState(false);
-    const xl = Hooks.useMediaQuery('(min-width: 1280px)');
-    const lg = Hooks.useMediaQuery('(min-width: 1024px)');
+    const [navigationAnnouncement, setNavigationAnnouncement] = useState('');
 
     // Reset the store when navigating away from the publication flow, this is why we have the save feature
     // If I save a publication then go to create a new, my old data is still in the store, we dont want this
@@ -472,6 +470,19 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
     };
     const alerts = generateAlertComponents();
 
+    // When the user hits the prev/next buttons.
+    const sectionNavigate = (forward: boolean): void => {
+        const newStep = props.currentStep + (forward ? 1 : -1);
+        props.setStep(newStep);
+        Helpers.scrollTopSmooth();
+        setNavigationAnnouncement(`Navigated to ${props.steps[newStep].title} section and scrolled to top of section.`);
+    };
+
+    const topPrevButtonXlId = 'top-previous-button-xl-displays';
+    const topNextButtonXlId = 'top-next-button-xl-displays';
+    const topPrevButtonSmallId = 'top-previous-button-small-displays';
+    const topNextButtonSmallId = 'top-next-button-small-displays';
+
     return (
         <>
             <Components.Modal
@@ -625,6 +636,9 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
                             {store.publicationVersion &&
                                 Helpers.formatPublicationType(store.publicationVersion.publication.type)}
                         </span>
+                        <div aria-live="polite" className="sr-only">
+                            {navigationAnnouncement}
+                        </div>
                         <div className="hidden items-center justify-end gap-8 xl:flex xl:w-full xl:justify-between 2xl:w-auto 2xl:justify-end">
                             <div className="flex gap-4">
                                 <Components.Button
@@ -675,16 +689,18 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
                                     className="children:border-0"
                                     disabled={props.currentStep <= 0}
                                     startIcon={<OutlineIcons.ArrowLeftIcon className="h-4 w-4 text-teal-600" />}
-                                    onClick={() => props.setStep((prevState: number) => prevState - 1)}
+                                    onClick={() => sectionNavigate(false)}
                                     title="Previous"
+                                    id={topPrevButtonXlId}
                                 />
 
                                 <Components.Button
                                     className="children:border-0"
                                     disabled={props.currentStep >= props.steps.length - 1}
                                     endIcon={<OutlineIcons.ArrowRightIcon className="h-4 w-4 text-teal-600" />}
-                                    onClick={() => props.setStep((prevState: number) => prevState + 1)}
+                                    onClick={() => sectionNavigate(true)}
                                     title="Next"
+                                    id={topNextButtonXlId}
                                 />
                             </div>
                         </div>
@@ -732,13 +748,15 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
                                     title="Previous"
                                     icon={<OutlineIcons.ArrowLeftIcon className="h-4 w-4 text-teal-500" />}
                                     disabled={props.currentStep <= 0}
-                                    onClick={() => props.setStep((prevState: number) => prevState - 1)}
+                                    onClick={() => sectionNavigate(false)}
+                                    id={topPrevButtonSmallId}
                                 />
                                 <Components.IconButton
                                     title="Next"
                                     icon={<OutlineIcons.ArrowRightIcon className="h-4 w-4 text-teal-500" />}
                                     disabled={props.currentStep >= props.steps.length - 1}
-                                    onClick={() => props.setStep((prevState: number) => prevState + 1)}
+                                    onClick={() => sectionNavigate(true)}
+                                    id={topNextButtonSmallId}
                                 />
                             </div>
                         </div>
@@ -763,7 +781,10 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
                                 className="children:border-0"
                                 disabled={props.currentStep <= 0}
                                 startIcon={<OutlineIcons.ArrowLeftIcon className="h-4 w-4 text-teal-600" />}
-                                onClick={() => props.setStep((prevState: number) => prevState - 1)}
+                                onClick={() => {
+                                    sectionNavigate(false);
+                                    document.getElementById(topPrevButtonXlId)?.focus();
+                                }}
                                 title="Previous"
                             />
                             {props.steps.length - 1 === props.currentStep && (
@@ -816,7 +837,10 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
                                 disabled={props.currentStep <= 0}
                                 icon={<OutlineIcons.ArrowLeftIcon className="h-4 w-4" />}
                                 title="Previous"
-                                onClick={() => props.setStep((prevState: number) => prevState - 1)}
+                                onClick={() => {
+                                    sectionNavigate(false);
+                                    document.getElementById(topPrevButtonSmallId)?.focus();
+                                }}
                             />
                             {props.steps.length - 1 === props.currentStep && (
                                 <>
@@ -858,8 +882,8 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
                                     endIcon={<OutlineIcons.ArrowRightIcon className="h-4 w-4 text-teal-600" />}
                                     title="Next"
                                     onClick={() => {
-                                        props.setStep((prevState: number) => prevState + 1);
-                                        Helpers.scrollTopSmooth();
+                                        sectionNavigate(true);
+                                        document.getElementById(topNextButtonXlId)?.focus();
                                     }}
                                 />
 
@@ -869,8 +893,8 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
                                     icon={<OutlineIcons.ArrowRightIcon className="h-4 w-4" />}
                                     title="Next"
                                     onClick={() => {
-                                        props.setStep((prevState: number) => prevState + 1);
-                                        Helpers.scrollTopSmooth();
+                                        sectionNavigate(true);
+                                        document.getElementById(topNextButtonSmallId)?.focus();
                                     }}
                                 />
                             </>

--- a/ui/src/pages/publications/[id]/edit.tsx
+++ b/ui/src/pages/publications/[id]/edit.tsx
@@ -175,13 +175,13 @@ const Edit: Types.NextPage<Props> = (props): React.ReactElement => {
     const stepsToUse = Helpers.getTabCompleteness(stepsByType, store);
 
     // Choose which step to land the page on
-    let defaultStep = React.useMemo(() => {
-        let defaultStep = props.step ? parseInt(props.step) : 0;
-        defaultStep = defaultStep <= stepsToUse.length - 1 && defaultStep >= 0 ? defaultStep : 0;
-        return defaultStep;
+    let defaultStepIdx = React.useMemo(() => {
+        let defaultStepIdx = props.step ? parseInt(props.step) : 0;
+        defaultStepIdx = defaultStepIdx <= stepsToUse.length - 1 && defaultStepIdx >= 0 ? defaultStepIdx : 0;
+        return defaultStepIdx;
     }, [props.step, stepsToUse.length]);
 
-    const [currentStep, setCurrentStep] = React.useState(defaultStep);
+    const [currentStepIdx, setCurrentStepIdx] = React.useState(defaultStepIdx);
     const [publicationVersion] = React.useState(props.publicationVersion);
 
     React.useEffect(() => {
@@ -199,12 +199,14 @@ const Edit: Types.NextPage<Props> = (props): React.ReactElement => {
     React.useEffect(() => {
         router.push(
             {
-                query: { ...router.query, step: currentStep }
+                query: { ...router.query, step: currentStepIdx }
             },
             undefined,
             { shallow: true }
         );
-    }, [currentStep]);
+    }, [currentStepIdx]);
+
+    const currentStep = stepsToUse.find((step, index) => index === currentStepIdx);
 
     return (
         <>
@@ -217,24 +219,21 @@ const Edit: Types.NextPage<Props> = (props): React.ReactElement => {
 
             <Layouts.BuildPublication
                 steps={stepsToUse}
-                currentStep={currentStep}
-                setStep={setCurrentStep}
+                currentStep={currentStepIdx}
+                setStep={setCurrentStepIdx}
                 publicationVersion={publicationVersion}
                 token={props.token}
             >
                 {publicationVersion
-                    ? stepsToUse.map(
-                          (step, index) =>
-                              index === currentStep && (
-                                  <Framer.motion.section
-                                      key={index}
-                                      initial={{ opacity: 0 }}
-                                      animate={{ opacity: 1 }}
-                                      transition={{ duration: 0.35 }}
-                                  >
-                                      {step.component}
-                                  </Framer.motion.section>
-                              )
+                    ? currentStep && (
+                          <Framer.motion.section
+                              key={currentStepIdx}
+                              initial={{ opacity: 0 }}
+                              animate={{ opacity: 1 }}
+                              transition={{ duration: 0.35 }}
+                          >
+                              {currentStep.component}
+                          </Framer.motion.section>
                       )
                     : null}
             </Layouts.BuildPublication>


### PR DESCRIPTION
The purpose of this PR was to reposition focus at the top of the editing section when the user hits one of the lower prev/next buttons on the publication editing page. Up to now, focus remained in the same place, so users would have to backtrack through the new section entirely to get to the start of it.

Experimented with a few things, but on balance felt that changing focus to the equivalent button in the higher navigation area made the most sense, in combination with the message displayed in the aria-live region. The element is already focusable and the navigation immediately precedes the content area that has changed.

---

### Acceptance Criteria:

- After using the “Next” and “Previous” options at the bottom of each tab of the edit page, focus moves to the top of the newly displayed tab area
- An ARIA polite markup announces to the user that they have “Navigated to <tab title> section”

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
![Screenshot 2024-04-23 150036](https://github.com/JiscSD/octopus/assets/132363734/35540bf2-f8ac-4958-abd6-347ad61e2782)

E2E
![Screenshot 2024-04-23 145949](https://github.com/JiscSD/octopus/assets/132363734/eb04f07f-fc9b-4614-a9c0-bf3f2ddf66de)