### PR TITLE
OC-862: Requesting API keys

### DIFF
--- a/api/docs/api.yml
+++ b/api/docs/api.yml
@@ -2,7 +2,10 @@ openapi: 3.0.0
 info:
   version: '1'
   title: Octopus
-  description: Open research publishing platform
+  description: >
+    ## API Keys
+
+    An API key is required for many of the API’s operations. To request a unique API key, please send an email to [help@jisc.ac.uk](<mailto:help@jisc.ac.uk?subject=Octopus API key request>) from the address you are signed up to Octopus with, including the subject line “Octopus API key request”.
 servers:
   - url: https://prod.api.octopus.ac/v1
     description: Octopus live environment

--- a/ui/src/components/Nav/index.tsx
+++ b/ui/src/components/Nav/index.tsx
@@ -92,6 +92,10 @@ const Nav: React.FC = (): React.ReactElement => {
                     {
                         label: 'FAQ',
                         value: Config.urls.faq.path
+                    },
+                    {
+                        label: 'API Documentation',
+                        value: '/documentation/api'
                     }
                 ]
             },


### PR DESCRIPTION
The purpose of this PR was to give users a way to get in touch to request an API key.

---

### Acceptance Criteria:

- Text is present at the top of the API documentation reading “An API key is required for many of the API’s operations. To request a unique API key, please send an email to [help@jisc.ac.uk](mailto:help@jisc.ac.uk) from the address you are signed up to Octopus with, including the subject line “Octopus API key request”
    - Where [help@jisc.ac.uk](mailto:help@jisc.ac.uk) is a mailto “mailto:help@jisc.ac.uk?subject=Octopus API key request”
- A link is present at the bottom of the “How To” dropdown reading “API Documentation” that links to https://www.octopus.ac/documentation/api

---

### Checklist:

- [ ] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests: N/A
