### PR TITLE
OC-873: Remove or replace copy-webpack-plugin from API

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -19,6 +19,7 @@ Create a `.env` file inside `~/api` using `cp .env.example .env`.
 Make sure to update the values within to match your environment.
 
 #### Changes to .env file
+
 When adding a new item to the .env file, make sure to update the environment variables in the docker-compose.yml file so the API tests can access them.
 
 ### AWS Credentials File
@@ -93,6 +94,7 @@ You can then apply the changes made by the new migration using the two commands 
 More information on migrations in Prisma can be found here: [Prisma Migrate Documentation](https://www.prisma.io/docs/concepts/components/prisma-migrate/).
 
 ---
+
 ## Opensearch
 
 This provides a search index for publications. Locally, it runs in a docker container, and on AWS it runs as a [dedicated service](https://aws.amazon.com/opensearch-service/). Other searchable models such as authors and topics aren't stored in opensearch - their search functions use prisma.
@@ -100,6 +102,7 @@ This provides a search index for publications. Locally, it runs in a docker cont
 The field mapping of the index is not explicitly defined; it is set automatically when a document is inserted into it.
 
 ## Reindexing
+
 There is a script which deletes and recreates the publications index, inserting a document into it for each live publication. This can be run from the api directory with `npm run reindex`.
 
 A similar process happens when the database is seeded. After publications are inserted into the database, they are also fed into a blank opensearch index.
@@ -139,3 +142,9 @@ A similar process happens when the database is seeded. After publications are in
 API tests are written in [Jest](https://jestjs.io/) and each endpoint has tests written to ensure the code is correct and working. These can be run manually using `npm run test:local`.
 
 ---
+
+## Overridden dependencies
+
+This is a place to track where we have added dependency overrides in package.json and explain why so that we can understand when they're no longer necessary.
+
+-   micromatch ^4.0.6: to address two vulnerabilities ([1](https://security.snyk.io/vuln/SNYK-JS-BRACES-6838727), [2](https://security.snyk.io/vuln/SNYK-JS-MICROMATCH-6838728)) introduced via copy-webpack-plugin's dependency on this package.

--- a/api/README.md
+++ b/api/README.md
@@ -147,4 +147,6 @@ API tests are written in [Jest](https://jestjs.io/) and each endpoint has tests 
 
 This is a place to track where we have added dependency overrides in package.json and explain why so that we can understand when they're no longer necessary.
 
+-   fast-xml-parser ^4.2.5: to address [dependabot alert](https://github.com/JiscSD/octopus/security/dependabot/59)
+-   http-cache-semantics ^4.1.1: to address [dependabot alert](https://github.com/JiscSD/octopus/security/dependabot/45)
 -   micromatch ^4.0.6: to address two vulnerabilities ([1](https://security.snyk.io/vuln/SNYK-JS-BRACES-6838727), [2](https://security.snyk.io/vuln/SNYK-JS-MICROMATCH-6838728)) introduced via copy-webpack-plugin's dependency on this package.

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -16622,11 +16622,11 @@
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-            "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
+            "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
             "dependencies": {
-                "braces": "^3.0.2",
+                "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
             },
             "engines": {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -10686,11 +10686,11 @@
             }
         },
         "node_modules/braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dependencies": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             },
             "engines": {
                 "node": ">=8"
@@ -11435,13 +11435,13 @@
             }
         },
         "node_modules/copy-webpack-plugin/node_modules/globby": {
-            "version": "13.1.3",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.3.tgz",
-            "integrity": "sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==",
+            "version": "13.2.2",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
+            "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
             "dependencies": {
                 "dir-glob": "^3.0.1",
-                "fast-glob": "^3.2.11",
-                "ignore": "^5.2.0",
+                "fast-glob": "^3.3.0",
+                "ignore": "^5.2.4",
                 "merge2": "^1.4.1",
                 "slash": "^4.0.0"
             },
@@ -11453,14 +11453,14 @@
             }
         },
         "node_modules/copy-webpack-plugin/node_modules/schema-utils": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
-            "integrity": "sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
+            "integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
             "dependencies": {
                 "@types/json-schema": "^7.0.9",
-                "ajv": "^8.8.0",
+                "ajv": "^8.9.0",
                 "ajv-formats": "^2.1.1",
-                "ajv-keywords": "^5.0.0"
+                "ajv-keywords": "^5.1.0"
             },
             "engines": {
                 "node": ">= 12.13.0"
@@ -13216,18 +13216,18 @@
             "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
         },
         "node_modules/fast-xml-parser": {
-            "version": "4.2.6",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.6.tgz",
-            "integrity": "sha512-Xo1qV++h/Y3Ng8dphjahnYe+rGHaaNdsYOBWL9Y9GCPKpNKilJtilvWkLcI9f9X2DoKTLsZsGYAls5+JL5jfLA==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.0.tgz",
+            "integrity": "sha512-kLY3jFlwIYwBNDojclKsNAC12sfD6NwW74QB2CoNGPvtVxjliYehVunB3HYyNi+n4Tt1dAcgwYvmKF/Z18flqg==",
             "dev": true,
             "funding": [
                 {
-                    "type": "paypal",
-                    "url": "https://paypal.me/naturalintelligence"
-                },
-                {
                     "type": "github",
                     "url": "https://github.com/sponsors/NaturalIntelligence"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/naturalintelligence"
                 }
             ],
             "dependencies": {
@@ -13385,9 +13385,9 @@
             }
         },
         "node_modules/fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -14122,9 +14122,9 @@
             "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
         },
         "node_modules/ignore": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
+            "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
             "engines": {
                 "node": ">= 4"
             }

--- a/api/package.json
+++ b/api/package.json
@@ -96,7 +96,6 @@
     "overrides": {
         "fast-xml-parser": "^4.2.5",
         "http-cache-semantics": "^4.1.1",
-        "micromatch": "^4.0.6",
-        "node-fetch": "^2.6.12"
+        "micromatch": "^4.0.6"
     }
 }

--- a/api/package.json
+++ b/api/package.json
@@ -94,6 +94,7 @@
         "webpack-node-externals": "^3.0.0"
     },
     "overrides": {
+        "braces": "^3.0.3",
         "fast-xml-parser": "^4.2.5",
         "http-cache-semantics": "^4.1.1",
         "node-fetch": "^2.6.12"

--- a/api/package.json
+++ b/api/package.json
@@ -94,9 +94,9 @@
         "webpack-node-externals": "^3.0.0"
     },
     "overrides": {
-        "braces": "^3.0.3",
         "fast-xml-parser": "^4.2.5",
         "http-cache-semantics": "^4.1.1",
+        "micromatch": "^4.0.6",
         "node-fetch": "^2.6.12"
     }
 }

--- a/e2e/tests/PageModel.ts
+++ b/e2e/tests/PageModel.ts
@@ -126,7 +126,7 @@ export const PageModel = {
         octopusPublications: 'h2:has-text("Octopus publications")'
     },
     login: {
-        username: '#username',
+        username: '#username-input',
         password: '#password',
         signInButton: '#signin-button',
         authorizeButton: '#authorize-button',


### PR DESCRIPTION
The purpose of this PR was to address the fact that the copy-webpack-plugin package has vulnerabilities in its subdependencies. The way we use it is quite simple but it actually turned out to be difficult to do without this package, so instead this PR overrides the semver for its subdependency "micromatch". This means that the versions of the affected packages will be newer than the vulnerable ones.

Added a section to the API readme explaining why the dependency override was added so it can be removed if it ever becomes redundant.

---

### Acceptance Criteria:

- Either copy-webpack-plugin is removed (with PDF generation still working and styled correctly), or the vulnerabilities in its subdependencies are addressed.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [x] Documentation updated

---

### Tests:

E2E
![Screenshot 2024-05-28 102044](https://github.com/JiscSD/octopus/assets/132363734/71048b6d-e0cb-4a61-943a-6fcb218575d7)

API
![Screenshot 2024-05-28 104918](https://github.com/JiscSD/octopus/assets/132363734/40623a93-a1d2-4719-bf91-c3f8478271e0)

