### PR TITLE
OC-866: PDF failed to generate

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -15,7 +15,7 @@
                 "@opensearch-project/opensearch": "^2.5.0",
                 "@paralleldrive/cuid2": "^2.2.2",
                 "@prisma/client": "^5.11.0",
-                "@sparticuz/chromium": "^114.0.0",
+                "@sparticuz/chromium": "^119.0.2",
                 "ajv": "^8.12.0",
                 "ajv-formats": "^2.1.1",
                 "axios": "^1.6.8",
@@ -26,7 +26,7 @@
                 "jsonwebtoken": "^9.0.2",
                 "luxon": "^3.4.3",
                 "nodemailer": "^6.9.9",
-                "puppeteer-core": "^20.9.0",
+                "puppeteer-core": "^21.5.0",
                 "supertest": "^6.3.3"
             },
             "devDependencies": {
@@ -56,7 +56,7 @@
                 "nodemon": "^2.0.22",
                 "prettier": "^2.8.8",
                 "prisma": "^5.11.0",
-                "puppeteer": "^20.9.0",
+                "puppeteer": "^21.5.0",
                 "serverless-domain-manager": "^7.1.2",
                 "serverless-offline": "^12.0.4",
                 "serverless-offline-ssm": "^6.2.0",
@@ -7601,31 +7601,23 @@
             }
         },
         "node_modules/@puppeteer/browsers": {
-            "version": "1.4.6",
-            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.4.6.tgz",
-            "integrity": "sha512-x4BEjr2SjOPowNeiguzjozQbsc6h437ovD/wu+JpaenxVLm3jkgzHY2xOslMTp50HoTvQreMjiexiGQw1sqZlQ==",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
+            "integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
             "dependencies": {
                 "debug": "4.3.4",
                 "extract-zip": "2.0.1",
                 "progress": "2.0.3",
-                "proxy-agent": "6.3.0",
+                "proxy-agent": "6.3.1",
                 "tar-fs": "3.0.4",
                 "unbzip2-stream": "1.4.3",
-                "yargs": "17.7.1"
+                "yargs": "17.7.2"
             },
             "bin": {
                 "browsers": "lib/cjs/main-cli.js"
             },
             "engines": {
                 "node": ">=16.3.0"
-            },
-            "peerDependencies": {
-                "typescript": ">= 4.7.4"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@puppeteer/browsers/node_modules/tar-fs": {
@@ -7639,30 +7631,13 @@
             }
         },
         "node_modules/@puppeteer/browsers/node_modules/tar-stream": {
-            "version": "3.1.6",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
-            "integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+            "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
             "dependencies": {
                 "b4a": "^1.6.4",
                 "fast-fifo": "^1.2.0",
                 "streamx": "^2.15.0"
-            }
-        },
-        "node_modules/@puppeteer/browsers/node_modules/yargs": {
-            "version": "17.7.1",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-            "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
-            "dependencies": {
-                "cliui": "^8.0.1",
-                "escalade": "^3.1.1",
-                "get-caller-file": "^2.0.5",
-                "require-directory": "^2.1.1",
-                "string-width": "^4.2.3",
-                "y18n": "^5.0.5",
-                "yargs-parser": "^21.1.1"
-            },
-            "engines": {
-                "node": ">=12"
             }
         },
         "node_modules/@selderee/plugin-htmlparser2": {
@@ -9178,12 +9153,12 @@
             }
         },
         "node_modules/@sparticuz/chromium": {
-            "version": "114.0.0",
-            "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-114.0.0.tgz",
-            "integrity": "sha512-jzOUZInBjnJYXXCJFCDOEQb0t22Klx2+t7isZEiSOxLdDyDtDaykUS5c8Bw4KczWYb4fDxorO0D+g0rCFq5/gA==",
+            "version": "119.0.2",
+            "resolved": "https://registry.npmjs.org/@sparticuz/chromium/-/chromium-119.0.2.tgz",
+            "integrity": "sha512-VB6tHW13YpQ7HqyhKG1KU8Z1RIb/kfHMg8j/4ft5rk8mMvEm2YkBYFCHnj+yb0P/RPLcdgX3+VC58GuJilOtww==",
             "dependencies": {
-                "follow-redirects": "^1.15.2",
-                "tar-fs": "^2.1.1"
+                "follow-redirects": "^1.15.3",
+                "tar-fs": "^3.0.4"
             },
             "engines": {
                 "node": ">= 16"
@@ -9542,9 +9517,9 @@
             "dev": true
         },
         "node_modules/@types/yauzl": {
-            "version": "2.10.0",
-            "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
-            "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
+            "version": "2.10.3",
+            "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+            "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
             "optional": true,
             "dependencies": {
                 "@types/node": "*"
@@ -10571,6 +10546,47 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
+        "node_modules/bare-events": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.2.2.tgz",
+            "integrity": "sha512-h7z00dWdG0PYOQEvChhOSWvOfkIKsdZGkWr083FgN/HyoQuebSew/cgirYqh9SCuy/hRvxc5Vy6Fw8xAmYHLkQ==",
+            "optional": true
+        },
+        "node_modules/bare-fs": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.0.tgz",
+            "integrity": "sha512-TNFqa1B4N99pds2a5NYHR15o0ZpdNKbAeKTE/+G6ED/UeOavv8RY3dr/Fu99HW3zU3pXpo2kDNO8Sjsm2esfOw==",
+            "optional": true,
+            "dependencies": {
+                "bare-events": "^2.0.0",
+                "bare-path": "^2.0.0",
+                "bare-stream": "^1.0.0"
+            }
+        },
+        "node_modules/bare-os": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.3.0.tgz",
+            "integrity": "sha512-oPb8oMM1xZbhRQBngTgpcQ5gXw6kjOaRsSWsIeNyRxGed2w/ARyP7ScBYpWR1qfX2E5rS3gBw6OWcSQo+s+kUg==",
+            "optional": true
+        },
+        "node_modules/bare-path": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.1.tgz",
+            "integrity": "sha512-OHM+iwRDRMDBsSW7kl3dO62JyHdBKO3B25FB9vNQBPcGHMo4+eA8Yj41Lfbk3pS/seDY+siNge0LdRTulAau/A==",
+            "optional": true,
+            "dependencies": {
+                "bare-os": "^2.1.0"
+            }
+        },
+        "node_modules/bare-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-1.0.0.tgz",
+            "integrity": "sha512-KhNUoDL40iP4gFaLSsoGE479t0jHijfYdIcxRn/XtezA2BaUD0NRf/JGRpsMq6dMNM+SrCrB0YSSo/5wBY4rOQ==",
+            "optional": true,
+            "dependencies": {
+                "streamx": "^2.16.1"
+            }
+        },
         "node_modules/base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -10591,9 +10607,9 @@
             ]
         },
         "node_modules/basic-ftp": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.3.tgz",
