### PR TITLE
OC-771 - Displaying all cross links

### DIFF
--- a/api/prisma/migrations/20240509091139_crosslink_score/migration.sql
+++ b/api/prisma/migrations/20240509091139_crosslink_score/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Crosslink" ADD COLUMN     "score" INTEGER NOT NULL DEFAULT 1;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -264,6 +264,9 @@ model Crosslink {
     user              User            @relation(fields: [createdBy], references: [id], onDelete: Cascade)
     votes             CrosslinkVote[]
     createdAt         DateTime        @default(now())
+    // Score can be deduced via "votes" relation, but we need it at query time.
+    // Prisma can do computed fields, but these only support scalar fields, not relations.
+    score             Int             @default(1) // Creator automatically upvotes their own crosslink on creation.
 
     @@unique([publicationFromId, publicationToId])
 }

--- a/api/prisma/seeds/publications.ts
+++ b/api/prisma/seeds/publications.ts
@@ -453,6 +453,7 @@ const publicationSeeds: Prisma.PublicationCreateInput[] = [
                 publicationToId: 'publication-problem-live',
                 createdBy: 'test-user-1',
                 createdAt: '2024-01-22T10:00:00.000Z',
+                score: 3,
                 votes: {
                     createMany: {
                         data: [
@@ -547,6 +548,7 @@ const publicationSeeds: Prisma.PublicationCreateInput[] = [
                 publicationToId: 'publication-hypothesis-live',
                 createdBy: 'test-user-2',
                 createdAt: '2024-01-22T11:00:00.000Z',
+                score: -3,
                 votes: {
                     createMany: {
                         data: [
@@ -646,6 +648,7 @@ const publicationSeeds: Prisma.PublicationCreateInput[] = [
                 publicationToId: 'publication-hypothesis-live',
                 createdBy: 'test-user-3',
                 createdAt: '2024-01-22T12:00:00.000Z',
+                score: 1,
                 votes: {
                     createMany: {
                         data: [
@@ -720,6 +723,7 @@ const publicationSeeds: Prisma.PublicationCreateInput[] = [
                 publicationToId: 'publication-hypothesis-live',
                 createdBy: 'test-user-4',
                 createdAt: '2024-01-22T13:00:00.000Z',
+                score: -1,
                 votes: {
                     createMany: {
                         data: [

--- a/api/prisma/seeds/publicationsDevSeedData.ts
+++ b/api/prisma/seeds/publicationsDevSeedData.ts
@@ -983,6 +983,7 @@ const newPublicationSeeds: Prisma.PublicationCreateInput[] = [
                 publicationToId: 'publication-user-1-problem-1-live',
                 createdBy: users.user6,
                 createdAt: '2024-04-10T13:33:00.000Z',
+                score: -3,
                 votes: {
                     createMany: {
                         data: [
@@ -1171,6 +1172,7 @@ const newPublicationSeeds: Prisma.PublicationCreateInput[] = [
                 publicationToId: 'publication-user-1-problem-1-live',
                 createdBy: users.user1,
                 createdAt: '2024-04-10T13:31:00.000Z',
+                score: 5,
                 votes: {
                     createMany: {
                         data: [

--- a/api/src/components/crosslink/__tests__/getPublicationCrosslinks.test.ts
+++ b/api/src/components/crosslink/__tests__/getPublicationCrosslinks.test.ts
@@ -112,4 +112,13 @@ describe('Get crosslinks of a publication', () => {
         expect(getCrosslinks.body.data[0].createdAt).toEqual('2024-01-22T11:00:00.000Z');
         expect(getCrosslinks.body.data[1].createdAt).toEqual('2024-01-22T10:00:00.000Z');
     });
+
+    test('Mixed sort order cannot be used with pagination', async () => {
+        const getCrosslinks = await testUtils.agent
+            .get('/publications/publication-hypothesis-live/crosslinks')
+            .query({ offset: 2, order: 'mix' });
+
+        expect(getCrosslinks.status).toEqual(400);
+        expect(getCrosslinks.body.message).toEqual('Pagination cannot be used with "mix" sort order.');
+    });
 });

--- a/api/src/components/crosslink/__tests__/getPublicationCrosslinks.test.ts
+++ b/api/src/components/crosslink/__tests__/getPublicationCrosslinks.test.ts
@@ -10,12 +10,12 @@ describe('Get crosslinks of a publication', () => {
         const getCrosslinks = await testUtils.agent.get('/publications/publication-hypothesis-live/crosslinks');
 
         expect(getCrosslinks.status).toEqual(200);
-        expect(getCrosslinks.body).toHaveLength(4);
+        expect(getCrosslinks.body.data).toHaveLength(4);
         // Confirm that sort order is default (crosslink creation date, descending).
-        expect(getCrosslinks.body[0].createdAt).toEqual('2024-01-22T13:00:00.000Z');
-        expect(getCrosslinks.body[1].createdAt).toEqual('2024-01-22T12:00:00.000Z');
-        expect(getCrosslinks.body[2].createdAt).toEqual('2024-01-22T11:00:00.000Z');
-        expect(getCrosslinks.body[3].createdAt).toEqual('2024-01-22T10:00:00.000Z');
+        expect(getCrosslinks.body.data[0].createdAt).toEqual('2024-01-22T13:00:00.000Z');
+        expect(getCrosslinks.body.data[1].createdAt).toEqual('2024-01-22T12:00:00.000Z');
+        expect(getCrosslinks.body.data[2].createdAt).toEqual('2024-01-22T11:00:00.000Z');
+        expect(getCrosslinks.body.data[3].createdAt).toEqual('2024-01-22T10:00:00.000Z');
     });
 
     test('User can sort publication crosslinks by score', async () => {
@@ -24,10 +24,10 @@ describe('Get crosslinks of a publication', () => {
             .query({ order: 'relevant' });
 
         expect(getCrosslinks.status).toEqual(200);
-        expect(getCrosslinks.body[0].score).toEqual(3);
-        expect(getCrosslinks.body[1].score).toEqual(1);
-        expect(getCrosslinks.body[2].score).toEqual(-1);
-        expect(getCrosslinks.body[3].score).toEqual(-3);
+        expect(getCrosslinks.body.data[0].score).toEqual(3);
+        expect(getCrosslinks.body.data[1].score).toEqual(1);
+        expect(getCrosslinks.body.data[2].score).toEqual(-1);
+        expect(getCrosslinks.body.data[3].score).toEqual(-3);
     });
 
     test('User can get a mixed order of crosslinks', async () => {
@@ -37,10 +37,10 @@ describe('Get crosslinks of a publication', () => {
 
         expect(getCrosslinks.status).toEqual(200);
         // First 2 results have most recent crosslink created date, then others sorted by score.
-        expect(getCrosslinks.body.recent[0].createdAt).toEqual('2024-01-22T13:00:00.000Z');
-        expect(getCrosslinks.body.recent[1].createdAt).toEqual('2024-01-22T12:00:00.000Z');
-        expect(getCrosslinks.body.relevant[0].score).toEqual(3);
-        expect(getCrosslinks.body.relevant[1].score).toEqual(-3);
+        expect(getCrosslinks.body.data.recent[0].createdAt).toEqual('2024-01-22T13:00:00.000Z');
+        expect(getCrosslinks.body.data.recent[1].createdAt).toEqual('2024-01-22T12:00:00.000Z');
+        expect(getCrosslinks.body.data.relevant[0].score).toEqual(3);
+        expect(getCrosslinks.body.data.relevant[1].score).toEqual(-3);
     });
 
     test('User must supply a recognised sort order', async () => {
@@ -50,7 +50,7 @@ describe('Get crosslinks of a publication', () => {
 
         expect(getCrosslinks.status).toEqual(400);
         expect(getCrosslinks.body.message[0].message).toEqual('must be equal to one of the allowed values');
-        expect(getCrosslinks.body.message[0].params.allowedValues).toEqual(['mix', 'relevant', null]);
+        expect(getCrosslinks.body.message[0].params.allowedValues).toEqual(['mix', 'relevant', 'recent', null]);
     });
 
     test('User cannot get crosslinks for a non-existent publication ID', async () => {
@@ -58,5 +58,58 @@ describe('Get crosslinks of a publication', () => {
 
         expect(getCrosslinks.status).toEqual(404);
         expect(getCrosslinks.body.message).toEqual('Publication not found.');
+    });
+
+    test('User can filter crosslinks to ones they created', async () => {
+        const getCrosslinks = await testUtils.agent
+            .get('/publications/publication-hypothesis-live/crosslinks')
+            .query({ own: true, apiKey: '123456789' });
+
+        expect(getCrosslinks.status).toEqual(200);
+        expect(getCrosslinks.body.data.length).toEqual(1);
+        expect(getCrosslinks.body.data[0].createdBy).toEqual('test-user-1');
+    });
+
+    test('Anonymous user cannot filter to their own crosslinks', async () => {
+        const getCrosslinks = await testUtils.agent
+            .get('/publications/publication-hypothesis-live/crosslinks')
+            .query({ own: true });
+
+        expect(getCrosslinks.status).toEqual(400);
+        expect(getCrosslinks.body.message).toEqual(
+            'Cannot filter to your own items when the request is not authenticated.'
+        );
+    });
+
+    test('User can filter crosslinks by publication title', async () => {
+        const getCrosslinks = await testUtils.agent
+            .get('/publications/publication-hypothesis-live/crosslinks')
+            .query({ search: 'protocol' });
+
+        expect(getCrosslinks.status).toEqual(200);
+        expect(getCrosslinks.body.data.length).toEqual(1);
+        expect(getCrosslinks.body.data[0].linkedPublication.id).toEqual('publication-protocol-live');
+    });
+
+    test('Number of crosslinks returned can be limited', async () => {
+        const getCrosslinks = await testUtils.agent
+            .get('/publications/publication-hypothesis-live/crosslinks')
+            .query({ limit: 2 });
+
+        expect(getCrosslinks.status).toEqual(200);
+        expect(getCrosslinks.body.data.length).toEqual(2);
+        expect(getCrosslinks.body.metadata.total).toEqual(4);
+    });
+
+    test('Results can be offset', async () => {
+        const getCrosslinks = await testUtils.agent
+            .get('/publications/publication-hypothesis-live/crosslinks')
+            .query({ offset: 2 });
+
+        expect(getCrosslinks.status).toEqual(200);
+        expect(getCrosslinks.body.data.length).toEqual(2);
+        // Expect to receive the results that would be third and fourth in a normal request.
+        expect(getCrosslinks.body.data[0].createdAt).toEqual('2024-01-22T11:00:00.000Z');
+        expect(getCrosslinks.body.data[1].createdAt).toEqual('2024-01-22T10:00:00.000Z');
     });
 });

--- a/api/src/components/crosslink/controller.ts
+++ b/api/src/components/crosslink/controller.ts
@@ -174,7 +174,7 @@ export const getPublicationCrosslinks = async (
             });
         }
 
-        const search = event.queryStringParameters?.search
+        const search = event.queryStringParameters.search
             ? helpers.sanitizeSearchQuery(event.queryStringParameters.search)
             : '';
         const limit = event.queryStringParameters?.limit || 10;

--- a/api/src/components/crosslink/controller.ts
+++ b/api/src/components/crosslink/controller.ts
@@ -165,6 +165,15 @@ export const getPublicationCrosslinks = async (
             });
         }
 
+        if (
+            event.queryStringParameters.order === 'mix' &&
+            (event.queryStringParameters.limit || event.queryStringParameters.offset)
+        ) {
+            return response.json(400, {
+                message: 'Pagination cannot be used with "mix" sort order.'
+            });
+        }
+
         const search = event.queryStringParameters?.search
             ? helpers.sanitizeSearchQuery(event.queryStringParameters.search)
             : '';

--- a/api/src/components/crosslink/routes.ts
+++ b/api/src/components/crosslink/routes.ts
@@ -38,4 +38,5 @@ export const getVote = middy(crosslinkController.getVote)
 export const getPublicationCrosslinks = middy(crosslinkController.getPublicationCrosslinks)
     .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))
     .use(middleware.httpJsonBodyParser())
+    .use(middleware.authentication(true))
     .use(middleware.validator(crosslinkSchema.getPublicationCrosslinks, 'queryStringParameters'));

--- a/api/src/components/crosslink/schema/getPublicationCrosslinks.ts
+++ b/api/src/components/crosslink/schema/getPublicationCrosslinks.ts
@@ -3,9 +3,30 @@ import * as I from 'interface';
 const getPublicationCrosslinksSchema: I.JSONSchemaType<I.GetPublicationCrosslinksQueryParams> = {
     type: 'object',
     properties: {
+        search: {
+            type: 'string',
+            nullable: true,
+            default: ''
+        },
+        offset: {
+            type: 'number',
+            nullable: true,
+            default: 0
+        },
+        limit: {
+            type: 'number',
+            nullable: true,
+            default: 10
+        },
+        own: {
+            type: 'string',
+            enum: ['true', 'false', null],
+            nullable: true,
+            default: null
+        },
         order: {
             type: 'string',
-            enum: ['mix', 'relevant', null],
+            enum: ['mix', 'relevant', 'recent', null],
             nullable: true,
             default: null
         }

--- a/api/src/components/crosslink/schema/getPublicationCrosslinks.ts
+++ b/api/src/components/crosslink/schema/getPublicationCrosslinks.ts
@@ -11,12 +11,12 @@ const getPublicationCrosslinksSchema: I.JSONSchemaType<I.GetPublicationCrosslink
         offset: {
             type: 'number',
             nullable: true,
-            default: 0
+            default: null
         },
         limit: {
             type: 'number',
             nullable: true,
-            default: 10
+            default: null
         },
         own: {
             type: 'string',

--- a/api/src/components/crosslink/service.ts
+++ b/api/src/components/crosslink/service.ts
@@ -100,7 +100,11 @@ const updateScore = async (crosslinkId: string) => {
         }
     });
 
-    const score = crosslink?.votes
+    if (!crosslink) {
+        return false;
+    }
+
+    const score = crosslink.votes
         .map((vote) => vote.vote)
         .reduce((accumulator, currentValue) => accumulator + (currentValue ? 1 : -1), 0);
 

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -964,9 +964,18 @@ export interface GetPublicationCrosslinksPathParams {
     publicationId: string;
 }
 
-export type GetPublicationCrosslinksOrder = 'relevant' | 'mix';
+export type GetPublicationCrosslinksOrder = 'recent' | 'relevant' | 'mix';
 export interface GetPublicationCrosslinksQueryParams {
+    search?: string;
+    limit?: number;
+    offset?: number;
+    own?: string;
     order?: GetPublicationCrosslinksOrder;
+}
+
+// Options for the service function, as distinct from the query params received in the controller.
+export interface GetPublicationCrosslinksOptions extends Omit<GetPublicationCrosslinksQueryParams, 'own'> {
+    userIdFilter?: string;
 }
 
 // Additional information

--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -1705,7 +1705,9 @@ test.describe('Publication flow + co-authors', () => {
 
         // publish v3
         await page.locator(PageModel.publish.publishButton).click();
-        await page.locator(PageModel.publish.confirmPublishButton).click();
+        await Promise.all([
+            (page.waitForURL('**/versions/latest'), page.locator(PageModel.publish.confirmPublishButton).click())
+        ]);
         await page.locator(`h1:has-text("${newTitle}")`).first().waitFor({ state: 'visible' });
     });
 

--- a/e2e/tests/PageModel.ts
+++ b/e2e/tests/PageModel.ts
@@ -126,7 +126,7 @@ export const PageModel = {
         octopusPublications: 'h2:has-text("Octopus publications")'
     },
     login: {
-        username: '#username',
+        username: '#username-input',
         password: '#password',
         signInButton: '#signin-button',
         authorizeButton: '#authorize-button',

--- a/ui/src/__tests__/components/AccordionSection.test.tsx
+++ b/ui/src/__tests__/components/AccordionSection.test.tsx
@@ -1,6 +1,6 @@
 import * as Components from '@/components';
 
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 
 describe('Accordion section', () => {

--- a/ui/src/__tests__/components/Publication/RelatedPublications.test.tsx
+++ b/ui/src/__tests__/components/Publication/RelatedPublications.test.tsx
@@ -2,32 +2,30 @@ import { within } from '@testing-library/dom';
 import { render, screen } from '@testing-library/react';
 
 import * as Components from '@/components';
+import * as TestUtils from '@/testUtils';
 
 describe('No crosslinks', () => {
     it('Nothing is rendered', () => {
         const { container } = render(
-            <Components.RelatedPublications id="related-publications" crosslinks={{ recent: [], relevant: [] }} />
+            <Components.RelatedPublications
+                id="related-publications"
+                crosslinks={{
+                    data: { recent: [], relevant: [] },
+                    metadata: {
+                        total: 0,
+                        offset: 0,
+                        limit: 10
+                    }
+                }}
+                publicationId="test"
+            />
         );
         expect(container).toBeEmptyDOMElement();
     });
 });
 
-const crosslinkBase = {
-    linkedPublication: {
-        id: 'test-1',
-        latestLiveVersion: {
-            title: 'Test 1',
-            publishedDate: '2024-04-11T11:47:00.000Z',
-            user: {
-                firstName: 'Test',
-                lastName: 'User'
-            }
-        }
-    },
-    score: 0,
-    createdAt: '2024-04-11T10:47:00.000Z',
-    createdBy: 'test'
-};
+const crosslinkBase = TestUtils.testCrosslink;
+const title = crosslinkBase.linkedPublication.latestLiveVersion.title;
 
 describe('Recent and relevant crosslinks', () => {
     beforeEach(() => {
@@ -35,16 +33,36 @@ describe('Recent and relevant crosslinks', () => {
             <Components.RelatedPublications
                 id="related-publications"
                 crosslinks={{
-                    recent: [
-                        crosslinkBase,
-                        { ...crosslinkBase, linkedPublication: { ...crosslinkBase.linkedPublication, id: 'test-2' } }
-                    ],
-                    relevant: [
-                        { ...crosslinkBase, linkedPublication: { ...crosslinkBase.linkedPublication, id: 'test-3' } },
-                        { ...crosslinkBase, linkedPublication: { ...crosslinkBase.linkedPublication, id: 'test-4' } },
-                        { ...crosslinkBase, linkedPublication: { ...crosslinkBase.linkedPublication, id: 'test-5' } }
-                    ]
+                    data: {
+                        recent: [
+                            crosslinkBase,
+                            {
+                                ...crosslinkBase,
+                                linkedPublication: { ...crosslinkBase.linkedPublication, id: 'test-2' }
+                            }
+                        ],
+                        relevant: [
+                            {
+                                ...crosslinkBase,
+                                linkedPublication: { ...crosslinkBase.linkedPublication, id: 'test-3' }
+                            },
+                            {
+                                ...crosslinkBase,
+                                linkedPublication: { ...crosslinkBase.linkedPublication, id: 'test-4' }
+                            },
+                            {
+                                ...crosslinkBase,
+                                linkedPublication: { ...crosslinkBase.linkedPublication, id: 'test-5' }
+                            }
+                        ]
+                    },
+                    metadata: {
+                        total: 10,
+                        offset: 0,
+                        limit: 10
+                    }
                 }}
+                publicationId="test"
             />
         );
     });
@@ -56,7 +74,7 @@ describe('Recent and relevant crosslinks', () => {
     it('2 recent crosslinks are shown', () => {
         // RelatedPublications is an AccordionSection, which is a section, so "Most Recent" section is the one after that.
         const recentSection = document.getElementsByTagName('section')[1];
-        expect(within(recentSection).getAllByText('Test 1')).toHaveLength(2);
+        expect(within(recentSection).getAllByText(title)).toHaveLength(2);
     });
 
     it('"Most relevant" label is shown', () => {
@@ -65,7 +83,7 @@ describe('Recent and relevant crosslinks', () => {
 
     it('3 relevant crosslinks are shown', () => {
         const recentSection = document.getElementsByTagName('section')[2];
-        expect(within(recentSection).getAllByText('Test 1')).toHaveLength(3);
+        expect(within(recentSection).getAllByText(title)).toHaveLength(3);
     });
 });
 
@@ -75,12 +93,23 @@ describe('Only recent crosslinks', () => {
             <Components.RelatedPublications
                 id="related-publications"
                 crosslinks={{
-                    recent: [
-                        crosslinkBase,
-                        { ...crosslinkBase, linkedPublication: { ...crosslinkBase.linkedPublication, id: 'test-2' } }
-                    ],
-                    relevant: []
+                    data: {
+                        recent: [
+                            crosslinkBase,
+                            {
+                                ...crosslinkBase,
+                                linkedPublication: { ...crosslinkBase.linkedPublication, id: 'test-2' }
+                            }
+                        ],
+                        relevant: []
+                    },
+                    metadata: {
+                        total: 10,
+                        offset: 0,
+                        limit: 10
+                    }
                 }}
+                publicationId="test"
             />
         );
     });
@@ -90,7 +119,7 @@ describe('Only recent crosslinks', () => {
     });
 
     it('2 crosslinks are shown', () => {
-        expect(screen.getAllByText('Test 1')).toHaveLength(2);
+        expect(screen.getAllByText(title)).toHaveLength(2);
     });
 
     it('Only one crosslink list section is shown', () => {
@@ -105,12 +134,23 @@ describe('Only relevant crosslinks', () => {
             <Components.RelatedPublications
                 id="related-publications"
                 crosslinks={{
-                    recent: [],
-                    relevant: [
-                        crosslinkBase,
-                        { ...crosslinkBase, linkedPublication: { ...crosslinkBase.linkedPublication, id: 'test-2' } }
-                    ]
+                    data: {
+                        recent: [],
+                        relevant: [
+                            crosslinkBase,
+                            {
+                                ...crosslinkBase,
+                                linkedPublication: { ...crosslinkBase.linkedPublication, id: 'test-2' }
+                            }
+                        ]
+                    },
+                    metadata: {
+                        total: 10,
+                        offset: 0,
+                        limit: 10
+                    }
                 }}
+                publicationId="test"
             />
         );
     });
@@ -120,7 +160,7 @@ describe('Only relevant crosslinks', () => {
     });
 
     it('2 crosslinks are shown', () => {
-        expect(screen.getAllByText('Test 1')).toHaveLength(2);
+        expect(screen.getAllByText(title)).toHaveLength(2);
     });
 
     it('Only one crosslink list section is shown', () => {

--- a/ui/src/__tests__/components/Publication/RelatedPublications/Card.test.tsx
+++ b/ui/src/__tests__/components/Publication/RelatedPublications/Card.test.tsx
@@ -3,23 +3,9 @@ import { render, screen } from '@testing-library/react';
 import * as Components from '@/components';
 import * as Config from '@/config';
 import * as Helpers from '@/helpers';
+import * as TestUtils from '@/testUtils';
 
-const crosslink = {
-    linkedPublication: {
-        id: 'test-1',
-        latestLiveVersion: {
-            title: 'Test 1',
-            publishedDate: '2024-04-11T11:47:00.000Z',
-            user: {
-                firstName: 'Test',
-                lastName: 'User'
-            }
-        }
-    },
-    score: 0,
-    createdBy: 'test',
-    createdAt: '2024-04-11T10:47:00.000Z'
-};
+const crosslink = TestUtils.testCrosslink;
 
 describe('Related publication card', () => {
     beforeEach(() => {
@@ -31,7 +17,7 @@ describe('Related publication card', () => {
     });
 
     it('Corresponding author credit is shown', () => {
-        expect(screen.getByText('By T. User')).toBeInTheDocument();
+        expect(screen.getByText('By J. Doe')).toBeInTheDocument();
     });
 
     it('Published date is shown in short format', () => {

--- a/ui/src/__tests__/components/Publication/RelatedPublications/Result.test.tsx
+++ b/ui/src/__tests__/components/Publication/RelatedPublications/Result.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+
+import * as Components from '@/components';
+import * as Config from '@/config';
+import * as Helpers from '@/helpers';
+import * as TestUtils from '@/testUtils';
+
+const crosslink = TestUtils.testCrosslink;
+
+describe('Related publication result', () => {
+    beforeEach(() => {
+        render(<Components.RelatedPublicationsResult crosslink={crosslink} mutateList={jest.fn} setError={jest.fn} />);
+    });
+
+    it('Title is shown', () => {
+        expect(screen.getByText(crosslink.linkedPublication.latestLiveVersion.title)).toBeInTheDocument();
+    });
+
+    it('Author attribution is shown', () => {
+        expect(
+            screen.getByText(
+                `By ${Helpers.abbreviateUserName(crosslink.linkedPublication.latestLiveVersion.user)} | ${Helpers.relativeDate(crosslink.linkedPublication.latestLiveVersion.publishedDate)}`
+            )
+        ).toBeInTheDocument();
+    });
+
+    it('Visit publication link is shown', () => {
+        const link = screen.getByRole('link');
+        expect(link).toHaveAccessibleName('Visit publication');
+        expect(link).toHaveAttribute('href', `${Config.urls.viewPublication.path}/${crosslink.linkedPublication.id}`);
+    });
+});

--- a/ui/src/__tests__/testUtils/index.tsx
+++ b/ui/src/__tests__/testUtils/index.tsx
@@ -139,3 +139,32 @@ export const testFlag: Interfaces.Flag = {
         employment: testUser2.employment
     }
 };
+
+export const testCrosslink: Interfaces.Crosslink = {
+    id: 'test',
+    linkedPublication: {
+        id: 'test-1',
+        latestLiveVersion: {
+            title: testPublicationVersion.title,
+            publishedDate: '2024-04-11T11:47:00.000Z',
+            user: {
+                id: testCoreUser.id,
+                firstName: testCoreUser.firstName,
+                lastName: testCoreUser.lastName
+            },
+            coAuthors: [
+                {
+                    linkedUser: testCoreUser.id,
+                    user: {
+                        firstName: testCoreUser.firstName,
+                        lastName: testCoreUser.lastName,
+                        role: testCoreUser.role
+                    }
+                }
+            ]
+        }
+    },
+    score: 0,
+    createdBy: testUser2.id,
+    createdAt: '2024-04-11T10:47:00.000Z'
+};

--- a/ui/src/components/Alert/index.tsx
+++ b/ui/src/components/Alert/index.tsx
@@ -104,7 +104,7 @@ const Alert: React.FC<Props> = (props): React.ReactElement => {
 
                             {props.details && (
                                 <div className={`mt-2 text-sm transition-colors duration-500 ${classes.details}`}>
-                                    <ul className="list-disc space-y-1 pl-5">
+                                    <ul className="list-disc space-y-1 pl-5 text-left">
                                         {props.details.map((detail) => (
                                             <li key={detail}>{detail}</li>
                                         ))}

--- a/ui/src/components/Modal/index.tsx
+++ b/ui/src/components/Modal/index.tsx
@@ -20,6 +20,7 @@ type Props = {
 const Modal: React.FC<Props> = (props) => {
     const cancelButtonRef = React.useRef(null);
     const loading = !!props.loading;
+    const showPositiveActionButton = props.positiveActionCallback && props.positiveButtonText;
 
     return (
         <HeadlessUI.Transition.Root show={props.open} as={React.Fragment}>
@@ -73,8 +74,10 @@ const Modal: React.FC<Props> = (props) => {
                                         <div className="mt-2">{props.children}</div>
                                     </div>
                                 </div>
-                                <div className="mt-5 flex justify-between space-x-4 sm:mt-6">
-                                    {props.positiveActionCallback && props.positiveButtonText && (
+                                <div
+                                    className={`mt-5 flex ${showPositiveActionButton ? 'justify-between' : 'justify-end'} space-x-4 sm:mt-6`}
+                                >
+                                    {showPositiveActionButton && (
                                         <Components.ModalButton
                                             onClick={() => {
                                                 // Shouldn't be necessary but typescript still thinks the function could be undefined
@@ -82,8 +85,8 @@ const Modal: React.FC<Props> = (props) => {
                                                     props.positiveActionCallback();
                                             }}
                                             disabled={loading}
-                                            text={props.positiveButtonText}
-                                            title={props.positiveButtonText}
+                                            text={props.positiveButtonText || ''}
+                                            title={props.positiveButtonText || ''}
                                             actionType="POSITIVE"
                                         />
                                     )}
@@ -98,6 +101,7 @@ const Modal: React.FC<Props> = (props) => {
                                         text={props.cancelButtonText}
                                         title={props.cancelButtonText}
                                         actionType="NEGATIVE"
+                                        className="md:w-1/6"
                                     />
                                 </div>
                             </div>

--- a/ui/src/components/Modal/index.tsx
+++ b/ui/src/components/Modal/index.tsx
@@ -6,8 +6,8 @@ import * as Components from '@/components';
 type Props = {
     open: boolean;
     onClose: any; // state setter
-    positiveActionCallback: any; // state setter
-    positiveButtonText: string;
+    positiveActionCallback?: any; // state setter
+    positiveButtonText?: string;
     negativeActionCallback?: any;
     cancelButtonText: string;
     title: string;
@@ -53,7 +53,7 @@ const Modal: React.FC<Props> = (props) => {
                         leaveFrom="opacity-100 translate-y-0 sm:scale-100"
                         leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
                     >
-                        <div className="relative mx-8 my-20 inline-block w-11/12 transform overflow-hidden rounded-lg bg-white-50 text-left align-bottom shadow-xl transition-all sm:align-middle lg:max-w-xl">
+                        <div className="relative mx-8 my-20 inline-block w-11/12 transform overflow-hidden rounded-lg bg-white-50 text-left align-bottom shadow-xl transition-all sm:align-middle lg:max-w-3xl xl:max-w-5xl">
                             <Components.ModalBarLoader loading={loading} />
                             <div className="px-4 pb-4 pt-5 sm:px-8 sm:py-6">
                                 <div>
@@ -73,13 +73,15 @@ const Modal: React.FC<Props> = (props) => {
                                     </div>
                                 </div>
                                 <div className="mt-5 flex justify-between space-x-4 sm:mt-6">
-                                    <Components.ModalButton
-                                        onClick={() => props.positiveActionCallback()}
-                                        disabled={loading}
-                                        text={props.positiveButtonText}
-                                        title={props.positiveButtonText}
-                                        actionType="POSITIVE"
-                                    />
+                                    {props.positiveActionCallback && props.positiveButtonText && (
+                                        <Components.ModalButton
+                                            onClick={() => props.positiveActionCallback()}
+                                            disabled={loading}
+                                            text={props.positiveButtonText}
+                                            title={props.positiveButtonText}
+                                            actionType="POSITIVE"
+                                        />
+                                    )}
                                     <Components.ModalButton
                                         onClick={() =>
                                             props.negativeActionCallback

--- a/ui/src/components/Modal/index.tsx
+++ b/ui/src/components/Modal/index.tsx
@@ -5,12 +5,13 @@ import * as Components from '@/components';
 
 type Props = {
     open: boolean;
-    onClose: any; // state setter
-    positiveActionCallback?: any; // state setter
+    onClose: () => void; // state setter
+    positiveActionCallback?: () => void; // state setter
     positiveButtonText?: string;
-    negativeActionCallback?: any;
+    negativeActionCallback?: () => void;
     cancelButtonText: string;
     title: string;
+    titleClasses?: string;
     icon?: React.ReactNode;
     children?: React.ReactNode;
     loading?: boolean;
@@ -65,7 +66,7 @@ const Modal: React.FC<Props> = (props) => {
                                     <div className="mt-3 text-center sm:mt-5">
                                         <HeadlessUI.Dialog.Title
                                             as="h3"
-                                            className="font-montserrat text-lg font-medium leading-6 text-grey-900"
+                                            className={`font-montserrat text-lg font-medium leading-6 text-grey-900${props.titleClasses ? ' ' + props.titleClasses : ''}`}
                                         >
                                             {props.title}
                                         </HeadlessUI.Dialog.Title>
@@ -75,7 +76,11 @@ const Modal: React.FC<Props> = (props) => {
                                 <div className="mt-5 flex justify-between space-x-4 sm:mt-6">
                                     {props.positiveActionCallback && props.positiveButtonText && (
                                         <Components.ModalButton
-                                            onClick={() => props.positiveActionCallback()}
+                                            onClick={() => {
+                                                // Shouldn't be necessary but typescript still thinks the function could be undefined
+                                                if (props.positiveActionCallback !== undefined)
+                                                    props.positiveActionCallback();
+                                            }}
                                             disabled={loading}
                                             text={props.positiveButtonText}
                                             title={props.positiveButtonText}

--- a/ui/src/components/Publication/RelatedPublications/Modal/index.tsx
+++ b/ui/src/components/Publication/RelatedPublications/Modal/index.tsx
@@ -1,38 +1,74 @@
-import React from 'react';
+import React, { useState } from 'react';
+import useSWR from 'swr';
+import * as Framer from 'framer-motion';
 import * as SolidIcons from '@heroicons/react/24/solid';
 
 import * as Components from '@/components';
+import * as Config from '@/config';
+import * as Interfaces from '@/interfaces';
+import * as Stores from '@/stores';
 
-const Modal: React.FC = (): React.ReactElement => {
-    const isValidating = false;
+type Props = {
+    publicationId: string;
+    open: boolean;
+    onClose: () => void;
+};
 
-    const filterInputId = 'crosslink-filter';
+const RelatedPublicationsModal: React.FC<Props> = (props): React.ReactElement => {
+    const user = Stores.useAuthStore((state) => state.user);
+    const searchInputRef = React.useRef<HTMLInputElement>(null);
+    const searchInputId = 'crosslink-search';
     const recentInputId = 'sort-order-recent';
     const relevantInputId = 'sort-order-relevant';
+    const sortOrderInputName = 'sort-order';
     const ownFilterInputId = 'view-own';
     const formId = 'crosslink-search-form';
+    const [searchTerm, setSearchTerm] = useState('');
+    const [sortOrder, setSortOrder] = useState<'recent' | 'relevant'>('recent');
+    const [ownLinks, setOwnLinks] = useState(false);
+    const [offset, setOffset] = useState(0);
+    const [genericError, setGenericError] = useState('');
+    const limit = 5;
+    const swrKey = `${Config.endpoints.publications}/${props.publicationId}/crosslinks?order=${sortOrder}&search=${searchTerm}&own=${ownLinks}&offset=${offset}&limit=${limit}`;
+    const {
+        data: getCrosslinksResponse,
+        error: getCrosslinksError,
+        isValidating,
+        mutate
+    } = useSWR<Interfaces.GetPublicationCrosslinksResponse>(swrKey);
+
+    const handleFormSubmit = (event: React.FormEvent) => {
+        event.preventDefault();
+        setSearchTerm(searchInputRef.current?.value || '');
+    };
+
+    const handleClose = () => {
+        setGenericError('');
+        props.onClose();
+    };
 
     return (
         <Components.Modal
-            open={true}
-            onClose={() => console.log('close')}
-            loading={false}
-            cancelButtonText="Cancel"
+            open={props.open}
+            onClose={handleClose}
+            cancelButtonText="Close"
             title="Related Content"
+            titleClasses="text-left"
         >
-            <form name="crosslink-search-form" id={formId} onSubmit={() => console.log('form submit')}>
-                <label htmlFor={filterInputId} className="relative block w-full">
+            <form name="crosslink-search-form" id={formId} onSubmit={handleFormSubmit}>
+                <label htmlFor={searchInputId} className="relative block w-full">
                     <span className="block mb-2 text-xxs font-bold uppercase tracking-widest text-grey-600 transition-colors duration-500 dark:text-grey-300 text-left">
                         Search for suggested links
                     </span>
                     <input
-                        id={filterInputId}
+                        ref={searchInputRef}
+                        id={searchInputId}
                         name="filter"
                         className="w-full rounded border border-grey-100 text-grey-700 shadow focus:ring-2 focus:ring-yellow-400"
                     />
                     <button
-                        type="submit"
                         form={formId}
+                        type="submit"
                         aria-label="Search related content"
                         className="absolute right-px p-2 outline-none focus:ring-2 focus:ring-yellow-500 disabled:opacity-70"
                         disabled={isValidating}
@@ -40,30 +76,137 @@ const Modal: React.FC = (): React.ReactElement => {
                         <SolidIcons.MagnifyingGlassIcon className="h-6 w-6 text-teal-500" />
                     </button>
                 </label>
-                <div className="flex mt-4 items-end gap-4">
-                    <fieldset className="w-1/2">
-                        <legend className="block mb-2 text-xxs font-bold uppercase tracking-widest text-grey-600 transition-colors duration-500 dark:text-grey-300 text-left">
-                            Sort by
-                        </legend>
-                        <div className="flex">
-                            <label htmlFor={recentInputId} className="flex mr-6">
-                                <input type="radio" id={recentInputId} />
-                                <span className="text-gray-700 mb-2 ml-3 block text-sm font-medium">Most Recent</span>
-                            </label>
-                            <label htmlFor={recentInputId} className="flex">
-                                <input type="radio" id={relevantInputId} />
-                                <span className="text-gray-700 mb-2 ml-3 block text-sm font-medium">Most Relevant</span>
-                            </label>
-                        </div>
-                    </fieldset>
+            </form>
+            <div className="flex mt-4 items-end gap-4 mb-4">
+                <fieldset className="w-1/2">
+                    <legend className="block mb-2 text-xxs font-bold uppercase tracking-widest text-grey-600 transition-colors duration-500 dark:text-grey-300 text-left">
+                        Sort by
+                    </legend>
+                    <div className="flex">
+                        <label htmlFor={recentInputId} className="flex mr-6">
+                            <input
+                                type="radio"
+                                id={recentInputId}
+                                name={sortOrderInputName}
+                                onChange={() => setSortOrder('recent')}
+                                defaultChecked={sortOrder === 'recent'}
+                            />
+                            <span className="text-gray-700 mb-2 ml-3 block text-sm font-medium">Most Recent</span>
+                        </label>
+                        <label htmlFor={relevantInputId} className="flex">
+                            <input
+                                type="radio"
+                                id={relevantInputId}
+                                name={sortOrderInputName}
+                                onChange={() => setSortOrder('relevant')}
+                                defaultChecked={sortOrder === 'relevant'}
+                            />
+                            <span className="text-gray-700 mb-2 ml-3 block text-sm font-medium">Most Relevant</span>
+                        </label>
+                    </div>
+                </fieldset>
+                {user && (
                     <label htmlFor={ownFilterInputId} className="w-1/2 flex justify-end pt-5">
-                        <input type="checkbox" id={ownFilterInputId} className="rounded-sm" />
+                        <input
+                            type="checkbox"
+                            id={ownFilterInputId}
+                            className="rounded-sm"
+                            checked={ownLinks}
+                            onChange={(event) => setOwnLinks(event.target.checked)}
+                        />
                         <span className="text-gray-700 mb-2 ml-3 block text-sm font-medium">View my suggestions</span>
                     </label>
-                </div>
-            </form>
+                )}
+            </div>
+            <Framer.AnimatePresence>
+                {getCrosslinksError && (
+                    <Components.Alert
+                        key="getCrosslinksError"
+                        severity="ERROR"
+                        title={getCrosslinksError.response.data.message || getCrosslinksError.message}
+                        className="mb-4"
+                    />
+                )}
+                {genericError && (
+                    <Components.Alert key="genericError" severity="ERROR" title={genericError} className="mb-4" />
+                )}
+                {!getCrosslinksResponse?.data?.length && !isValidating && (
+                    <Components.Alert
+                        severity="INFO"
+                        title="No results found"
+                        details={[
+                            'Try some different search criteria.',
+                            'If you think something is wrong, please contact the helpdesk.'
+                        ]}
+                        className="mb-4"
+                    />
+                )}
+                {getCrosslinksResponse?.data?.length && (
+                    <>
+                        <div className="rounded flex flex-col gap-4">
+                            {getCrosslinksResponse.data.map((crosslink, index: number) => {
+                                let classes = '';
+                                index === 0 ? (classes += 'rounded-t') : null;
+                                index === getCrosslinksResponse.data.length - 1
+                                    ? (classes += '!border-b-transparent !rounded-b')
+                                    : null;
+
+                                return (
+                                    <Components.RelatedPublicationsResult
+                                        key={crosslink.id}
+                                        crosslink={crosslink}
+                                        setError={setGenericError}
+                                        mutateList={mutate}
+                                    />
+                                );
+                            })}
+                        </div>
+
+                        {!!getCrosslinksResponse?.data.length && (
+                            <Components.Delay delay={getCrosslinksResponse.data.length * 50}>
+                                <Framer.motion.div
+                                    initial={{ opacity: 0 }}
+                                    animate={{ opacity: 1 }}
+                                    exit={{ opacity: 0 }}
+                                    transition={{ type: 'tween', duration: 0.75 }}
+                                    className="mt-8 w-full items-center justify-between lg:flex lg:flex-row-reverse"
+                                >
+                                    <div className="flex justify-between">
+                                        <button
+                                            onClick={() => {
+                                                setOffset((prev) => prev - limit);
+                                            }}
+                                            disabled={offset === 0}
+                                            className="mr-6 rounded font-semibold text-grey-800 underline decoration-teal-500 decoration-2 underline-offset-4 outline-none transition-colors duration-500 focus:ring-2 focus:ring-yellow-500 disabled:decoration-teal-600 disabled:opacity-70 dark:text-white-50"
+                                        >
+                                            Previous
+                                        </button>
+
+                                        <button
+                                            onClick={() => {
+                                                setOffset((prev) => prev + limit);
+                                            }}
+                                            className="rounded font-semibold text-grey-800 underline decoration-teal-500 decoration-2 underline-offset-4 outline-none transition-colors duration-500 focus:ring-2 focus:ring-yellow-500 disabled:decoration-teal-600 disabled:opacity-70 dark:text-white-50"
+                                            disabled={limit + offset >= getCrosslinksResponse.metadata.total}
+                                        >
+                                            Next
+                                        </button>
+                                    </div>
+                                    <span className="mt-4 block font-medium text-grey-800 transition-colors duration-500 dark:text-white-50">
+                                        Showing {offset + 1} -{' '}
+                                        {limit + offset > getCrosslinksResponse.metadata.total
+                                            ? getCrosslinksResponse.metadata.total
+                                            : limit + offset}{' '}
+                                        of {getCrosslinksResponse.metadata.total}
+                                    </span>
+                                </Framer.motion.div>
+                            </Components.Delay>
+                        )}
+                    </>
+                )}
+            </Framer.AnimatePresence>
         </Components.Modal>
     );
 };
 
-export default Modal;
+export default RelatedPublicationsModal;

--- a/ui/src/components/Publication/RelatedPublications/Modal/index.tsx
+++ b/ui/src/components/Publication/RelatedPublications/Modal/index.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import * as SolidIcons from '@heroicons/react/24/solid';
+
+import * as Components from '@/components';
+
+const Modal: React.FC = (): React.ReactElement => {
+    const isValidating = false;
+
+    const filterInputId = 'crosslink-filter';
+    const recentInputId = 'sort-order-recent';
+    const relevantInputId = 'sort-order-relevant';
+    const ownFilterInputId = 'view-own';
+    const formId = 'crosslink-search-form';
+
+    return (
+        <Components.Modal
+            open={true}
+            onClose={() => console.log('close')}
+            loading={false}
+            cancelButtonText="Cancel"
+            title="Related Content"
+        >
+            <form name="crosslink-search-form" id={formId} onSubmit={() => console.log('form submit')}>
+                <label htmlFor={filterInputId} className="relative block w-full">
+                    <span className="block mb-2 text-xxs font-bold uppercase tracking-widest text-grey-600 transition-colors duration-500 dark:text-grey-300 text-left">
+                        Search for suggested links
+                    </span>
+                    <input
+                        id={filterInputId}
+                        name="filter"
+                        className="w-full rounded border border-grey-100 text-grey-700 shadow focus:ring-2 focus:ring-yellow-400"
+                    />
+                    <button
+                        type="submit"
+                        form={formId}
+                        aria-label="Search related content"
+                        className="absolute right-px p-2 outline-none focus:ring-2 focus:ring-yellow-500 disabled:opacity-70"
+                        disabled={isValidating}
+                    >
+                        <SolidIcons.MagnifyingGlassIcon className="h-6 w-6 text-teal-500" />
+                    </button>
+                </label>
+                <div className="flex mt-4 items-end gap-4">
+                    <fieldset className="w-1/2">
+                        <legend className="block mb-2 text-xxs font-bold uppercase tracking-widest text-grey-600 transition-colors duration-500 dark:text-grey-300 text-left">
+                            Sort by
+                        </legend>
+                        <div className="flex">
+                            <label htmlFor={recentInputId} className="flex mr-6">
+                                <input type="radio" id={recentInputId} />
+                                <span className="text-gray-700 mb-2 ml-3 block text-sm font-medium">Most Recent</span>
+                            </label>
+                            <label htmlFor={recentInputId} className="flex">
+                                <input type="radio" id={relevantInputId} />
+                                <span className="text-gray-700 mb-2 ml-3 block text-sm font-medium">Most Relevant</span>
+                            </label>
+                        </div>
+                    </fieldset>
+                    <label htmlFor={ownFilterInputId} className="w-1/2 flex justify-end pt-5">
+                        <input type="checkbox" id={ownFilterInputId} className="rounded-sm" />
+                        <span className="text-gray-700 mb-2 ml-3 block text-sm font-medium">View my suggestions</span>
+                    </label>
+                </div>
+            </form>
+        </Components.Modal>
+    );
+};
+
+export default Modal;

--- a/ui/src/components/Publication/RelatedPublications/Modal/index.tsx
+++ b/ui/src/components/Publication/RelatedPublications/Modal/index.tsx
@@ -77,13 +77,13 @@ const RelatedPublicationsModal: React.FC<Props> = (props): React.ReactElement =>
                     </button>
                 </label>
             </form>
-            <div className="flex mt-4 items-end gap-4 mb-4">
-                <fieldset className="w-1/2">
+            <div className="flex flex-col mt-4 gap-4 mb-4 sm:flex-row sm:items-end">
+                <fieldset className="sm:w-1/2">
                     <legend className="block mb-2 text-xxs font-bold uppercase tracking-widest text-grey-600 transition-colors duration-500 dark:text-grey-300 text-left">
                         Sort by
                     </legend>
                     <div className="flex">
-                        <label htmlFor={recentInputId} className="flex mr-6">
+                        <label htmlFor={recentInputId} className="flex mr-6 items-center">
                             <input
                                 type="radio"
                                 id={recentInputId}
@@ -91,9 +91,11 @@ const RelatedPublicationsModal: React.FC<Props> = (props): React.ReactElement =>
                                 onChange={() => setSortOrder('recent')}
                                 defaultChecked={sortOrder === 'recent'}
                             />
-                            <span className="text-gray-700 mb-2 ml-3 block text-sm font-medium">Most Recent</span>
+                            <span className="text-gray-700 ml-3 block text-sm font-medium sm:text-nowrap">
+                                Most Recent
+                            </span>
                         </label>
-                        <label htmlFor={relevantInputId} className="flex">
+                        <label htmlFor={relevantInputId} className="flex items-center">
                             <input
                                 type="radio"
                                 id={relevantInputId}
@@ -101,12 +103,14 @@ const RelatedPublicationsModal: React.FC<Props> = (props): React.ReactElement =>
                                 onChange={() => setSortOrder('relevant')}
                                 defaultChecked={sortOrder === 'relevant'}
                             />
-                            <span className="text-gray-700 mb-2 ml-3 block text-sm font-medium">Most Relevant</span>
+                            <span className="text-gray-700 ml-3 block text-sm font-medium sm:text-nowrap">
+                                Most Relevant
+                            </span>
                         </label>
                     </div>
                 </fieldset>
                 {user && (
-                    <label htmlFor={ownFilterInputId} className="w-1/2 flex justify-end pt-5">
+                    <label htmlFor={ownFilterInputId} className="flex items-center sm:w-1/2 sm:justify-end sm:pt-5">
                         <input
                             type="checkbox"
                             id={ownFilterInputId}
@@ -114,7 +118,9 @@ const RelatedPublicationsModal: React.FC<Props> = (props): React.ReactElement =>
                             checked={ownLinks}
                             onChange={(event) => setOwnLinks(event.target.checked)}
                         />
-                        <span className="text-gray-700 mb-2 ml-3 block text-sm font-medium">View my suggestions</span>
+                        <span className="text-gray-700 ml-3 block text-sm font-medium sm:text-nowrap">
+                            View my suggestions
+                        </span>
                     </label>
                 )}
             </div>

--- a/ui/src/components/Publication/RelatedPublications/Result/index.tsx
+++ b/ui/src/components/Publication/RelatedPublications/Result/index.tsx
@@ -1,0 +1,117 @@
+import React, { useState } from 'react';
+import * as Framer from 'framer-motion';
+import * as OutlineIcons from '@heroicons/react/24/outline';
+
+import * as api from '@/api';
+import * as Components from '@/components';
+import * as Config from '@/config';
+import * as Helpers from '@/helpers';
+import * as Interfaces from '@/interfaces';
+import * as Stores from '@/stores';
+
+type Props = {
+    className?: string;
+    crosslink: Interfaces.Crosslink;
+    mutateList: () => void; // Refetch the list of related publications, e.g. after this one is deleted.
+    setError: (message: string) => void;
+};
+
+const RelatedPublicationsResult: React.FC<Props> = (props): React.ReactElement => {
+    const user = Stores.useAuthStore((state) => state.user);
+    const [deleteLoading, setDeleteLoading] = useState(false);
+    const coAuthors = props.crosslink.linkedPublication.latestLiveVersion.coAuthors;
+    const publicationVersion = props.crosslink.linkedPublication.latestLiveVersion;
+    const publicationId = props.crosslink.linkedPublication.id;
+    const authorNames = React.useMemo(() => {
+        const authorNames = coAuthors.map((author) => Helpers.abbreviateUserName(author.user));
+        return authorNames.join(', ');
+    }, [coAuthors]);
+
+    const handleDeleteCrosslink = async () => {
+        setDeleteLoading(true);
+        try {
+            await api.destroy(`${Config.endpoints.crosslinks}/${props.crosslink.id}`, user?.token);
+            props.mutateList();
+        } catch (err) {
+            props.setError('Failed to delete link.');
+        } finally {
+            setDeleteLoading(false);
+        }
+    };
+
+    return (
+        <Framer.motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ type: 'tween', duration: 0.35 }}
+        >
+            <div
+                className={`
+                    min-h-[4rem]
+                    items-start
+                    overflow-hidden
+                    rounded-none
+                    border-b
+                    border-grey-50
+                    bg-white-50
+                    px-4
+                    py-4
+                    shadow
+                    outline-0
+                    transition-colors
+                    duration-500
+                    hover:opacity-95
+                    focus:overflow-hidden
+                    focus:border-transparent
+                    focus:opacity-95
+                    focus:ring-2
+                    focus:ring-yellow-500
+                    dark:border-grey-600
+                    dark:bg-grey-700
+                    w-full
+                    flex
+                    flex-col
+                    justify-between
+                    ${props.className ? props.className : ''}
+                `}
+            >
+                <div>
+                    <p className="text-left font-semibold mb-2 leading-6 text-grey-800 transition-colors duration-500 dark:text-white-50">
+                        {publicationVersion.title}
+                    </p>
+                </div>
+
+                <div className="flex justify-between w-full">
+                    <span
+                        className="block overflow-hidden text-ellipsis whitespace-nowrap text-xs tracking-wide text-grey-800 transition-colors duration-500 dark:text-grey-100"
+                        title={authorNames}
+                    >
+                        By {authorNames} | {Helpers.relativeDate(publicationVersion.publishedDate)}
+                    </span>
+                    <span className="flex">
+                        <Components.Link
+                            href={`${Config.urls.viewPublication.path}/${publicationId}`}
+                            openNew={true}
+                            ariaLabel={'Visit publication'}
+                            className="block p-1"
+                        >
+                            <OutlineIcons.ArrowTopRightOnSquareIcon className="h-4 w-4 text-teal-600" />
+                        </Components.Link>
+                        {props.crosslink.createdBy === user?.id && (
+                            <Components.IconButton
+                                icon={<OutlineIcons.TrashIcon className="h-4 w-4 text-teal-600" />}
+                                title="Delete suggestion"
+                                onClick={handleDeleteCrosslink}
+                                className="ml-2"
+                                disabled={deleteLoading}
+                            />
+                        )}
+                    </span>
+                </div>
+            </div>
+        </Framer.motion.div>
+    );
+};
+
+export default RelatedPublicationsResult;

--- a/ui/src/components/Publication/RelatedPublications/index.tsx
+++ b/ui/src/components/Publication/RelatedPublications/index.tsx
@@ -1,19 +1,20 @@
-import React from 'react';
+import React, { useState } from 'react';
 import * as Components from '@/components';
 import * as Interfaces from '@/interfaces';
 
 type Props = {
     id: string;
-    crosslinks: Interfaces.MixedCrosslinks;
+    publicationId: string;
+    crosslinks: Interfaces.GetPublicationMixedCrosslinksResponse;
 };
 
 const RelatedPublications: React.FC<Props> = (props) => {
-    const { recent, relevant } = props.crosslinks;
-    const totalCrosslinks = recent.length + relevant.length;
+    const { recent, relevant } = props.crosslinks.data;
+    const totalCrosslinks = props.crosslinks.metadata.total;
+    const [modalVisibility, setModalVisibility] = useState(false);
     const showShowAllButton = totalCrosslinks > 5;
     return totalCrosslinks ? (
         <Components.AccordionSection id={props.id} title={'Related Publications'}>
-            <Components.RelatedPublicationsModal />
             <div className="space-y-4 px-6 py-4">
                 {!!recent.length && (
                     <section className="flex flex-col">
@@ -22,7 +23,7 @@ const RelatedPublications: React.FC<Props> = (props) => {
                                 Most recent
                             </span>
                         )}
-                        {props.crosslinks.recent.map((crosslink) => (
+                        {recent.map((crosslink) => (
                             <Components.RelatedPublicationsCard
                                 crosslink={crosslink}
                                 key={crosslink.linkedPublication.id}
@@ -37,7 +38,7 @@ const RelatedPublications: React.FC<Props> = (props) => {
                                 Most relevant
                             </span>
                         )}
-                        {props.crosslinks.relevant.map((crosslink) => (
+                        {relevant.map((crosslink) => (
                             <Components.RelatedPublicationsCard
                                 crosslink={crosslink}
                                 key={crosslink.linkedPublication.id}
@@ -46,10 +47,18 @@ const RelatedPublications: React.FC<Props> = (props) => {
                     </section>
                 )}
                 {showShowAllButton && (
-                    <Components.Button
-                        title="Show All"
-                        className="rounded border-2 border-transparent bg-teal-600 px-2.5 text-white-50 shadow-sm focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 children:border-0 children:text-white-50"
-                    />
+                    <>
+                        <Components.Button
+                            title="Show All"
+                            className="rounded border-2 border-transparent bg-teal-600 px-2.5 text-white-50 shadow-sm focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 children:border-0 children:text-white-50"
+                            onClick={() => setModalVisibility((prevState) => !prevState)}
+                        />
+                        <Components.RelatedPublicationsModal
+                            publicationId={props.publicationId}
+                            open={modalVisibility}
+                            onClose={() => setModalVisibility(false)}
+                        />
+                    </>
                 )}
             </div>
         </Components.AccordionSection>

--- a/ui/src/components/Publication/RelatedPublications/index.tsx
+++ b/ui/src/components/Publication/RelatedPublications/index.tsx
@@ -9,8 +9,11 @@ type Props = {
 
 const RelatedPublications: React.FC<Props> = (props) => {
     const { recent, relevant } = props.crosslinks;
-    return recent.length || relevant.length ? (
+    const totalCrosslinks = recent.length + relevant.length;
+    const showShowAllButton = totalCrosslinks > 5;
+    return totalCrosslinks ? (
         <Components.AccordionSection id={props.id} title={'Related Publications'}>
+            <Components.RelatedPublicationsModal />
             <div className="space-y-4 px-6 py-4">
                 {!!recent.length && (
                     <section className="flex flex-col">
@@ -41,6 +44,12 @@ const RelatedPublications: React.FC<Props> = (props) => {
                             />
                         ))}
                     </section>
+                )}
+                {showShowAllButton && (
+                    <Components.Button
+                        title="Show All"
+                        className="rounded border-2 border-transparent bg-teal-600 px-2.5 text-white-50 shadow-sm focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 children:border-0 children:text-white-50"
+                    />
                 )}
             </div>
         </Components.AccordionSection>

--- a/ui/src/components/Publication/SearchResult/index.tsx
+++ b/ui/src/components/Publication/SearchResult/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import parse from 'html-react-parser';
 import * as Framer from 'framer-motion';
 import * as OutlineIcons from '@heroicons/react/24/outline';
 

--- a/ui/src/components/index.tsx
+++ b/ui/src/components/index.tsx
@@ -84,6 +84,7 @@ export { default as PublicationVisualization } from './Publication/Visualization
 export { default as RelatedPublications } from './Publication/RelatedPublications';
 export { default as RelatedPublicationsCard } from './Publication/RelatedPublications/Card';
 export { default as RelatedPublicationsModal } from './Publication/RelatedPublications/Modal';
+export { default as RelatedPublicationsResult } from './Publication/RelatedPublications/Result';
 export { default as RequiredIndicator } from './RequiredIndicator';
 export { default as ScrollToTop } from './ScrollToTop';
 export { default as Search } from './SearchToggle';

--- a/ui/src/components/index.tsx
+++ b/ui/src/components/index.tsx
@@ -83,6 +83,7 @@ export { default as PublicationSkeleton } from './Publication/Skeleton';
 export { default as PublicationVisualization } from './Publication/Visualization';
 export { default as RelatedPublications } from './Publication/RelatedPublications';
 export { default as RelatedPublicationsCard } from './Publication/RelatedPublications/Card';
+export { default as RelatedPublicationsModal } from './Publication/RelatedPublications/Modal';
 export { default as RequiredIndicator } from './RequiredIndicator';
 export { default as ScrollToTop } from './ScrollToTop';
 export { default as Search } from './SearchToggle';

--- a/ui/src/config/endpoints.ts
+++ b/ui/src/config/endpoints.ts
@@ -1,18 +1,19 @@
 import * as api from '@/api';
 
 const endpoints = {
+    authorization: `${api.baseURL}/authorization`,
+    bookmarks: `${api.baseURL}/bookmarks`,
+    crosslinks: `${api.baseURL}/crosslinks`,
+    decodeUserToken: `${api.baseURL}/decode-user-token`,
+    flags: `${api.baseURL}/flags`,
+    links: `${api.baseURL}/links`,
     publications: `${api.baseURL}/publications`,
     publicationVersions: `${api.baseURL}/publication-versions`,
-    users: `${api.baseURL}/users`,
-    links: `${api.baseURL}/links`,
-    authorization: `${api.baseURL}/authorization`,
-    verification: `${api.baseURL}/verification`,
-    flags: `${api.baseURL}/flags`,
-    bookmarks: `${api.baseURL}/bookmarks`,
-    decodeUserToken: `${api.baseURL}/decode-user-token`,
-    verifyOrcidAccess: `${api.baseURL}/verify-orcid-access`,
     revokeOrcidAccess: `${api.baseURL}/revoke-orcid-access`,
-    topics: `${api.baseURL}/topics`
+    topics: `${api.baseURL}/topics`,
+    users: `${api.baseURL}/users`,
+    verification: `${api.baseURL}/verification`,
+    verifyOrcidAccess: `${api.baseURL}/verify-orcid-access`
 };
 
 export default endpoints;

--- a/ui/src/lib/interfaces.ts
+++ b/ui/src/lib/interfaces.ts
@@ -536,10 +536,17 @@ export interface AuthorSearchQuery extends ParsedUrlQuery {
 
 // Crosslinking
 export interface Crosslink {
+    id: string;
     linkedPublication: {
         id: string;
-        latestLiveVersion: Pick<PublicationVersion, 'title' | 'publishedDate'> & {
-            user: Pick<PublicationVersionUser, 'firstName' | 'lastName'>;
+        latestLiveVersion: Pick<PublicationVersion, 'title'> & {
+            publishedDate: string;
+            user: Pick<PublicationVersionUser, 'id' | 'firstName' | 'lastName'>;
+            coAuthors: Array<
+                Pick<CoAuthor, 'linkedUser'> & {
+                    user: Pick<User, 'firstName' | 'lastName' | 'role'>;
+                }
+            >;
         };
     };
     score: number;
@@ -550,4 +557,14 @@ export interface Crosslink {
 export interface MixedCrosslinks {
     recent: Crosslink[];
     relevant: Crosslink[];
+}
+
+export interface GetPublicationCrosslinksResponse {
+    data: Crosslink[];
+    metadata: SearchResultMeta;
+}
+
+export interface GetPublicationMixedCrosslinksResponse {
+    data: MixedCrosslinks;
+    metadata: SearchResultMeta;
 }

--- a/ui/src/pages/publications/[id]/versions/[versionId].tsx
+++ b/ui/src/pages/publications/[id]/versions/[versionId].tsx
@@ -53,7 +53,7 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
         Promise<Interfaces.BookmarkedEntityData[] | void>,
         Promise<Interfaces.PublicationWithLinks | void>,
         Promise<Interfaces.Flag[] | void>,
-        Promise<Interfaces.MixedCrosslinks | void>
+        Promise<Interfaces.GetPublicationMixedCrosslinksResponse | void>
     ] = [
         api
             .get(`${Config.endpoints.publications}/${requestedId}/publication-versions/${versionId}`, token)
@@ -142,7 +142,7 @@ type Props = {
     bookmarkId: string | null;
     directLinks: Interfaces.PublicationWithLinks;
     flags: Interfaces.Flag[];
-    crosslinks: Interfaces.MixedCrosslinks;
+    crosslinks: Interfaces.GetPublicationMixedCrosslinksResponse;
 };
 
 const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
@@ -749,6 +749,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
 
                             <Components.RelatedPublications
                                 id="mobile-related-publications"
+                                publicationId={props.publicationId}
                                 crosslinks={props.crosslinks}
                             />
                         </div>
@@ -1051,6 +1052,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                         />
                         <Components.RelatedPublications
                             id="desktop-related-publications"
+                            publicationId={props.publicationId}
                             crosslinks={props.crosslinks}
                         />
                     </div>

--- a/ui/src/pages/search/publications/index.tsx
+++ b/ui/src/pages/search/publications/index.tsx
@@ -1,4 +1,3 @@
-import { DateTime } from 'luxon';
 import React from 'react';
 import useSWR from 'swr';
 import Head from 'next/head';
@@ -176,7 +175,7 @@ const Publications: Types.NextPage<Props> = (props): React.ReactElement => {
         use: [Helpers.laggy]
     });
 
-    const handlerSearchFormSubmit: React.ReactEventHandler<HTMLFormElement> = async (
+    const handleSearchFormSubmit: React.ReactEventHandler<HTMLFormElement> = async (
         e: React.SyntheticEvent<HTMLFormElement, Event>
     ): Promise<void> => {
         e.preventDefault();
@@ -338,7 +337,7 @@ const Publications: Types.NextPage<Props> = (props): React.ReactElement => {
                             name="query-form"
                             id="query-form"
                             className="col-span-12 lg:col-span-7 xl:col-span-8"
-                            onSubmit={handlerSearchFormSubmit}
+                            onSubmit={handleSearchFormSubmit}
                         >
                             <label htmlFor="query" className="relative block w-full">
                                 <span className="mb-1 block text-xxs font-bold uppercase tracking-widest text-grey-600 transition-colors duration-500 dark:text-grey-300">
@@ -572,10 +571,7 @@ const Publications: Types.NextPage<Props> = (props): React.ReactElement => {
                                                             Next
                                                         </button>
                                                     </div>
-                                                    <span
-                                                        data-testid="baz"
-                                                        className="mt-4 block font-medium text-grey-800 transition-colors duration-500 dark:text-white-50"
-                                                    >
+                                                    <span className="mt-4 block font-medium text-grey-800 transition-colors duration-500 dark:text-white-50">
                                                         Showing {offset + 1} -{' '}
                                                         {limit + offset > response.metadata.total
                                                             ? response.metadata.total


### PR DESCRIPTION
The purpose of this PR was to give users a way of viewing all the crosslinks associated with a publication, further to the related publications sidebar which is capped at showing 5 links.

---

### Acceptance Criteria:

- Whilst viewing a publication page and there are more than 5 suggested links, a button to “Show All” is present at the bottom of the “Related publications” area, opening the “Related Content” modal. 
- The “Related Content” modal shows a list of each publication that has been suggested for linking with this publication, including title, publication date and first author.
    - A search control is present at the top of the modal to search user suggested links by publication title
    - Above the publication list, the text “Sort by” is present, with options available to sort the list by “Most recent” and “Most relevant”, presented as two radio buttons (not present in mockup).
        - By default, the list is sorted by recency, with the newest links first
    - To the right of the sort options, a checkbox is present if the user is logged in, reading “View my suggestions” which filters to links that the author has suggested.
    - The list of publications is paginated, with X publications displayed per page.
        - The same style of pagination control is used as is shown on the main publication search page.
        - A delete button is present against any suggestions the user has made.
            - Clicking this delete button will remove the suggested link.
        - An “opens in a new tab” style button is present to view each publication
    - A close button is present below the pagination options at the bottom of the modal (not in mockup)
---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
![Screenshot 2024-05-09 150805](https://github.com/JiscSD/octopus/assets/132363734/477c53a5-2ed1-4ff4-8c77-bae6fd24ebd9)

API
![Screenshot 2024-05-09 153541](https://github.com/JiscSD/octopus/assets/132363734/e55b4c87-affd-4256-8412-f9ed00c95289)

E2E
![Screenshot 2024-05-10 113839](https://github.com/JiscSD/octopus/assets/132363734/45786c20-9e6d-4b05-8bef-1464a3f319c9)

---

### Screenshots:
![Screenshot 2024-05-10 115409](https://github.com/JiscSD/octopus/assets/132363734/a176111b-989c-4b85-aef4-b239310c7187)
