### PR TITLE
OC-887: Create accounts for ARI departments

### DIFF
--- a/api/prisma/createOrganisationalAccounts.ts
+++ b/api/prisma/createOrganisationalAccounts.ts
@@ -1,3 +1,4 @@
+import * as I from 'interface';
 import * as userController from 'user/controller';
 import * as fs from 'fs';
 
@@ -8,8 +9,20 @@ const createOrganisationalAccounts = async (): Promise<string> => {
     if (!fs.existsSync(inputFileName)) {
         return `Input file "${inputFileName}" not found.`;
     }
+
+    const environment = process.argv[2];
+
+    if (!environment) {
+        return 'Expected an environment value ("int" or "prod") to be provided.';
+    }
+
+    if (!['int', 'prod'].includes(environment)) {
+        return `Invalid environment specified: ${environment}`;
+    }
+
     const data = JSON.parse(fs.readFileSync(inputFileName, 'utf8'));
-    const createdUsers = await userController.createOrganisationalAccounts(data);
+    const createdUsers = await userController.createOrganisationalAccounts(data, environment as I.Environment);
+
     return JSON.stringify(createdUsers);
 };
 

--- a/api/src/components/user/__tests__/createOrganisationalAccounts.test.ts
+++ b/api/src/components/user/__tests__/createOrganisationalAccounts.test.ts
@@ -1,3 +1,4 @@
+import * as I from 'interface';
 import * as testUtils from 'lib/testUtils';
 import * as userController from 'user/controller';
 
@@ -7,17 +8,53 @@ describe('Create organisational accounts', () => {
         await testUtils.testSeed();
     });
 
-    test('Basic organisational accounts can be created', async () => {
-        const createAccounts = await userController.createOrganisationalAccounts([
+    test('Organisational accounts can be created', async () => {
+        const inputData: I.CreateOrganisationalAccountInput[] = [
             {
-                name: 'Organisation 1'
+                name: 'Organisation 1',
+                email: 'info@test.ac.uk',
+                ror: 'example',
+                url: 'https://test.ac.uk',
+                defaultTopic: {
+                    title: 'Test topic',
+                    ids: {
+                        int: 'test-topic-1',
+                        prod: 'placeholder'
+                    }
+                }
             },
             {
-                name: 'Organisation 2'
+                name: 'Organisation 2',
+                email: 'person@place.gov.uk',
+                ror: 'persongovuk123',
+                url: 'https://test.gov.uk',
+                defaultTopic: {
+                    title: 'Test sub-topic A',
+                    ids: {
+                        int: 'test-topic-1a',
+                        prod: 'placeholder'
+                    }
+                }
             }
-        ]);
+        ];
+        const createAccounts = await userController.createOrganisationalAccounts(inputData);
 
         expect(createAccounts).toHaveLength(2);
+        expect(createAccounts[0]).toHaveProperty('role', 'ORGANISATION');
+        expect(createAccounts[0]).toHaveProperty('firstName', inputData[0].name);
+        expect(createAccounts[0]).toHaveProperty('lastName', null);
+        expect(createAccounts[0]).toHaveProperty('email', inputData[0].email);
+        expect(createAccounts[0]).toHaveProperty('ror', inputData[0].ror);
+        expect(createAccounts[0]).toHaveProperty('url', inputData[0].url);
+        expect(createAccounts[0]).toHaveProperty('defaultTopicId', inputData[0].defaultTopic?.ids.int);
+
+        expect(createAccounts[1]).toHaveProperty('role', 'ORGANISATION');
+        expect(createAccounts[1]).toHaveProperty('firstName', inputData[1].name);
+        expect(createAccounts[1]).toHaveProperty('lastName', null);
+        expect(createAccounts[1]).toHaveProperty('email', inputData[1].email);
+        expect(createAccounts[1]).toHaveProperty('ror', inputData[1].ror);
+        expect(createAccounts[1]).toHaveProperty('url', inputData[1].url);
+        expect(createAccounts[1]).toHaveProperty('defaultTopicId', inputData[1].defaultTopic?.ids.int);
     });
 
     test('Email address must be valid', async () => {
@@ -33,5 +70,47 @@ describe('Create organisational accounts', () => {
         ]);
 
         expect(createAccounts).toEqual('Supplied email addresses must be valid.');
+    });
+
+    test('URL must be valid', async () => {
+        const createAccounts = await userController.createOrganisationalAccounts([
+            {
+                name: 'Organisation 1',
+                url: 'https://jisc.ac.uk'
+            },
+            {
+                name: 'Organisation 2',
+                url: 'not a url'
+            }
+        ]);
+
+        expect(createAccounts).toEqual('Supplied URLs must be valid.');
+    });
+
+    test('Default topic IDs must be valid', async () => {
+        const createAccounts = await userController.createOrganisationalAccounts([
+            {
+                name: 'Organisation 1',
+                defaultTopic: {
+                    title: 'Test topic',
+                    ids: {
+                        int: 'test-topic-1',
+                        prod: 'placeholder'
+                    }
+                }
+            },
+            {
+                name: 'Organisation 2',
+                defaultTopic: {
+                    title: 'Made up topic',
+                    ids: {
+                        int: 'not-a-topic-id',
+                        prod: 'placeholder'
+                    }
+                }
+            }
+        ]);
+
+        expect(createAccounts).toEqual('Topic not found with ID not-a-topic-id.');
     });
 });

