### PR TITLE
OC-771 fix: make wide modal styling opt-in

### DIFF
--- a/ui/src/components/Modal/index.tsx
+++ b/ui/src/components/Modal/index.tsx
@@ -15,6 +15,7 @@ type Props = {
     icon?: React.ReactNode;
     children?: React.ReactNode;
     loading?: boolean;
+    wide?: boolean;
 };
 
 const Modal: React.FC<Props> = (props) => {
@@ -55,7 +56,9 @@ const Modal: React.FC<Props> = (props) => {
                         leaveFrom="opacity-100 translate-y-0 sm:scale-100"
                         leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
                     >
-                        <div className="relative mx-8 my-20 inline-block w-11/12 transform overflow-hidden rounded-lg bg-white-50 text-left align-bottom shadow-xl transition-all sm:align-middle lg:max-w-3xl xl:max-w-5xl">
+                        <div
+                            className={`relative mx-8 my-20 inline-block w-11/12 transform overflow-hidden rounded-lg bg-white-50 text-left align-bottom shadow-xl transition-all sm:align-middle ${props.wide ? 'lg:max-w-3xl xl:max-w-5xl' : 'lg:max-w-xl'}`}
+                        >
                             <Components.ModalBarLoader loading={loading} />
                             <div className="px-4 pb-4 pt-5 sm:px-8 sm:py-6">
                                 <div>
@@ -88,6 +91,7 @@ const Modal: React.FC<Props> = (props) => {
                                             text={props.positiveButtonText || ''}
                                             title={props.positiveButtonText || ''}
                                             actionType="POSITIVE"
+                                            className={props.wide ? 'lg:w-1/3' : ''}
                                         />
                                     )}
                                     <Components.ModalButton
@@ -101,7 +105,7 @@ const Modal: React.FC<Props> = (props) => {
                                         text={props.cancelButtonText}
                                         title={props.cancelButtonText}
                                         actionType="NEGATIVE"
-                                        className="md:w-1/6"
+                                        className={props.wide ? 'lg:w-1/3' : ''}
                                     />
                                 </div>
                             </div>

--- a/ui/src/components/Publication/RelatedPublications/Modal/index.tsx
+++ b/ui/src/components/Publication/RelatedPublications/Modal/index.tsx
@@ -54,6 +54,7 @@ const RelatedPublicationsModal: React.FC<Props> = (props): React.ReactElement =>
             cancelButtonText="Close"
             title="Related Content"
             titleClasses="text-left"
+            wide={true}
         >
             <form name="crosslink-search-form" id={formId} onSubmit={handleFormSubmit}>
                 <label htmlFor={searchInputId} className="relative block w-full">


### PR DESCRIPTION
The purpose of this PR was to fix an issue that arose from OC-771 where modals unrelated to the item itself changed style due to the changes in the item. This PR makes those changes only applicable if a "wide" prop is passed to the Modal component. The default styling will remain as it used to be.

---

### Acceptance Criteria:

- Publications other than the related publications modal retain their width and button widths from before OC-771.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

Not run.

---

### Screenshots:

Before/after with modal unrelated to OC-771:
![Screenshot 2024-05-29 095353](https://github.com/JiscSD/octopus/assets/132363734/19a9c1e4-3c31-4c2f-ab26-665b53683c11)
![Screenshot 2024-05-29 095406](https://github.com/JiscSD/octopus/assets/132363734/e66b9ac9-45c2-4a72-9549-70c5868e222d)

Before/after with the modal from OC-771 (to demonstrate slight change to button width that was worked into this PR):
![Screenshot 2024-05-29 095435](https://github.com/JiscSD/octopus/assets/132363734/1c3a0fa1-8ad0-4996-9396-f139908d7ec2)
<img width="1634" alt="Screenshot 2024-05-29 095418" src="https://github.com/JiscSD/octopus/assets/132363734/66323258-7060-4292-bb8e-d36813d237bf">
