### PR TITLE
OC-876: Cross link show all improvements

### DIFF
--- a/ui/src/components/Publication/RelatedPublications/Modal/index.tsx
+++ b/ui/src/components/Publication/RelatedPublications/Modal/index.tsx
@@ -46,11 +46,6 @@ const RelatedPublicationsModal: React.FC<Props> = (props): React.ReactElement =>
         { maxWait: 1500 }
     );
 
-    const handleClose = () => {
-        setGenericError('');
-        props.onClose();
-    };
-
     const upperPageBound = getCrosslinksResponse
         ? limit + offset > getCrosslinksResponse.metadata.total
             ? getCrosslinksResponse.metadata.total
@@ -60,7 +55,7 @@ const RelatedPublicationsModal: React.FC<Props> = (props): React.ReactElement =>
     return (
         <Components.Modal
             open={props.open}
-            onClose={handleClose}
+            onClose={props.onClose}
             cancelButtonText="Close"
             title="Related Content"
             titleClasses="text-left"
@@ -141,78 +136,80 @@ const RelatedPublicationsModal: React.FC<Props> = (props): React.ReactElement =>
             <div aria-live="polite" className="sr-only">
                 {!resultCount && !isValidating && 'No results found'}
             </div>
-            {!resultCount && !isValidating && (
-                <Components.Alert
-                    severity="INFO"
-                    title="No results found"
-                    details={[
-                        'Try some different search criteria.',
-                        'If you think something is wrong, please contact the helpdesk.'
-                    ]}
-                    className="mb-4"
-                />
-            )}
-            {!resultCount && isValidating && (
-                <OutlineIcons.ArrowPathIcon
-                    className="h-5 w-5 animate-reverse-spin text-teal-600 transition-colors duration-500 dark:text-teal-400 m-auto"
-                    aria-hidden="true"
-                />
-            )}
-            {!!resultCount && (
-                <>
-                    <div className="rounded flex flex-col gap-4">
-                        {getCrosslinksResponse.data.map((crosslink, index: number) => {
-                            let classes = '';
+            <div className="min-h-160">
+                {!resultCount && !isValidating && (
+                    <Components.Alert
+                        severity="INFO"
+                        title="No results found"
+                        details={[
+                            'Try some different search criteria.',
+                            'If you think something is wrong, please contact the helpdesk.'
+                        ]}
+                        className="mb-4"
+                    />
+                )}
+                {!resultCount && isValidating && (
+                    <OutlineIcons.ArrowPathIcon
+                        className="h-5 w-5 animate-reverse-spin text-teal-600 transition-colors duration-500 dark:text-teal-400 m-auto"
+                        aria-hidden="true"
+                    />
+                )}
+                {!!resultCount && (
+                    <>
+                        <div className="rounded flex flex-col gap-4">
+                            {getCrosslinksResponse.data.map((crosslink, index: number) => {
+                                let classes = '';
 
-                            if (index === 0) {
-                                classes += 'rounded-t';
-                            }
+                                if (index === 0) {
+                                    classes += 'rounded-t';
+                                }
 
-                            if (index === getCrosslinksResponse.data.length - 1) {
-                                classes += '!border-b-transparent !rounded-b';
-                            }
+                                if (index === getCrosslinksResponse.data.length - 1) {
+                                    classes += '!border-b-transparent !rounded-b';
+                                }
 
-                            return (
-                                <Components.RelatedPublicationsResult
-                                    key={crosslink.id}
-                                    crosslink={crosslink}
-                                    setError={setGenericError}
-                                    mutateList={mutate}
-                                />
-                            );
-                        })}
-                    </div>
-
-                    {!!getCrosslinksResponse?.data.length && (
-                        <div className="mt-8 w-full items-center justify-between lg:flex lg:flex-row-reverse">
-                            <div className="flex justify-between">
-                                <button
-                                    onClick={() => {
-                                        setOffset((prev) => prev - limit);
-                                    }}
-                                    disabled={offset === 0}
-                                    className="mr-6 rounded font-semibold text-grey-800 underline decoration-teal-500 decoration-2 underline-offset-4 outline-none transition-colors duration-500 focus:ring-2 focus:ring-yellow-500 disabled:decoration-teal-600 disabled:opacity-70 dark:text-white-50"
-                                >
-                                    Previous
-                                </button>
-
-                                <button
-                                    onClick={() => {
-                                        setOffset((prev) => prev + limit);
-                                    }}
-                                    className="rounded font-semibold text-grey-800 underline decoration-teal-500 decoration-2 underline-offset-4 outline-none transition-colors duration-500 focus:ring-2 focus:ring-yellow-500 disabled:decoration-teal-600 disabled:opacity-70 dark:text-white-50"
-                                    disabled={limit + offset >= getCrosslinksResponse.metadata.total}
-                                >
-                                    Next
-                                </button>
-                            </div>
-                            <span className="mt-4 block font-medium text-grey-800 transition-colors duration-500 dark:text-white-50">
-                                Showing {offset + 1} - {upperPageBound} of {getCrosslinksResponse.metadata.total}
-                            </span>
+                                return (
+                                    <Components.RelatedPublicationsResult
+                                        key={crosslink.id}
+                                        crosslink={crosslink}
+                                        setError={setGenericError}
+                                        mutateList={mutate}
+                                    />
+                                );
+                            })}
                         </div>
-                    )}
-                </>
-            )}
+
+                        {!!getCrosslinksResponse?.data.length && (
+                            <div className="mt-8 w-full items-center justify-between lg:flex lg:flex-row-reverse">
+                                <div className="flex justify-between">
+                                    <button
+                                        onClick={() => {
+                                            setOffset((prev) => prev - limit);
+                                        }}
+                                        disabled={offset === 0}
+                                        className="mr-6 rounded font-semibold text-grey-800 underline decoration-teal-500 decoration-2 underline-offset-4 outline-none transition-colors duration-500 focus:ring-2 focus:ring-yellow-500 disabled:decoration-teal-600 disabled:opacity-70 dark:text-white-50"
+                                    >
+                                        Previous
+                                    </button>
+
+                                    <button
+                                        onClick={() => {
+                                            setOffset((prev) => prev + limit);
+                                        }}
+                                        className="rounded font-semibold text-grey-800 underline decoration-teal-500 decoration-2 underline-offset-4 outline-none transition-colors duration-500 focus:ring-2 focus:ring-yellow-500 disabled:decoration-teal-600 disabled:opacity-70 dark:text-white-50"
+                                        disabled={limit + offset >= getCrosslinksResponse.metadata.total}
+                                    >
+                                        Next
+                                    </button>
+                                </div>
+                                <span className="mt-4 block font-medium text-grey-800 transition-colors duration-500 dark:text-white-50">
+                                    Showing {offset + 1} - {upperPageBound} of {getCrosslinksResponse.metadata.total}
+                                </span>
+                            </div>
+                        )}
+                    </>
+                )}
+            </div>
         </Components.Modal>
     );
 };

