### PR TITLE
OC-867: Secure docker-compose file

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -32,7 +32,7 @@ jobs:
         run: docker compose -f "docker-compose.yml" up -d --build
 
       - name: Wait for API and DB to be ready
-        run: docker exec -t api-test dockerize -wait tcp://db:5432 -wait tcp://api-test:4003 -wait tcp://mailhog:8025 -wait tcp://localstack:4566 -timeout 120s
+        run: docker exec -t api-test dockerize -wait tcp://db:5432 -wait tcp://api-test:4003 -wait tcp://mailpit:8025 -wait tcp://localstack:4566 -timeout 120s
 
       - name: Run test suite
         working-directory: ./api

--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -1,9 +1,7 @@
-version: '3.2'
-
 services:
     db:
         container_name: api-test-db
-        image: postgres:14.5
+        image: postgres:14.11
         command: postgres -c 'max_connections=1000'
         restart: always
         environment:
@@ -13,13 +11,13 @@ services:
         ports:
             - '5432:5432'
 
-    mailhog:
-        container_name: api-test-mailhog
-        image: mailhog/mailhog:latest
+    mailpit:
+        container_name: api-test-mailpit
+        image: axllent/mailpit:latest
         restart: always
         ports:
-            - 1025:1025
-            - 8025:8025
+            - '1025:1025'
+            - '8025:8025'
 
     localstack:
         container_name: api-test-localstack
@@ -28,24 +26,15 @@ services:
             - '4510-4559:4510-4559'
             - '4567:4566'
         environment:
-            - SERVICES=s3
+            - SERVICES=s3,sqs
             - DEBUG=1
             - DATA_DIR=/tmp/localstack/data
         volumes:
-            - './.localstack:/var/lib/localstack'
+            - '${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack'
             - '/var/run/docker.sock:/var/run/docker.sock'
 
-    adminer:
-        container_name: api-test-adminer
-        image: adminer
-        restart: always
-        ports:
-            - 8080:8080
-        depends_on:
-            - db
-
     opensearch-node1: # This is also the hostname of the container within the Docker network (i.e. https://opensearch-node1/)
-        image: opensearchproject/opensearch:2.7.0
+        image: opensearchproject/opensearch:2.13.0
         container_name: api-test-opensearch-node1
         environment:
             - cluster.name=opensearch-cluster # Name the cluster
@@ -63,8 +52,8 @@ services:
                 soft: 65536 # maximum number of open files for the OpenSearch user, set to at least 65536 on modern systems
                 hard: 65536
         ports:
-            - 9200:9200 # REST API
-            - 9600:9600 # Performance Analyzer
+            - '9200:9200' # REST API
+            - '9600:9600' # Performance Analyzer
         healthcheck:
             test: ['CMD', 'curl', '-f', 'http://localhost:9200']
             interval: 30s
@@ -72,12 +61,10 @@ services:
             retries: 5
 
     opensearch-dashboards:
-        image: opensearchproject/opensearch-dashboards:2.7.0
+        image: opensearchproject/opensearch-dashboards:2.13.0
         container_name: api-test-opensearch-dashboards
         ports:
-            - 5601:5601 # Map host port 5601 to container port 5601
-        expose:
-            - '5601' # Expose port 5601 for web access to OpenSearch Dashboards
+            - '5601:5601' # Map host port 5601 to container port 5601
         environment:
             - 'OPENSEARCH_HOSTS=["http://opensearch-node1:9200"]' # Define the OpenSearch nodes that OpenSearch Dashboards will query
             - 'DISABLE_SECURITY_DASHBOARDS_PLUGIN=true' # disables security dashboards plugin in OpenSearch Dashboards
@@ -103,7 +90,7 @@ services:
             - BASE_URL=https://localhost:3001
             - AUTHORISATION_CALLBACK_URL=https://localhost:3001/login
             - JWT_SECRET=PUT_JWT_SECRET_HERE
-            - MAIL_SERVER=mailhog
+            - MAIL_SERVER=mailpit
             - LOCALSTACK_SERVER=http://localstack:4566
             - STAGE=local
             - EMAIL_SENDER_ADDRESS=no-reply@local.ac

--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
     db:
         container_name: api-test-db
-        image: postgres:14.11
+        image: postgres:14.11-alpine
         command: postgres -c 'max_connections=1000'
         restart: always
         environment:

--- a/api/src/components/verification/__tests__/confirmCode.test.ts
+++ b/api/src/components/verification/__tests__/confirmCode.test.ts
@@ -1,5 +1,4 @@
 import * as testUtils from 'lib/testUtils';