--- a/api/src/components/user/__tests__/updateOrganisationalAccount.test.ts
+++ b/api/src/components/user/__tests__/updateOrganisationalAccount.test.ts
@@ -29,7 +29,7 @@ describe('Update organisational account', () => {
             email: 'not an email address'
         });
 
-        expect(updatedAccount).toEqual('Supplied email address must be valid.');
+        expect(updatedAccount).toEqual('Supplied email addresses must be valid.');
     });
 
     test('At least one applicable property must be provided', async () => {
@@ -40,15 +40,27 @@ describe('Update organisational account', () => {
 
     test('Default topic ID must belong to a real topic', async () => {
         const updatedAccount = await userController.updateOrganisationalAccount('test-organisational-account-1', {
-            defaultTopicId: 'not a real ID'
+            defaultTopic: {
+                title: 'Made up topic',
+                ids: {
+                    int: 'not a real ID',
+                    prod: 'not a real ID'
+                }
+            }
         });
 
-        expect(updatedAccount).toEqual('Default topic not found.');
+        expect(updatedAccount).toEqual('Topic not found with ID not a real ID.');
     });
 
     test('Default topic ID can be set', async () => {
         const updatedAccount = await userController.updateOrganisationalAccount('test-organisational-account-1', {
-            defaultTopicId: 'test-topic-1'
+            defaultTopic: {
+                title: 'Test topic',
+                ids: {
+                    int: 'test-topic-1',
+                    prod: 'placeholder'
+                }
+            }
         });
 
         expect(updatedAccount).toHaveProperty('defaultTopicId', 'test-topic-1');

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -74,6 +74,8 @@ export interface JSONResponse {
     statusCode: number;
 }
 
+export type Environment = 'int' | 'prod';
+
 /**
  * @description Publications
  */
@@ -269,6 +271,13 @@ export interface CreateOrganisationalAccountInput {
     email?: string;
     ror?: string;
     url?: string;
+    defaultTopic?: {
+        title: string;
+        ids: {
+            int: string;
+            prod: string;
+        };
+    };
 }
 
 export interface UpdateOrganisationalAccountInput {
@@ -276,7 +285,13 @@ export interface UpdateOrganisationalAccountInput {
     email?: string;
     ror?: string;
     url?: string;
-    defaultTopicId?: string;
+    defaultTopic?: {
+        title: string;
+        ids: {
+            int: string;
+            prod: string;
+        };
+    };
 }
 
 /**

--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -1323,6 +1323,7 @@ test.describe('Publication flow + co-authors', () => {
     });
 
     test('Corresponding author can publish from Approvals Tracker', async ({ browser }) => {
+        test.slow();
         const page = await Helpers.getPageAsUser(browser);
 
         // create new publication


### PR DESCRIPTION
The purpose of this PR was to make some changes to the script and functions involved in creating organisational accounts to facilitate adding some government department accounts related to the ARI DB integration.

This was mainly work to allow default topics to be set on creation, and changes to support topic IDs for int and prod environments in the input data.

---

### Acceptance Criteria:

- Accounts exist for all 21 ARI departments (see  spreadsheet ari_departments.xlsx  )
    - The script will be run with supplied data after this code is approved.

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

API
![Screenshot 2024-07-11 120414](https://github.com/JiscSD/octopus/assets/132363734/11aaee48-7e7a-47f6-a731-8f9aec2e7dc7)

E2E
![Screenshot 2024-07-11 133020](https://github.com/JiscSD/octopus/assets/132363734/3b85fc32-0d4b-47cc-9681-124a431ed817)

---

### Screenshots:

Government department account inserted successfully on local environment
![Screenshot 2024-07-11 133629](https://github.com/JiscSD/octopus/assets/132363734/acd9a7f6-23fb-4d13-a6c5-01f266f8db0c)

