### PR TITLE
OC-852: Bold text turns blue on publication page

### DIFF
--- a/ui/src/config/values.ts
+++ b/ui/src/config/values.ts
@@ -889,7 +889,7 @@ export const HTMLStyles = `
     dark:prose-a:text-white-50
     dark:focus:prose-a:text-grey-800
     dark:prose-blockquote:text-grey-300
-    dark:prose-strong:text-teal-300
+    dark:prose-strong:text-grey-100
 `
     .split('\n')
     .join(' ');


### PR DESCRIPTION
The purpose of this PR was to ensure that bold text is the same colour as normal weight text in the publication content area.

Note this only affected dark mode.

---

### Acceptance Criteria:

- Bold text should remain the same colour as other text instead of having any custom colouring added without the user requesting it.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
![Screenshot 2024-06-13 093306](https://github.com/JiscSD/octopus/assets/132363734/4a45344f-fff3-4d1c-9b10-d91e67b05526)

E2E
![Screenshot 2024-06-13 091330](https://github.com/JiscSD/octopus/assets/132363734/8030e4bb-1eb6-4696-87ce-2ee2df008404)

---

### Screenshots:

Before
![Screenshot 2024-06-13 093603](https://github.com/JiscSD/octopus/assets/132363734/b759b465-1a32-4488-89b0-c0a3a67042af)

After
![Screenshot 2024-06-13 093550](https://github.com/JiscSD/octopus/assets/132363734/2052f394-388a-4493-98c3-e5f3dbc91df8)