-import * as cheerio from 'cheerio';
 
 describe('Confirm a verification code', () => {
     beforeEach(async () => {
@@ -36,16 +35,14 @@ describe('Confirm a verification code', () => {
     });
 
     test('User can confirm a correct verification code', async () => {
-        const email = 'example@domain.com';
+        const address = 'example@domain.com';
 
-        await testUtils.agent.get('/verification/0000-0000-0000-0001').query({ apiKey: 123456789, email });
+        await testUtils.agent.get('/verification/0000-0000-0000-0001').query({ apiKey: 123456789, email: address });
 
-        const inbox = await testUtils.getEmails(email);
-        const emailContent = inbox.items[0].Content.Body.replace(/3D"/g, '"'); // get rid of email encoding "3D"
-
-        // get verification code using cheerio
-        const $ = cheerio.load(emailContent);
-        const code = $('p[id="verification-code"]').text();
+        const emails = await testUtils.getEmails(address);
+        const emailId = emails.messages[0].ID;
+        const email = await testUtils.getEmail(emailId);
+        const code = email.Text.slice(-7); // Get code from end of email text body.
 
         const confirm = await testUtils.agent.post('/verification/0000-0000-0000-0001').send({ code });
 

--- a/api/src/components/verification/__tests__/requestCode.test.ts
+++ b/api/src/components/verification/__tests__/requestCode.test.ts
@@ -14,6 +14,6 @@ describe('Request a verification code', () => {
         const inbox = await testUtils.getEmails(email);
 
         expect(request.status).toEqual(200);
-        expect(inbox.items[0].Content.Headers.Subject).toContain('Verify your Octopus account');
+        expect(inbox.messages[0].Subject).toContain('Verify your Octopus account');
     });
 });

--- a/api/src/lib/testUtils.ts
+++ b/api/src/lib/testUtils.ts
@@ -116,24 +116,69 @@ export const clearDB = async (): Promise<void> => {
     }
 };
 
-interface Inbox {
-    items: {
-        Content: {
-            Headers: {
-                Subject: string;
-            };
-            Body: string;
-        };
-    };
+interface MailpitEmailAddress {
+    Name: string;
+    Address: string;
+}
+interface MailpitEmailSearchResponse {
+    total: number;
+    unread: number;
+    count: number;
+    messages_count: number;
+    start: number;
+    tags: string[];
+    messages: {
+        ID: string;
+        MessageID: string;
+        Read: boolean;
+        From: MailpitEmailAddress;
+        To: MailpitEmailAddress[];
+        Cc: MailpitEmailAddress[];
+        Bcc: MailpitEmailAddress[];
+        ReplyTo: MailpitEmailAddress[];
+        Subject: string;
+        Created: string;
+        Tags: string[];
+        Size: number;
+        Attachments: number;
+        Snippet: string;
+    }[];
 }
 
-export const getEmails = async (query: string): Promise<Inbox> => {
-    const emails = await axios.get(`http://${process.env.MAIL_SERVER}:8025/api/v2/search`, {
+export const getEmails = async (query: string): Promise<MailpitEmailSearchResponse> => {
+    const emails = await axios.get(`http://${process.env.MAIL_SERVER}:8025/api/v1/search`, {
         params: {
-            kind: 'to',
             query
         }
     });
 
-    return emails?.data as Inbox;
+    return emails?.data as MailpitEmailSearchResponse;
+};
+
+interface MailpitEmailResponse {
+    ID: string;
+    MessageID: string;
+    From: MailpitEmailAddress;
+    To: MailpitEmailAddress[];
+    Cc: MailpitEmailAddress[];
+    Bcc: MailpitEmailAddress[];
+    ReplyTo: MailpitEmailAddress[];
+    Subject: string;
+    ListUnsubscribe: {
+        Header: string;
+        Links: string[];
+        Errors: string;
+        HeaderPost: string;
+    };
+    Date: string;
+    Tags: string[];
+    Text: string;
+    HTML: string;
+    Size: number;
+}
+
+export const getEmail = async (id = 'latest'): Promise<MailpitEmailResponse> => {
+    const email = await axios.get(`http://${process.env.MAIL_SERVER}:8025/api/v1/message/${id}`);
+
+    return email?.data as MailpitEmailResponse;
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:14.11
+    image: postgres:14.11-alpine
     command: postgres -c 'max_connections=1000'
     restart: always
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
-version: "3.2"
-
 services:
   db:
-    image: postgres:14.5
+    image: postgres:14.11
     command: postgres -c 'max_connections=1000'
     restart: always
     environment:
@@ -12,20 +10,12 @@ services:
     ports:
       - "5435:5432"
 
-  adminer:
-    image: adminer
+  mailpit:
+    image: axllent/mailpit:latest
     restart: always
     ports:
-      - 8080:8080
-    depends_on:
-      - db
-
-  mailhog:
-    image: mailhog/mailhog:latest
-    restart: always
-    ports:
-      - 1025:1025
-      - 8025:8025
+      - "1025:1025"
+      - "8025:8025"
 
   localstack:
     image: localstack/localstack:${LOCALSTACK_IMAGE_VERSION:-latest}
@@ -34,15 +24,15 @@ services:
       - "4510-4559:4510-4559"
       - "4566:4566"
     environment:
-      - SERVICES=s3
+      - SERVICES=s3,sqs
       - DEBUG=1
       - DATA_DIR=/tmp/localstack/data
     volumes:
-      - "./.localstack:/tmp/localstack"
+      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"
 
   opensearch-node1: # This is also the hostname of the container within the Docker network (i.e. https://opensearch-node1/)
-    image: opensearchproject/opensearch:2.7.0
+    image: opensearchproject/opensearch:2.13.0
     restart: always
     container_name: opensearch-node1
     environment:
@@ -61,26 +51,24 @@ services:
         soft: 65536 # maximum number of open files for the OpenSearch user, set to at least 65536 on modern systems
         hard: 65536
     ports:
-      - 9200:9200 # REST API
-      - 9600:9600 # Performance Analyzer
+      - "9200:9200" # REST API
+      - "9600:9600" # Performance Analyzer
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9200"]
       interval: 30s
       timeout: 10s
       retries: 5
     networks:
-      - opensearch-net # All of the containers will join the same Docker bridge network
+      - opensearch-net
 
   opensearch-dashboards:
-    image: opensearchproject/opensearch-dashboards:2.7.0
+    image: opensearchproject/opensearch-dashboards:2.13.0
     restart: always
     container_name: opensearch-dashboards
     depends_on:
       - opensearch-node1
     ports:
-      - 5601:5601 # Map host port 5601 to container port 5601
-    expose:
-      - "5601" # Expose port 5601 for web access to OpenSearch Dashboards
+      - "5601:5601" # Map host port 5601 to container port 5601
     environment:
       - 'OPENSEARCH_HOSTS=["http://opensearch-node1:9200"]' # Define the OpenSearch nodes that OpenSearch Dashboards will query
       - "DISABLE_SECURITY_DASHBOARDS_PLUGIN=true" # disables security dashboards plugin in OpenSearch Dashboards

--- a/e2e/.env.example
+++ b/e2e/.env.example
@@ -18,5 +18,5 @@ ORCID_TEST_PASS4=
 ORCID_TEST_FIRST_NAME4=
 ORCID_TEST_LAST_NAME4=
 
-MAIL_HOG=http://localhost:8025/
+MAILPIT=http://localhost:8025/
 UI_BASE=https://localhost:3001

--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -672,22 +672,22 @@ const requestApproval = async (page: Page) => {
 };
 
 const confirmInvolvement = async (browser: Browser, user: Helpers.TestUser, page: Page) => {
-    const mailhogPage = await browser.newPage();
-    await mailhogPage.goto(Helpers.MAIL_HOG);
-    await mailhogPage.waitForSelector('.messages > .row');
-    await mailhogPage
-        .locator(`.msglist-message:has-text("${user.email}")`, {
+    const mailpitPage = await browser.newPage();
+    await mailpitPage.goto(Helpers.MAILPIT);
+    await mailpitPage.waitForSelector('#message-page');
+    await mailpitPage
+        .locator(`.message:has-text("${user.email}")`, {
             hasText: 'You’ve been added as a co-author on Octopus'
         })
         .first()
         .click();
 
     // clicking 'Confirm & Review Publication' link is blocked by cors
-    const invitationLink = await mailhogPage
+    const invitationLink = await mailpitPage
         .frameLocator('iframe')
         .locator("a:has-text('Confirm & Review Publication')")
         .getAttribute('href');
-    await mailhogPage.close();
+    await mailpitPage.close();
     // navigate to that link instead
     await page.goto(invitationLink);
     await expect(page.locator('a[title="Select your affiliations"]')).toBeVisible();
@@ -727,12 +727,12 @@ const approveControlRequest = async (
 ) => {
     const page = await Helpers.getPageAsUser(browser, user);
 
-    await page.goto(Helpers.MAIL_HOG);
-    await page.waitForSelector('.messages > .row');
+    await page.goto(Helpers.MAILPIT);
+    await page.waitForSelector('#message-page');
 
     // click on the latest request for the given 'requesterName' that has been sent to this user
     await page
-        .locator(`.msglist-message:has-text("${user.email}")`, {
+        .locator(`.message:has-text("${user.email}")`, {
             hasText: `${requesterName} is requesting to take over editing`
         })
         .first()
@@ -766,12 +766,12 @@ const rejectCoAuthorInvitation = async (
 ) => {
     const page = await Helpers.getPageAsUser(browser, user);
     const page2 = await browser.newPage();
-    await page2.goto(Helpers.MAIL_HOG);
-    await page2.waitForSelector('.messages > .row');
+    await page2.goto(Helpers.MAILPIT);
+    await page2.waitForSelector('#message-page');
 
     // click latest invitation link which was sent to this user and has text: "You’ve been added as a co-author on Octopus"
     await page2
-        .locator(`.msglist-message:has-text("${user.email}")`, {
+        .locator(`.message:has-text("${user.email}")`, {
             hasText: 'You’ve been added as a co-author on Octopus'
         })
         .first()
@@ -797,9 +797,9 @@ const rejectCoAuthorInvitation = async (
 const verifyLastEmailNotification = async (browser: Browser, user: Helpers.TestUser, emailSubject: string) => {
     const context = await browser.newContext();
     const page = await context.newPage();
-    await page.goto(Helpers.MAIL_HOG);
+    await page.goto(Helpers.MAILPIT);
     // verify last notification sent to this email
-    await expect(page.locator(`.msglist-message:has-text("${user.email}")`).first()).toContainText(emailSubject);
+    await expect(page.locator(`.message:has-text("${user.email}")`).first()).toContainText(emailSubject);
     await context.close();
 };
 
@@ -1416,9 +1416,9 @@ test.describe('Publication flow + co-authors', () => {
         await expect(page.getByText('Reminder sent at')).toBeVisible();
 
         // check email
-        await page.goto(Helpers.MAIL_HOG);
+        await page.goto(Helpers.MAILPIT);
         await page
-            .locator(`.msglist-message:has-text("${Helpers.user2.email}")`, {
+            .locator(`.message:has-text("${Helpers.user2.email}")`, {
                 hasText: 'You’ve been added as a co-author on Octopus'
             })
             .first()

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -1,7 +1,7 @@
 import { Browser, expect, Locator, Page } from '@playwright/test';
 import { PageModel } from './PageModel';
 
-export const MAIL_HOG = process.env.MAIL_HOG;
+export const MAILPIT = process.env.MAILPIT;
 
 export const STORAGE_STATE_BASE = 'playwright/.auth/';
 
@@ -22,7 +22,7 @@ const requiredEnvVariables = [
     'ORCID_TEST_PASS4',
     'ORCID_TEST_FIRST_NAME4',
     'ORCID_TEST_LAST_NAME4',
-    'MAIL_HOG',
+    'MAILPIT',
     'UI_BASE'
 ];
 
@@ -113,10 +113,10 @@ export const login = async (page: Page, browser: Browser, user: TestUser) => {
         const context = await browser.newContext();
         const [newPage] = await Promise.all([context.waitForEvent('page'), context.newPage()]);
 
-        // navigate to MailHog and take the last verification code sent to this user
-        await newPage.goto(MAIL_HOG);
+        // navigate to Mailpit and take the last verification code sent to this user
+        await newPage.goto(MAILPIT);
         await newPage
-            .locator(`.msglist-message:has-text("${user.email}")`, { hasText: 'Verify your Octopus account' })
+            .locator(`.message:has-text("${user.email}")`, { hasText: 'Verify your Octopus account' })
             .first()
             .click();
         const verificationCode = await newPage.frameLocator('iframe').locator('#verification-code').textContent();


### PR DESCRIPTION
The purpose of this PR was to make changes to the docker-compose file to stop our use of outdated docker images that have security vulnerabilities.

This is mostly using later image versions but two changes were a bit different:
- Mailhog was swapped out for a similar application called Mailpit which was pretty much like for like. Mailpit is actively updated while mailhog hadn't been updated for some time.
- Adminer was removed because its latest docker image had vulnerabilities and a similar utility can be got from running `npx prisma studio` in the /api directory.

---

### Acceptance Criteria:

- Update vulnerable / outdated software  / docker images in use on the docker containers.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

E2E
![Screenshot 2024-04-30 111104](https://github.com/JiscSD/octopus/assets/132363734/abe2fd96-57d7-4e17-b9c7-76505feb0cc3)