-            "integrity": "sha512-QHX8HLlncOLpy54mh+k/sWIFd0ThmRqwe9ZjELybGZK+tZ8rUb9VO0saKJUROTbE+KhzDUT7xziGpGrW8Kmd+g==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+            "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
             "engines": {
                 "node": ">=10.0.0"
             }
@@ -10611,6 +10627,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
             "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+            "dev": true,
             "dependencies": {
                 "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
@@ -10621,6 +10638,7 @@
             "version": "5.7.1",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
             "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -11029,11 +11047,6 @@
                 "fsevents": "~2.3.2"
             }
         },
-        "node_modules/chownr": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
-        },
         "node_modules/chrome-trace-event": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
@@ -11043,11 +11056,12 @@
             }
         },
         "node_modules/chromium-bidi": {
-            "version": "0.4.16",
-            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.16.tgz",
-            "integrity": "sha512-7ZbXdWERxRxSwo3txsBjjmc/NLxqb1Bk30mRb0BMS4YIaiV6zvKZqL/UAH+DdqcDYayDWk2n/y8klkBDODrPvA==",
+            "version": "0.5.8",
+            "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.8.tgz",
+            "integrity": "sha512-blqh+1cEQbHBKmok3rVJkBlBxt9beKBgOsxbFgs7UJcoVbbeZ+K7+6liAsjgpc8l1Xd55cQUy14fXZdGSb4zIw==",
             "dependencies": {
-                "mitt": "3.0.0"
+                "mitt": "3.0.1",
+                "urlpattern-polyfill": "10.0.0"
             },
             "peerDependencies": {
                 "devtools-protocol": "*"
@@ -11474,21 +11488,29 @@
             "dev": true
         },
         "node_modules/cosmiconfig": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
-            "integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+            "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
             "dev": true,
             "dependencies": {
-                "import-fresh": "^3.2.1",
+                "env-paths": "^2.2.1",
+                "import-fresh": "^3.3.0",
                 "js-yaml": "^4.1.0",
-                "parse-json": "^5.0.0",
-                "path-type": "^4.0.0"
+                "parse-json": "^5.2.0"
             },
             "engines": {
                 "node": ">=14"
             },
             "funding": {
                 "url": "https://github.com/sponsors/d-fischer"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.9.5"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
             }
         },
         "node_modules/cosmiconfig/node_modules/argparse": {
@@ -12109,9 +12131,9 @@
             }
         },
         "node_modules/devtools-protocol": {
-            "version": "0.0.1147663",
-            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1147663.tgz",
-            "integrity": "sha512-hyWmRrexdhbZ1tcJUGpO95ivbRhWXz++F4Ko+n21AY5PNln2ovoJw+8ZMNDTtip+CNFQfrtLVh/w4009dXO/eQ=="
+            "version": "0.0.1232444",
+            "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1232444.tgz",
+            "integrity": "sha512-pM27vqEfxSxRkTMnF+XCmxSEb6duO5R+t8A9DEEJgy4Wz2RVanje2mmj99B6A3zv2r/qGfYlOvYznUhuokizmg=="
         },
         "node_modules/dezalgo": {
             "version": "1.0.4",
@@ -12318,6 +12340,15 @@
             },
             "funding": {
                 "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/env-paths": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+            "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+            "dev": true,
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/error-ex": {
@@ -13501,7 +13532,8 @@
         "node_modules/fs-constants": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+            "dev": true
         },
         "node_modules/fs-extra": {
             "version": "10.1.0",
@@ -13696,54 +13728,38 @@
             }
         },
         "node_modules/get-uri": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.1.tgz",
