### PR TITLE
OC-857: Medium vulnerability in dompurify

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -22,7 +22,7 @@
                 "cheerio": "^1.0.0-rc.12",
                 "copy-webpack-plugin": "^11.0.0",
                 "html-to-text": "^9.0.5",
-                "isomorphic-dompurify": "^2.4.0",
+                "isomorphic-dompurify": "^2.11.0",
                 "jsonwebtoken": "^9.0.2",
                 "luxon": "^3.4.3",
                 "nodemailer": "^6.9.9",
@@ -12225,9 +12225,9 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.9.tgz",
-            "integrity": "sha512-uyb4NDIvQ3hRn6NiC+SIFaP4mJ/MdXlvtunaqK9Bn6dD3RuB/1S/gasEjDHD8eiaqdSael2vBv+hOs7Y+jhYOQ=="
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.5.tgz",
+            "integrity": "sha512-lwG+n5h8QNpxtyrJW/gJWckL+1/DQiYMX8f7t8Z2AZTPw1esVrqjI63i7Zc2Gz0aKzLVMYC1V1PL/ky+aY/NgA=="
         },
         "node_modules/domutils": {
             "version": "3.1.0",
@@ -14667,12 +14667,12 @@
             "dev": true
         },
         "node_modules/isomorphic-dompurify": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-2.4.0.tgz",
-            "integrity": "sha512-OW3VSGrjppnbshcHz7RNKnoYlCJkyBBJzEE5yxrTSA+kOl9JPTIrXsnIgOuH4wdLqqRujx22bz/IXebGWPLMAg==",
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-2.11.0.tgz",
+            "integrity": "sha512-PNGGCbbSH7+zF45UKu4Kh+yI8hm1bWA8kIZQow4KMImnjYQtrqJA0ZmwHamYUU7+M5tQ84z7xXMWmZF/v5t5eA==",
             "dependencies": {
                 "@types/dompurify": "^3.0.5",
-                "dompurify": "^3.0.9",
+                "dompurify": "^3.1.4",
                 "jsdom": "^24.0.0"
             },
             "engines": {

--- a/api/package.json
+++ b/api/package.json
@@ -44,7 +44,7 @@
         "cheerio": "^1.0.0-rc.12",
         "copy-webpack-plugin": "^11.0.0",
         "html-to-text": "^9.0.5",
-        "isomorphic-dompurify": "^2.4.0",
+        "isomorphic-dompurify": "^2.11.0",
         "jsonwebtoken": "^9.0.2",
         "luxon": "^3.4.3",
         "nodemailer": "^6.9.9",


### PR DESCRIPTION
The purpose of this PR was to address a [vulnerability](https://security.snyk.io/vuln/SNYK-JS-DOMPURIFY-6474511) that Snyk has flagged with our API dependencies. By updating isomorphic-dompurify to the latest version, dompurify will be at a secure version.

---

### Acceptance Criteria:

- dompurify is version 2.4.9, 3.0.11 or higher.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

API
![Screenshot 2024-06-05 100050](https://github.com/JiscSD/octopus/assets/132363734/e198d825-e82b-4c8a-be1e-32710a97d052)

E2E
![Screenshot 2024-06-05 092222](https://github.com/JiscSD/octopus/assets/132363734/6a6476ff-5205-4be9-a523-e1091b883b67)