--- a/ui/src/components/Publication/RelatedPublications/Result/index.tsx
+++ b/ui/src/components/Publication/RelatedPublications/Result/index.tsx
@@ -42,7 +42,7 @@ const RelatedPublicationsResult: React.FC<Props> = (props): React.ReactElement =
     return (
         <div
             className={`
-                    min-h-[4rem]
+                    h-[6rem]
                     items-start
                     overflow-hidden
                     rounded-none
@@ -70,11 +70,9 @@ const RelatedPublicationsResult: React.FC<Props> = (props): React.ReactElement =
                     ${props.className ? props.className : ''}
                 `}
         >
-            <div>
-                <p className="text-left font-semibold mb-2 leading-6 text-grey-800 transition-colors duration-500 dark:text-white-50">
-                    {publicationVersion.title}
-                </p>
-            </div>
+            <p className="text-left font-semibold mb-2 leading-6 text-grey-800 transition-colors duration-500 dark:text-white-50 truncate w-full">
+                {publicationVersion.title}
+            </p>
 
             <div className="flex justify-between w-full">
                 <span

--- a/ui/src/components/Publication/RelatedPublications/index.tsx
+++ b/ui/src/components/Publication/RelatedPublications/index.tsx
@@ -12,7 +12,15 @@ const RelatedPublications: React.FC<Props> = (props) => {
     const { recent, relevant } = props.crosslinks.data;
     const totalCrosslinks = props.crosslinks.metadata.total;
     const [modalVisibility, setModalVisibility] = useState(false);
+    const [modalKey, setModalKey] = useState(0);
     const showShowAllButton = totalCrosslinks > 5;
+
+    const openModal = () => {
+        setModalVisibility(true);
+        // Resets modal state
+        setModalKey(modalKey + 1);
+    };
+
     return totalCrosslinks ? (
         <Components.AccordionSection id={props.id} title={'Related Publications'}>
             <div className="space-y-4 px-6 py-4">
@@ -51,12 +59,13 @@ const RelatedPublications: React.FC<Props> = (props) => {
                         <Components.Button
                             title="Show All"
                             className="rounded border-2 border-transparent bg-teal-600 px-2.5 text-white-50 shadow-sm focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2 children:border-0 children:text-white-50"
-                            onClick={() => setModalVisibility((prevState) => !prevState)}
+                            onClick={openModal}
                         />
                         <Components.RelatedPublicationsModal
                             publicationId={props.publicationId}
                             open={modalVisibility}
                             onClose={() => setModalVisibility(false)}
+                            key={modalKey}
                         />
                     </>
                 )}


### PR DESCRIPTION
The purpose of this PR was to fix some issues observed with the "View All" related publications modal.

- The modal will resize rapidly as it adjusts to display results for my search term.
    - To fix this, the modal should not resize when the number of results changes.
- The search term, sort order, results etc. are retained when the modal is closed and re-opened.
    - To fix this, the modal's state should be reset when it is re-opened.

---

### Acceptance Criteria:

- The all cross-links modal always displays with a height equivalent to if it were showing 5 search results, even if less are visible.
- Upon re-opening the all cross-links modal, any previously entered search term is disregarded and the full list of cross links is displayed.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
![Screenshot 2024-06-11 102102](https://github.com/JiscSD/octopus/assets/132363734/0f24a20c-a630-46cf-9191-d5c63aefa50d)

E2E
![Screenshot 2024-06-11 110640](https://github.com/JiscSD/octopus/assets/132363734/2e5d35c7-3e4e-4a74-9a0f-29c1f8b43969)

---

### Screenshots:

Modal retains size when showing fewer results
![Screenshot 2024-06-11 111143](https://github.com/JiscSD/octopus/assets/132363734/9ecf27e6-0580-4ea1-b0e7-22eaacfca270)