-            "integrity": "sha512-7ZqONUVqaabogsYNWlYj0t3YZaL6dhuEueZXGF+/YVmf6dHmaFg8/6psJKqhx9QykIDKzpGcy2cn4oV4YC7V/Q==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
+            "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
             "dependencies": {
                 "basic-ftp": "^5.0.2",
-                "data-uri-to-buffer": "^5.0.1",
+                "data-uri-to-buffer": "^6.0.2",
                 "debug": "^4.3.4",
-                "fs-extra": "^8.1.0"
+                "fs-extra": "^11.2.0"
             },
             "engines": {
                 "node": ">= 14"
             }
         },
         "node_modules/get-uri/node_modules/data-uri-to-buffer": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-5.0.1.tgz",
-            "integrity": "sha512-a9l6T1qqDogvvnw0nKlfZzqsyikEBZBClF39V3TFoKhDtGBqHu2HkuomJc02j5zft8zrUaXEuoicLeW54RkzPg==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+            "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
             "engines": {
                 "node": ">= 14"
             }
         },
         "node_modules/get-uri/node_modules/fs-extra": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
             "dependencies": {
                 "graceful-fs": "^4.2.0",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
             },
             "engines": {
-                "node": ">=6 <7 || >=8"
-            }
-        },
-        "node_modules/get-uri/node_modules/jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/get-uri/node_modules/universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-            "engines": {
-                "node": ">= 4.0.0"
+                "node": ">=14.14"
             }
         },
         "node_modules/glob": {
@@ -14015,9 +14031,9 @@
             "dev": true
         },
         "node_modules/http-proxy-agent": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
-            "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
             "dependencies": {
                 "agent-base": "^7.1.0",
                 "debug": "^4.3.4"
@@ -14182,7 +14198,8 @@
         "node_modules/inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
         },
         "node_modules/inquirer": {
             "version": "8.2.5",
@@ -14224,10 +14241,22 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/ip": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-            "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ=="
+        "node_modules/ip-address": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+            "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+            "dependencies": {
+                "jsbn": "1.1.0",
+                "sprintf-js": "^1.1.3"
+            },
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/ip-address/node_modules/sprintf-js": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
         },
         "node_modules/is-arguments": {
             "version": "1.1.1",
@@ -15375,6 +15404,11 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
+        "node_modules/jsbn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+            "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+        },
         "node_modules/jsdom": {
             "version": "24.0.0",
             "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.0.0.tgz",
@@ -15664,7 +15698,6 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
             "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-            "dev": true,
             "dependencies": {
                 "universalify": "^2.0.0"
             },
@@ -16704,9 +16737,9 @@
             }
         },
         "node_modules/mitt": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
-            "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ=="
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+            "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
         },
         "node_modules/mkdirp-classic": {
             "version": "0.5.3",
@@ -17361,27 +17394,27 @@
             }
         },
         "node_modules/pac-proxy-agent": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.0.tgz",
-            "integrity": "sha512-t4tRAMx0uphnZrio0S0Jw9zg3oDbz1zVhQ/Vy18FjLfP1XOLNUEjaVxYCYRI6NS+BsMBXKIzV6cTLOkO9AtywA==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.1.tgz",
+            "integrity": "sha512-ASV8yU4LLKBAjqIPMbrgtaKIvxQri/yh2OpI+S6hVa9JRkUI3Y3NPFbfngDtY7oFtSMD3w31Xns89mDa3Feo5A==",
             "dependencies": {
                 "@tootallnate/quickjs-emscripten": "^0.23.0",
                 "agent-base": "^7.0.2",
                 "debug": "^4.3.4",
                 "get-uri": "^6.0.1",
                 "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.2",
                 "pac-resolver": "^7.0.0",
-                "socks-proxy-agent": "^8.0.1"
+                "socks-proxy-agent": "^8.0.2"
             },
             "engines": {
                 "node": ">= 14"
             }
         },
         "node_modules/pac-proxy-agent/node_modules/agent-base": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-            "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
             "dependencies": {
                 "debug": "^4.3.4"
             },
@@ -17390,9 +17423,9 @@
             }
         },
         "node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.1.tgz",
-            "integrity": "sha512-Eun8zV0kcYS1g19r78osiQLEFIRspRUDd9tIfBCTBPBeMieF/EsJNL8VI3xOIdYRDEkjQnqOYPsZ2DsWsVsFwQ==",
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+            "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
             "dependencies": {
                 "agent-base": "^7.0.2",
                 "debug": "4"
@@ -17831,27 +17864,27 @@
             }
         },
         "node_modules/proxy-agent": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.0.tgz",
-            "integrity": "sha512-0LdR757eTj/JfuU7TL2YCuAZnxWXu3tkJbg4Oq3geW/qFNT/32T0sp2HnZ9O0lMR4q3vwAt0+xCA8SR0WAD0og==",
+            "version": "6.3.1",
+            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.1.tgz",
+            "integrity": "sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==",
             "dependencies": {
                 "agent-base": "^7.0.2",
                 "debug": "^4.3.4",
                 "http-proxy-agent": "^7.0.0",
-                "https-proxy-agent": "^7.0.0",
+                "https-proxy-agent": "^7.0.2",
                 "lru-cache": "^7.14.1",
-                "pac-proxy-agent": "^7.0.0",
+                "pac-proxy-agent": "^7.0.1",
                 "proxy-from-env": "^1.1.0",
-                "socks-proxy-agent": "^8.0.1"
+                "socks-proxy-agent": "^8.0.2"
             },
             "engines": {
                 "node": ">= 14"
             }
         },
         "node_modules/proxy-agent/node_modules/agent-base": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-            "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
             "dependencies": {
                 "debug": "^4.3.4"
             },
@@ -17860,9 +17893,9 @@
             }
         },
         "node_modules/proxy-agent/node_modules/https-proxy-agent": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.1.tgz",
-            "integrity": "sha512-Eun8zV0kcYS1g19r78osiQLEFIRspRUDd9tIfBCTBPBeMieF/EsJNL8VI3xOIdYRDEkjQnqOYPsZ2DsWsVsFwQ==",
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+            "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
             "dependencies": {
                 "agent-base": "^7.0.2",
                 "debug": "4"
@@ -17913,48 +17946,43 @@
             }
         },
         "node_modules/puppeteer": {
-            "version": "20.9.0",
-            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-20.9.0.tgz",
-            "integrity": "sha512-kAglT4VZ9fWEGg3oLc4/de+JcONuEJhlh3J6f5R1TLkrY/EHHIHxWXDOzXvaxQCtedmyVXBwg8M+P8YCO/wZjw==",
+            "version": "21.11.0",
+            "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.11.0.tgz",
+            "integrity": "sha512-9jTHuYe22TD3sNxy0nEIzC7ZrlRnDgeX3xPkbS7PnbdwYjl2o/z/YuCrRBwezdKpbTDTJ4VqIggzNyeRcKq3cg==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
-                "@puppeteer/browsers": "1.4.6",
-                "cosmiconfig": "8.2.0",
-                "puppeteer-core": "20.9.0"
+                "@puppeteer/browsers": "1.9.1",
+                "cosmiconfig": "9.0.0",
+                "puppeteer-core": "21.11.0"
+            },
+            "bin": {
+                "puppeteer": "lib/esm/puppeteer/node/cli.js"
             },
             "engines": {
-                "node": ">=16.3.0"
+                "node": ">=16.13.2"
             }
         },
         "node_modules/puppeteer-core": {
-            "version": "20.9.0",
-            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.9.0.tgz",
-            "integrity": "sha512-H9fYZQzMTRrkboEfPmf7m3CLDN6JvbxXA3qTtS+dFt27tR+CsFHzPsT6pzp6lYL6bJbAPaR0HaPO6uSi+F94Pg==",
+            "version": "21.11.0",
+            "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.11.0.tgz",
+            "integrity": "sha512-ArbnyA3U5SGHokEvkfWjW+O8hOxV1RSJxOgriX/3A4xZRqixt9ZFHD0yPgZQF05Qj0oAqi8H/7stDorjoHY90Q==",
             "dependencies": {
-                "@puppeteer/browsers": "1.4.6",
-                "chromium-bidi": "0.4.16",
+                "@puppeteer/browsers": "1.9.1",
+                "chromium-bidi": "0.5.8",
                 "cross-fetch": "4.0.0",
                 "debug": "4.3.4",
-                "devtools-protocol": "0.0.1147663",
-                "ws": "8.13.0"
+                "devtools-protocol": "0.0.1232444",
+                "ws": "8.16.0"
             },
             "engines": {
-                "node": ">=16.3.0"
-            },
-            "peerDependencies": {
-                "typescript": ">= 4.7.4"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
+                "node": ">=16.13.2"
             }
         },
         "node_modules/puppeteer-core/node_modules/ws": {
-            "version": "8.13.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-            "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+            "version": "8.16.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+            "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -18071,6 +18099,7 @@
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
             "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "dev": true,
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -19744,24 +19773,24 @@
             }
         },
         "node_modules/socks": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-            "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+            "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
             "dependencies": {
-                "ip": "^2.0.0",
+                "ip-address": "^9.0.5",
                 "smart-buffer": "^4.2.0"
             },
             "engines": {
-                "node": ">= 10.13.0",
+                "node": ">= 10.0.0",
                 "npm": ">= 3.0.0"
             }
         },
         "node_modules/socks-proxy-agent": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.1.tgz",
-            "integrity": "sha512-59EjPbbgg8U3x62hhKOFVAmySQUcfRQ4C7Q/D5sEHnZTQRrQlNKINks44DMR1gwXp0p4LaVIeccX2KHTTcHVqQ==",
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.3.tgz",
+            "integrity": "sha512-VNegTZKhuGq5vSD6XNKlbqWhyt/40CgoEw8XxD6dhnm8Jq9IEa3nIa4HwnM8XOqU0CdB0BwWVXusqiFXfHB3+A==",
             "dependencies": {
-                "agent-base": "^7.0.1",
+                "agent-base": "^7.1.1",
                 "debug": "^4.3.4",
                 "socks": "^2.7.1"
             },
@@ -19770,9 +19799,9 @@
             }
         },
         "node_modules/socks-proxy-agent/node_modules/agent-base": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-            "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
             "dependencies": {
                 "debug": "^4.3.4"
             },
@@ -19907,18 +19936,22 @@
             }
         },
         "node_modules/streamx": {
-            "version": "2.15.0",
-            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.0.tgz",
-            "integrity": "sha512-HcxY6ncGjjklGs1xsP1aR71INYcsXFJet5CU1CHqihQ2J5nOsbd4OjgjHO42w/4QNv9gZb3BueV+Vxok5pLEXg==",
+            "version": "2.16.1",
+            "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.16.1.tgz",
+            "integrity": "sha512-m9QYj6WygWyWa3H1YY69amr4nVgy61xfjys7xO7kviL5rfIEc2naf+ewFiOA+aEJD7y0JO3h2GoiUv4TDwEGzQ==",
             "dependencies": {
                 "fast-fifo": "^1.1.0",
                 "queue-tick": "^1.0.1"
+            },
+            "optionalDependencies": {
+                "bare-events": "^2.2.0"
             }
         },
         "node_modules/string_decoder": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
             "dependencies": {
                 "safe-buffer": "~5.1.0"
             }
@@ -19926,7 +19959,8 @@
         "node_modules/string_decoder/node_modules/safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
         },
         "node_modules/string-argv": {
             "version": "0.3.2",
@@ -20244,20 +20278,33 @@
             }
         },
         "node_modules/tar-fs": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.5.tgz",
+            "integrity": "sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==",
             "dependencies": {
-                "chownr": "^1.1.1",
-                "mkdirp-classic": "^0.5.2",
                 "pump": "^3.0.0",
-                "tar-stream": "^2.1.4"
+                "tar-stream": "^3.1.5"
+            },
+            "optionalDependencies": {
+                "bare-fs": "^2.1.1",
+                "bare-path": "^2.1.0"
+            }
+        },
+        "node_modules/tar-fs/node_modules/tar-stream": {
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+            "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+            "dependencies": {
+                "b4a": "^1.6.4",
+                "fast-fifo": "^1.2.0",
+                "streamx": "^2.15.0"
             }
         },
         "node_modules/tar-stream": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
             "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+            "dev": true,
             "dependencies": {
                 "bl": "^4.0.3",
                 "end-of-stream": "^1.4.1",
@@ -20904,7 +20951,7 @@
             "version": "5.2.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
             "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-            "devOptional": true,
+            "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -20979,7 +21026,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
             "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-            "dev": true,
             "engines": {
                 "node": ">= 10.0.0"
             }
@@ -21066,6 +21112,11 @@
                 "node": ">=0.4.x"
             }
         },
+        "node_modules/urlpattern-polyfill": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+            "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg=="
+        },
         "node_modules/util": {
             "version": "0.12.5",
             "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
@@ -21082,7 +21133,8 @@
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+            "dev": true
         },
         "node_modules/uuid": {
             "version": "8.3.2",
@@ -21486,7 +21538,6 @@
             "version": "17.7.2",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
             "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-            "dev": true,
             "dependencies": {
                 "cliui": "^8.0.1",
                 "escalade": "^3.1.1",

--- a/api/package.json
+++ b/api/package.json
@@ -37,7 +37,7 @@
         "@opensearch-project/opensearch": "^2.5.0",
         "@paralleldrive/cuid2": "^2.2.2",
         "@prisma/client": "^5.11.0",
-        "@sparticuz/chromium": "^114.0.0",
+        "@sparticuz/chromium": "^119.0.2",
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
         "axios": "^1.6.8",
@@ -48,7 +48,7 @@
         "jsonwebtoken": "^9.0.2",
         "luxon": "^3.4.3",
         "nodemailer": "^6.9.9",
-        "puppeteer-core": "^20.9.0",
+        "puppeteer-core": "^21.5.0",
         "supertest": "^6.3.3"
     },
     "devDependencies": {
@@ -78,7 +78,7 @@
         "nodemon": "^2.0.22",
         "prettier": "^2.8.8",
         "prisma": "^5.11.0",
-        "puppeteer": "^20.9.0",
+        "puppeteer": "^21.5.0",
         "serverless-domain-manager": "^7.1.2",
         "serverless-offline": "^12.0.4",
         "serverless-offline-ssm": "^6.2.0",

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -50,6 +50,7 @@ provider:
         QUEUE_URL: ${ssm:/queue_url_${self:provider.stage}_octopus}
         SQS_ENDPOINT: ${ssm:/sqs_endpoint_${self:provider.stage}_octopus}
         MAIL_SERVER: ${ssm:/mail_server_${self:provider.stage}_octopus}
+        SLACK_CHANNEL_EMAIL: ${ssm:/slack_channel_email_${self:provider.stage}_octopus}
     deploymentBucket:
         tags:
             Project: Octopus

--- a/api/src/components/publicationVersion/service.ts
+++ b/api/src/components/publicationVersion/service.ts
@@ -3,12 +3,12 @@ import { Prisma } from '@prisma/client';
 import { createId } from '@paralleldrive/cuid2';
 import { Browser, launch } from 'puppeteer-core';
 import { PutObjectCommand } from '@aws-sdk/client-s3';
-import * as I from 'interface';
 import * as client from 'lib/client';
 import * as Helpers from 'lib/helpers';
-import * as s3 from 'lib/s3';
+import * as I from 'interface';
 import * as publicationService from 'publication/service';
 import * as referenceService from 'reference/service';
+import * as s3 from 'lib/s3';
 
 const defaultPublicationVersionInclude = {
     publication: {
@@ -624,9 +624,11 @@ export const generatePDF = async (publicationVersion: I.PublicationVersion): Pro
 
         const page = await browser.newPage();
         await page.setViewport({ width: 1440, height: 900, deviceScaleFactor: 2 });
+        console.log('Page viewport set');
         await page.setContent(htmlTemplate, {
             waitUntil: htmlTemplate.includes('<img') ? ['load', 'networkidle0'] : undefined
         });
+        console.log('Page content set');
 
         const pdf = await page.pdf({
             format: 'a4',
@@ -636,6 +638,7 @@ export const generatePDF = async (publicationVersion: I.PublicationVersion): Pro
             headerTemplate: Helpers.createPublicationHeaderTemplate(publicationVersion),
             footerTemplate: Helpers.createPublicationFooterTemplate(publicationVersion)
         });
+        console.log('Page exported to PDF');
 
         // upload pdf to S3
         await s3.client.send(

--- a/api/src/components/sqs/handler.ts
+++ b/api/src/components/sqs/handler.ts
@@ -1,5 +1,7 @@
 import axios from 'axios';
 
+import * as email from 'lib/email';
+
 export const generatePDFs = async (event): Promise<void> => {
     for (const record of event.Records) {
         const { body } = record;
@@ -10,6 +12,14 @@ export const generatePDFs = async (event): Promise<void> => {
             );
         } catch (err) {
             console.log(err);
+            // Send notification when PDF has failed to generate
+            const message = `PDF generation for publication with ID ${body} has failed. Please check the function logs.`;
+            await email.send({
+                to: process.env.SLACK_CHANNEL_EMAIL || '',
+                subject: 'A PDF has failed to generate',
+                html: `<html><body><p>${message}</p></body></html>`,
+                text: message
+            });
         }
     }
 };


### PR DESCRIPTION
The purpose of this PR was to investigate a [publication](https://int.octopus.ac/publications/ysjc-sc09/versions/latest) on int which had failed to generate a PDF.

There is an (almost) identical [publication](https://www.octopus.ac/publications/nv07-6x75/versions/latest) on prod that had its PDF generate successfully.

The PDF is now generated: https://s3.eu-west-1.amazonaws.com/science-octopus-publishing-pdfs-int/ysjc-sc09.pdf

---

### Acceptance Criteria:

- Successfully generate the PDF that has been failing
- Set up extra logging for PDF generation
- Set up slack notifications for when PDF generation fails

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

API
![Screenshot 2024-04-25 114927](https://github.com/JiscSD/octopus/assets/132363734/ea5148b8-63c2-4f17-884e-d0d1e45101e9)

E2E
![Screenshot 2024-04-25 113030](https://github.com/JiscSD/octopus/assets/132363734/6fa8d592-7fe2-4ece-874c-8c6d7309275d)

---

### Screenshots:
