### PR TITLE
OC-884: Create script to create publications for existing ARIs

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -112,7 +112,7 @@ prisma/seeds
 This is because they have different use cases.
 
 -   local (dev):
-    -   A wide set of data useful for local development. For example, the requisite data for testing out integrations - to import data from the ARI database, certain topic mappings and departmental user accounts are expected to exist.
+    -   A wide set of data useful for local development. For example, the requisite data for testing out [integrations](#integrations) - to import data from the ARI database, certain topic mappings and departmental user accounts are expected to exist.
     -   Seeded using the command `npm run seed:local`.
 -   local (unitTesting):
     -   A minimal set of data providing only what is needed for the [jest tests](#testing) to run. This needs to be small because the database is reseeded again and again while the test suite is run, so that process needs to be as quick as possible.
@@ -134,6 +134,12 @@ The field mapping of the index is not explicitly defined; it is set automaticall
 There is a script which deletes and recreates the publications index, inserting a document into it for each live publication. This can be run from the api directory with `npm run reindex`.
 
 A similar process happens when the database is seeded. After publications are inserted into the database, they are also fed into a blank opensearch index.
+
+---
+
+## Integrations
+
+Octopus is built to integrate with some external systems in order to import publications. For more information please read the dedicated [integrations readme](./src/lib/integrations/README.md).
 
 ---
 

--- a/api/README.md
+++ b/api/README.md
@@ -112,7 +112,7 @@ prisma/seeds
 This is because they have different use cases.
 
 -   local (dev):
-    -   A wide set of data useful for local development.
+    -   A wide set of data useful for local development. For example, the requisite data for testing out integrations - to import data from the ARI database, certain topic mappings and departmental user accounts are expected to exist.
     -   Seeded using the command `npm run seed:local`.
 -   local (unitTesting):
     -   A minimal set of data providing only what is needed for the [jest tests](#testing) to run. This needs to be small because the database is reseeded again and again while the test suite is run, so that process needs to be as quick as possible.

--- a/api/package.json
+++ b/api/package.json
@@ -23,6 +23,8 @@
         "test:watch": "npm run test:local -- --watch",
         "reindex": "ts-node scripts/reindex.ts",
         "createOrganisationalAccounts": "ts-node -r tsconfig-paths/register scripts/createOrganisationalAccounts.ts",
+        "createTopicMappings": "ts-node -r tsconfig-paths/register scripts/createTopicMappings.ts",
+        "createUserMappings": "ts-node -r tsconfig-paths/register scripts/createUserMappings.ts",
         "fullAriImport": "ts-node -r tsconfig-paths/register scripts/fullAriImport.ts",
         "updateOrganisationalAccount": "ts-node -r tsconfig-paths/register scripts/updateOrganisationalAccount.ts",
         "format:check": "npx prettier --check src/",

--- a/api/package.json
+++ b/api/package.json
@@ -23,6 +23,7 @@
         "test:watch": "npm run test:local -- --watch",
         "reindex": "ts-node scripts/reindex.ts",
         "createOrganisationalAccounts": "ts-node -r tsconfig-paths/register scripts/createOrganisationalAccounts.ts",
+        "fullAriImport": "ts-node -r tsconfig-paths/register scripts/fullAriImport.ts",
         "updateOrganisationalAccount": "ts-node -r tsconfig-paths/register scripts/updateOrganisationalAccount.ts",
         "format:check": "npx prettier --check src/",
         "format:write": "npx prettier --write src/",

--- a/api/prisma/migrations/20240815151246_user_mappings/migration.sql
+++ b/api/prisma/migrations/20240815151246_user_mappings/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "UserMapping" (
+    "userId" TEXT NOT NULL,
+    "value" TEXT NOT NULL,
+    "source" "PublicationImportSource" NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserMapping_value_source_key" ON "UserMapping"("value", "source");
+
+-- AddForeignKey
+ALTER TABLE "UserMapping" ADD CONSTRAINT "UserMapping_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -37,6 +37,7 @@ model User {
     crosslinkVotes       CrosslinkVote[]
     defaultTopicId       String?
     defaultTopic         Topic?                 @relation(fields: [defaultTopicId], references: [id])
+    mappings             UserMapping[]
 }
 
 model Verification {
@@ -245,6 +246,15 @@ model TopicMapping {
     source   PublicationImportSource
 
     @@unique([title, source])
+}
+
+model UserMapping {
+    userId String
+    user   User                    @relation(fields: [userId], references: [id], onDelete: Cascade)
+    value  String
+    source PublicationImportSource
+
+    @@unique([value, source])
 }
 
 model Bookmark {

--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -55,7 +55,7 @@ const createTopics = async (): Promise<void> => {
 };
 
 export const initialDevSeed = async (): Promise<void> => {
-    // Create users. These are relied upon when creating publications.
+    // Create basic users. These are relied upon when creating publications.
     await client.prisma.user.createMany({ data: SeedData.devUsers });
 
     const doesIndexExist = await client.search.indices.exists({
@@ -74,8 +74,11 @@ export const initialDevSeed = async (): Promise<void> => {
         createTopics()
     ]);
 
-    // Add topic mappings - these depend on topics.
-    await client.prisma.topicMapping.createMany({ data: SeedData.devTopicMappings });
+    // Add topic mappings and organisational accounts - these depend on topics.
+    await Promise.all([
+        client.prisma.topicMapping.createMany({ data: SeedData.devTopicMappings }),
+        client.prisma.user.createMany({ data: SeedData.devOrganisationalAccounts })
+    ]);
 
     if (process.env.STAGE === 'local') {
         // Create local S3 buckets

--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -80,6 +80,9 @@ export const initialDevSeed = async (): Promise<void> => {
         client.prisma.user.createMany({ data: SeedData.devOrganisationalAccounts })
     ]);
 
+    // Add organisational account mappings, which depend on organisational accounts.
+    await client.prisma.userMapping.createMany({ data: SeedData.devUserMappings });
+
     if (process.env.STAGE === 'local') {
         // Create local S3 buckets
         for (const bucketNameSegment in s3.buckets) {

--- a/api/prisma/seeds/index.ts
+++ b/api/prisma/seeds/index.ts
@@ -3,6 +3,7 @@ export { default as devOrganisationalAccounts } from './local/dev/organisational
 export { default as devOtherPublications } from './local/dev/otherPublications';
 export { default as devTopicMappings } from './local/dev/topicMappings';
 export { default as devTopics } from './local/dev/topics';
+export { default as devUserMappings } from './local/dev/userMappings';
 export { default as devUsers } from './local/dev/users';
 export { default as prodPublications } from './prod/publications';
 export { default as prodUsers } from './prod/users';
@@ -12,4 +13,5 @@ export { default as testPublications } from './local/unitTesting/publications';
 export { default as testReferences } from './local/unitTesting/references';
 export { default as testTopicMappings } from './local/unitTesting/topicMappings';
 export { default as testTopics } from './local/unitTesting/topics';
+export { default as testUserMappings } from './local/unitTesting/userMappings';
 export { default as testUsers } from './local/unitTesting/users';

--- a/api/prisma/seeds/index.ts
+++ b/api/prisma/seeds/index.ts
@@ -1,4 +1,5 @@
 export { default as devProblems } from './local/dev/problems';
+export { default as devOrganisationalAccounts } from './local/dev/organisationalAccounts';
 export { default as devOtherPublications } from './local/dev/otherPublications';
 export { default as devTopicMappings } from './local/dev/topicMappings';
 export { default as devTopics } from './local/dev/topics';

--- a/api/prisma/seeds/local/dev/organisationalAccounts.ts
+++ b/api/prisma/seeds/local/dev/organisationalAccounts.ts
@@ -2,157 +2,178 @@ import { Prisma } from '@prisma/client';
 
 const userSeeds: Prisma.UserCreateManyInput[] = [
     {
+        id: 'clyheq7ko0001eg48k2id2jao',
         role: 'ORGANISATION',
-        firstName: 'UK Policing: Office of Police Chief Scientific Adviser (GB)',
+        firstName: 'Office of Police Chief Scientific Adviser (UK)',
         email: 'ari.comment@go-science.gov.uk',
         defaultTopicId: 'cly468yf300007ryzm3e5px2a' // Crime
     },
     {
+        id: 'clyheq7kp0003eg48dlp686sc',
         role: 'ORGANISATION',
-        firstName: 'Department for Science, Innovation & Technology (GB)',
+        firstName: 'Department for Science, Innovation & Technology (UK)',
         email: 'ari.comment@go-science.gov.uk',
         defaultTopicId: 'clkv6uivq008sl2rsh8muvs18', // Technology (General)
         url: 'https://www.gov.uk/government/organisations/department-for-science-innovation-and-technology'
     },
     {
+        id: 'clyheq7kp0005eg48dlythcrr',
         role: 'ORGANISATION',
-        firstName: 'Nuclear Decommissioning Authority (GB)',
+        firstName: 'Nuclear Decommissioning Authority (UK)',
         email: 'ari.comment@go-science.gov.uk',
         defaultTopicId: 'cly468ztz006a7ryzihan74l9', // Nuclear policy
         url: 'https://www.gov.uk/government/organisations/nuclear-decommissioning-authority'
     },
     {
+        id: 'clyheq7kp0007eg48jc3ot4id',
         role: 'ORGANISATION',
-        firstName: 'Office for Statistics Regulation (GB)',
+        firstName: 'Office for Statistics Regulation (UK)',
         email: 'ari.comment@go-science.gov.uk',
         defaultTopicId: 'cly468zfd003y7ryzoeleyai4', // Government policy
         url: 'https://osr.statisticsauthority.gov.uk/'
     },
     {
+        id: 'clyheq7kp0009eg48m1tg5fxx',
         role: 'ORGANISATION',
-        firstName: 'Metropolitan Police (GB)',
+        firstName: 'Metropolitan Police (UK)',
         email: 'ari.comment@go-science.gov.uk',
         defaultTopicId: 'cly468yf300007ryzm3e5px2a', // Crime
         url: 'https://www.met.police.uk/'
     },
     {
+        id: 'clyheq7kq000beg48wlra7tm4',
         role: 'ORGANISATION',
-        firstName: 'Ministry of Justice (GB)',
+        firstName: 'Ministry of Justice (UK)',
         email: 'ari.comment@go-science.gov.uk',
         defaultTopicId: 'cly468zli00507ryzh96v7r8o', // Justice
         ror: 'https://ror.org/01xdnwc75',
         url: 'https://www.gov.uk/government/organisations/ministry-of-justice'
     },
     {
+        id: 'clyheq7kq000deg48a1gvgiuv',
         role: 'ORGANISATION',
-        firstName: 'Ministry of Defence (GB)',
+        firstName: 'Ministry of Defence (UK)',
         email: 'ari.comment@go-science.gov.uk',
         defaultTopicId: 'clkv6uidy002el2rsrw12sj6v', // Military science
         ror: 'https://ror.org/01bvxzn29',
         url: 'https://www.gov.uk/government/organisations/ministry-of-defence'
     },
     {
+        id: 'clyheq7kq000feg48xcu4ue2h',
         role: 'ORGANISATION',
-        firstName: 'Health and Safety Executive (GB)',
+        firstName: 'Health and Safety Executive (UK)',
         email: 'ari.comment@go-science.gov.uk',
         defaultTopicId: 'cly46908i008q7ryzfvth7486', // Safety of Citizens
         url: 'https://www.hse.gov.uk/'
     },
     {
+        id: 'clyheq7kq000heg48srz2qf7s',
         role: 'ORGANISATION',
-        firstName: 'Home Office (GB)',
+        firstName: 'Home Office (UK)',
         email: 'ari.comment@go-science.gov.uk',
         defaultTopicId: 'cly468zka004s7ryzogn1sx12', // Interior policy
         ror: 'https://ror.org/00y81cg83',
         url: 'https://www.gov.uk/government/organisations/home-office'
     },
     {
+        id: 'clyheq7kr000jeg48uq3wh46r',
         role: 'ORGANISATION',
-        firstName: 'Food Standards Agency (GB)',
+        firstName: 'Food Standards Agency (UK)',
         email: 'ari.comment@go-science.gov.uk',
         defaultTopicId: 'cly468zcn003g7ryz4eavc8jw', // Food industry
         url: 'https://www.food.gov.uk/'
     },
     {
+        id: 'clyheq7kr000leg48rrycwbjb',
         role: 'ORGANISATION',
-        firstName: 'Foreign, Commonwealth & Development Office (GB)',
+        firstName: 'Foreign, Commonwealth & Development Office (UK)',
         email: 'ari.comment@go-science.gov.uk',
         defaultTopicId: 'cly468zfd003y7ryzoeleyai4', // Government policy
         url: 'https://www.gov.uk/government/organisations/foreign-commonwealth-development-office'
     },
     {
+        id: 'clyheq7kr000neg48k9n53zik',
         role: 'ORGANISATION',
-        firstName: 'Department for Work and Pensions (GB)',
+        firstName: 'Department for Work and Pensions (UK)',
         email: 'ari.comment@go-science.gov.uk',
         defaultTopicId: 'cly468za8002z7ryz8g8pl8bx', // Employment
         ror: 'https://ror.org/0499kfe57',
         url: 'https://www.gov.uk/government/organisations/department-for-work-pensions'
     },
     {
+        id: 'clyheq7kr000peg482et9g4zb',
         role: 'ORGANISATION',
-        firstName: 'Department for Levelling Up, Housing and Communities (GB)',
+        firstName: 'Ministry of Housing, Communities and Local Government (UK)',
         email: 'ari.comment@go-science.gov.uk',
         defaultTopicId: 'cly468zhx004d7ryzsezmjjyt', // Housing and urban planning policy
         ror: 'https://ror.org/01w88hp45',
         url: 'https://www.gov.uk/government/organisations/department-for-levelling-up-housing-and-communities'
     },
     {
+        id: 'clyheq7kr000reg484lhdl5e0',
         role: 'ORGANISATION',
-        firstName: 'Department for International Trade (GB)',
+        firstName: 'Department for International Trade (UK)',
         email: 'ari.comment@go-science.gov.uk',
         defaultTopicId: 'clkv6uigk003el2rswm10fyv8', // Commerce
         ror: 'https://ror.org/01bgmsb44',
         url: 'https://www.great.gov.uk/'
     },
     {
+        id: 'clyheq7ks000teg48wgwhlqmh',
         role: 'ORGANISATION',
-        firstName: 'Department for Health and Social Care (GB)',
+        firstName: 'Department of Health and Social Care (UK)',
         email: 'ari.comment@go-science.gov.uk',
         defaultTopicId: 'cly468z6u002e7ryzlb1oxcau', // Social and public welfare
         url: 'https://www.gov.uk/government/organisations/department-of-health-and-social-care'
     },
     {
+        id: 'clyheq7ks000veg48nu1n7mfa',
         role: 'ORGANISATION',
-        firstName: 'Department for Transport (GB)',
+        firstName: 'Department for Transport (UK)',
         email: 'ari.comment@go-science.gov.uk',
         defaultTopicId: 'clkv6uigf003cl2rsanvnjdgl', // Transportation and communications
         ror: 'https://ror.org/010mf0m52',
         url: 'https://www.gov.uk/government/organisations/department-for-transport'
     },
     {
+        id: 'clyheq7ks000xeg48iuio6m3m',
         role: 'ORGANISATION',
-        firstName: 'Department for Education (GB)',
+        firstName: 'Department for Education (UK)',
         email: 'ari.comment@go-science.gov.uk',
         defaultTopicId: 'cly4690lq00ab7ryzpg64y15x', // Education policy
         ror: 'https://ror.org/0320bge18',
         url: 'https://www.gov.uk/government/organisations/department-for-education'
     },
     {
+        id: 'clyheq7ks000zeg48qrotkx5x',
         role: 'ORGANISATION',
-        firstName: 'Department for Environment, Food & Rural Affairs (GB)',
+        firstName: 'Department for Environment, Food & Rural Affairs (UK)',
         email: 'ari.comment@go-science.gov.uk',
         defaultTopicId: 'clkv6uium008gl2rs3d7ene92', // Agriculture (General)
         ror: 'https://ror.org/00tnppw48',
         url: 'https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs'
     },
     {
+        id: 'clyheq7kt0011eg489wbiaxgv',
         role: 'ORGANISATION',
-        firstName: 'Department for Digital, Culture, Media & Sport (GB)',
+        firstName: 'Department for Digital, Culture, Media & Sport (UK)',
         email: 'ari.comment@go-science.gov.uk',
         defaultTopicId: 'cly4690kb00a57ryzg1f59ik9', // Cultural policies
         ror: 'https://ror.org/02zqy3981',
         url: 'https://www.gov.uk/government/organisations/department-for-digital-culture-media-sport'
     },
     {
+        id: 'clyheq7kt0013eg48l8ukuwzn',
         role: 'ORGANISATION',
-        firstName: 'Cabinet Office (GB)',
+        firstName: 'Cabinet Office (UK)',
         email: 'ari.comment@go-science.gov.uk',
         defaultTopicId: 'cly468zfd003y7ryzoeleyai4', // Government policy
         url: 'https://www.gov.uk/government/organisations/cabinet-office'
     },
     {
+        id: 'clyheq7kt0015eg48i58jtf3a',
         role: 'ORGANISATION',
-        firstName: 'Department for Business, Energy & Industrial Strategy (GB)',
+        firstName: 'Department for Business, Energy & Industrial Strategy (UK)',
         email: 'ari.comment@go-science.gov.uk',
         defaultTopicId: 'cly46903l007x7ryzgan8igh3', // Regulation of industry
         ror: 'https://ror.org/019ya6433',

--- a/api/prisma/seeds/local/dev/organisationalAccounts.ts
+++ b/api/prisma/seeds/local/dev/organisationalAccounts.ts
@@ -1,0 +1,162 @@
+import { Prisma } from '@prisma/client';
+
+const userSeeds: Prisma.UserCreateManyInput[] = [
+    {
+        role: 'ORGANISATION',
+        firstName: 'UK Policing: Office of Police Chief Scientific Adviser (GB)',
+        email: 'ari.comment@go-science.gov.uk',
+        defaultTopicId: 'cly468yf300007ryzm3e5px2a' // Crime
+    },
+    {
+        role: 'ORGANISATION',
+        firstName: 'Department for Science, Innovation & Technology (GB)',
+        email: 'ari.comment@go-science.gov.uk',
+        defaultTopicId: 'clkv6uivq008sl2rsh8muvs18', // Technology (General)
+        url: 'https://www.gov.uk/government/organisations/department-for-science-innovation-and-technology'
+    },
+    {
+        role: 'ORGANISATION',
+        firstName: 'Nuclear Decommissioning Authority (GB)',
+        email: 'ari.comment@go-science.gov.uk',
+        defaultTopicId: 'cly468ztz006a7ryzihan74l9', // Nuclear policy
+        url: 'https://www.gov.uk/government/organisations/nuclear-decommissioning-authority'
+    },
+    {
+        role: 'ORGANISATION',
+        firstName: 'Office for Statistics Regulation (GB)',
+        email: 'ari.comment@go-science.gov.uk',
+        defaultTopicId: 'cly468zfd003y7ryzoeleyai4', // Government policy
+        url: 'https://osr.statisticsauthority.gov.uk/'
+    },
+    {
+        role: 'ORGANISATION',
+        firstName: 'Metropolitan Police (GB)',
+        email: 'ari.comment@go-science.gov.uk',
+        defaultTopicId: 'cly468yf300007ryzm3e5px2a', // Crime
+        url: 'https://www.met.police.uk/'
+    },
+    {
+        role: 'ORGANISATION',
+        firstName: 'Ministry of Justice (GB)',
+        email: 'ari.comment@go-science.gov.uk',
+        defaultTopicId: 'cly468zli00507ryzh96v7r8o', // Justice
+        ror: 'https://ror.org/01xdnwc75',
+        url: 'https://www.gov.uk/government/organisations/ministry-of-justice'
+    },
+    {
+        role: 'ORGANISATION',
+        firstName: 'Ministry of Defence (GB)',
+        email: 'ari.comment@go-science.gov.uk',
+        defaultTopicId: 'clkv6uidy002el2rsrw12sj6v', // Military science
+        ror: 'https://ror.org/01bvxzn29',
+        url: 'https://www.gov.uk/government/organisations/ministry-of-defence'
+    },
+    {
+        role: 'ORGANISATION',
+        firstName: 'Health and Safety Executive (GB)',
+        email: 'ari.comment@go-science.gov.uk',
+        defaultTopicId: 'cly46908i008q7ryzfvth7486', // Safety of Citizens
+        url: 'https://www.hse.gov.uk/'
+    },
+    {
+        role: 'ORGANISATION',
+        firstName: 'Home Office (GB)',
+        email: 'ari.comment@go-science.gov.uk',
+        defaultTopicId: 'cly468zka004s7ryzogn1sx12', // Interior policy
+        ror: 'https://ror.org/00y81cg83',
+        url: 'https://www.gov.uk/government/organisations/home-office'
+    },
+    {
+        role: 'ORGANISATION',
+        firstName: 'Food Standards Agency (GB)',
+        email: 'ari.comment@go-science.gov.uk',
+        defaultTopicId: 'cly468zcn003g7ryz4eavc8jw', // Food industry
+        url: 'https://www.food.gov.uk/'
+    },
+    {
+        role: 'ORGANISATION',
+        firstName: 'Foreign, Commonwealth & Development Office (GB)',
+        email: 'ari.comment@go-science.gov.uk',
+        defaultTopicId: 'cly468zfd003y7ryzoeleyai4', // Government policy
+        url: 'https://www.gov.uk/government/organisations/foreign-commonwealth-development-office'
+    },
+    {
+        role: 'ORGANISATION',
+        firstName: 'Department for Work and Pensions (GB)',
+        email: 'ari.comment@go-science.gov.uk',
+        defaultTopicId: 'cly468za8002z7ryz8g8pl8bx', // Employment
+        ror: 'https://ror.org/0499kfe57',
+        url: 'https://www.gov.uk/government/organisations/department-for-work-pensions'
+    },
+    {
+        role: 'ORGANISATION',
+        firstName: 'Department for Levelling Up, Housing and Communities (GB)',
+        email: 'ari.comment@go-science.gov.uk',
+        defaultTopicId: 'cly468zhx004d7ryzsezmjjyt', // Housing and urban planning policy
+        ror: 'https://ror.org/01w88hp45',
+        url: 'https://www.gov.uk/government/organisations/department-for-levelling-up-housing-and-communities'
+    },
+    {
+        role: 'ORGANISATION',
+        firstName: 'Department for International Trade (GB)',
+        email: 'ari.comment@go-science.gov.uk',
+        defaultTopicId: 'clkv6uigk003el2rswm10fyv8', // Commerce
+        ror: 'https://ror.org/01bgmsb44',
+        url: 'https://www.great.gov.uk/'
+    },
+    {
+        role: 'ORGANISATION',
+        firstName: 'Department for Health and Social Care (GB)',
+        email: 'ari.comment@go-science.gov.uk',
+        defaultTopicId: 'cly468z6u002e7ryzlb1oxcau', // Social and public welfare
+        url: 'https://www.gov.uk/government/organisations/department-of-health-and-social-care'
+    },
+    {
+        role: 'ORGANISATION',
+        firstName: 'Department for Transport (GB)',
+        email: 'ari.comment@go-science.gov.uk',
+        defaultTopicId: 'clkv6uigf003cl2rsanvnjdgl', // Transportation and communications
+        ror: 'https://ror.org/010mf0m52',
+        url: 'https://www.gov.uk/government/organisations/department-for-transport'
+    },
+    {
+        role: 'ORGANISATION',
+        firstName: 'Department for Education (GB)',
+        email: 'ari.comment@go-science.gov.uk',
+        defaultTopicId: 'cly4690lq00ab7ryzpg64y15x', // Education policy
+        ror: 'https://ror.org/0320bge18',
+        url: 'https://www.gov.uk/government/organisations/department-for-education'
+    },
+    {
+        role: 'ORGANISATION',
+        firstName: 'Department for Environment, Food & Rural Affairs (GB)',
+        email: 'ari.comment@go-science.gov.uk',
+        defaultTopicId: 'clkv6uium008gl2rs3d7ene92', // Agriculture (General)
+        ror: 'https://ror.org/00tnppw48',
+        url: 'https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs'
+    },
+    {
+        role: 'ORGANISATION',
+        firstName: 'Department for Digital, Culture, Media & Sport (GB)',
+        email: 'ari.comment@go-science.gov.uk',
+        defaultTopicId: 'cly4690kb00a57ryzg1f59ik9', // Cultural policies
+        ror: 'https://ror.org/02zqy3981',
+        url: 'https://www.gov.uk/government/organisations/department-for-digital-culture-media-sport'
+    },
+    {
+        role: 'ORGANISATION',
+        firstName: 'Cabinet Office (GB)',
+        email: 'ari.comment@go-science.gov.uk',
+        defaultTopicId: 'cly468zfd003y7ryzoeleyai4', // Government policy
+        url: 'https://www.gov.uk/government/organisations/cabinet-office'
+    },
+    {
+        role: 'ORGANISATION',
+        firstName: 'Department for Business, Energy & Industrial Strategy (GB)',
+        email: 'ari.comment@go-science.gov.uk',
+        defaultTopicId: 'cly46903l007x7ryzgan8igh3', // Regulation of industry
+        ror: 'https://ror.org/019ya6433',
+        url: 'https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy'
+    }
+];
+export default userSeeds;

--- a/api/prisma/seeds/local/dev/topicMappings.ts
+++ b/api/prisma/seeds/local/dev/topicMappings.ts
@@ -505,7 +505,7 @@ const topicMappings: Prisma.TopicMappingCreateManyInput[] = [
         isMapped: true
     },
     {
-        title: 'Climatechange',
+        title: 'Climate change',
         source: 'ARI',
         topicId: 'clkv6uizf00a6l2rsck5tw4cb',
         isMapped: true

--- a/api/prisma/seeds/local/dev/topics.ts
+++ b/api/prisma/seeds/local/dev/topics.ts
@@ -3,17 +3,11 @@ import { Prisma } from '@prisma/client';
 const topics: Prisma.TopicCreateInput[] = [
     {
         id: 'clkv6uiba001il2rsb9i7dka8',
-        title: 'What makes everything we can detect in the universe around us the way that it is, and why?',
-        parents: {
-            connect: []
-        }
+        title: 'What makes everything we can detect in the universe around us the way that it is, and why?'
     },
     {
         id: 'clkv6uoi102e6l2rs3bu1xo8b',
-        title: 'mosaic virus',
-        parents: {
-            connect: []
-        }
+        title: 'mosaic virus'
     },
     {
         id: 'clkv6uibe001kl2rsmoghv4f8',

--- a/api/prisma/seeds/local/dev/userMappings.ts
+++ b/api/prisma/seeds/local/dev/userMappings.ts
@@ -1,0 +1,116 @@
+import { Prisma } from '@prisma/client';
+
+const userMappings: Prisma.UserMappingCreateManyInput[] = [
+    {
+        userId: 'clyheq7ko0001eg48k2id2jao',
+        value: 'Office of Police Chief Scientific Adviser',
+        source: 'ARI'
+    },
+    {
+        userId: 'clyheq7kp0003eg48dlp686sc',
+        value: 'Department for Science, Innovation & Technology',
+        source: 'ARI'
+    },
+    {
+        userId: 'clyheq7kp0005eg48dlythcrr',
+        value: 'Nuclear Decommissioning Authority',
+        source: 'ARI'
+    },
+    {
+        userId: 'clyheq7kp0007eg48jc3ot4id',
+        value: 'Office for Statistics Regulation',
+        source: 'ARI'
+    },
+    {
+        userId: 'clyheq7kp0009eg48m1tg5fxx',
+        value: 'Metropolitan Police',
+        source: 'ARI'
+    },
+    {
+        userId: 'clyheq7kq000beg48wlra7tm4',
+        value: 'Ministry of Justice',
+        source: 'ARI'
+    },
+    {
+        userId: 'clyheq7kq000deg48a1gvgiuv',
+        value: 'Ministry of Defence',
+        source: 'ARI'
+    },
+    {
+        userId: 'clyheq7kq000feg48xcu4ue2h',
+        value: 'Health and Safety Executive',
+        source: 'ARI'
+    },
+    {
+        userId: 'clyheq7kq000heg48srz2qf7s',
+        value: 'Home Office',
+        source: 'ARI'
+    },
+    {
+        userId: 'clyheq7kr000jeg48uq3wh46r',
+        value: 'Food Standards Agency',
+        source: 'ARI'
+    },
+    {
+        userId: 'clyheq7kr000leg48rrycwbjb',
+        value: 'Foreign, Commonwealth & Development Office',
+        source: 'ARI'
+    },
+    {
+        userId: 'clyheq7kr000neg48k9n53zik',
+        value: 'Department for Work and Pensions',
+        source: 'ARI'
+    },
+    {
+        userId: 'clyheq7kr000peg482et9g4zb',
+        value: 'Department for Levelling Up, Housing and Communities',
+        source: 'ARI'
+    },
+    {
+        userId: 'clyheq7kr000reg484lhdl5e0',
+        value: 'Department for International Trade',
+        source: 'ARI'
+    },
+    {
+        userId: 'clyheq7ks000teg48wgwhlqmh',
+        value: 'Department for Health and Social Care',
+        source: 'ARI'
+    },
+    {
+        userId: 'clyheq7ks000teg48wgwhlqmh',
+        value: 'Department of Health and Social Care',
+        source: 'ARI'
+    },
+    {
+        userId: 'clyheq7ks000veg48nu1n7mfa',
+        value: 'Department for Transport',
+        source: 'ARI'
+    },
+    {
+        userId: 'clyheq7ks000xeg48iuio6m3m',
+        value: 'Department for Education',
+        source: 'ARI'
+    },
+    {
+        userId: 'clyheq7ks000zeg48qrotkx5x',
+        value: 'Department for Environment, Food & Rural Affairs',
+        source: 'ARI'
+    },
+    {
+        userId: 'clyheq7kt0011eg489wbiaxgv',
+        value: 'Department for Digital, Culture, Media & Sport',
+        source: 'ARI'
+    },
+    {
+        userId: 'clyheq7kt0013eg48l8ukuwzn',
+        value: 'Cabinet Office',
+        source: 'ARI'
+    },
+    {
+        userId: 'clyheq7kt0015eg48i58jtf3a',
+        value: 'Department for Business, Energy & Industrial Strategy',
+        source: 'ARI'
+    }
+];
+
+export default userMappings;

--- a/api/prisma/seeds/local/dev/userMappings.ts
+++ b/api/prisma/seeds/local/dev/userMappings.ts
@@ -3,7 +3,7 @@ import { Prisma } from '@prisma/client';
 const userMappings: Prisma.UserMappingCreateManyInput[] = [
     {
         userId: 'clyheq7ko0001eg48k2id2jao',
-        value: 'Office of Police Chief Scientific Adviser',
+        value: 'UK Policing: Office of Police Chief Scientific Adviser',
         source: 'ARI'
     },
     {

--- a/api/prisma/seeds/local/dev/users.ts
+++ b/api/prisma/seeds/local/dev/users.ts
@@ -7,7 +7,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Victoria',
         lastName: 'Allen',
         email: 'test-user-1b@jisc.ac.uk',
-        locked: false,
         apiKey: '000000001'
     },
     {
@@ -16,7 +15,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Science',
         lastName: 'Octopus',
         email: 'octopus@jisc.ac.uk',
-        locked: false,
         apiKey: 'kjahskjhuhaushkjhaskjhjkahsd'
     },
     {
@@ -25,7 +23,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Rami',
         lastName: 'Salem',
         email: 'test-user-2b@jisc.ac.uk',
-        locked: false,
         apiKey: '000000002'
     },
     {
@@ -34,7 +31,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Aoi',
         lastName: 'Han',
         email: 'test-user-3@jisc.ac.uk',
-        locked: false,
         apiKey: '000000003'
     },
     {
@@ -43,7 +39,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Juan',
         lastName: 'Garcia',
         email: 'test-user-4@jisc.ac.uk',
-        locked: false,
         apiKey: '000000004'
     },
     {
@@ -52,7 +47,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Amelia',
         lastName: 'Lucas',
         email: 'test-user-5@jisc.ac.uk',
-        locked: false,
         apiKey: '000000005'
     },
     {
@@ -61,7 +55,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Grace',
         lastName: 'Murphy',
         email: 'test-user-6@jisc.ac.uk',
-        locked: false,
         apiKey: '000000006'
     },
     {
@@ -70,7 +63,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Oliver',
         lastName: 'Smith',
         email: 'test-user-7@jisc.ac.uk',
-        locked: false,
         apiKey: '000000007'
     },
     {
@@ -79,7 +71,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Mia',
         lastName: 'Prakash',
         email: 'test-user-8@jisc.ac.uk',
-        locked: false,
         apiKey: '000000008'
     },
     {
@@ -88,7 +79,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Gabriel',
         lastName: 'Dubois',
         email: 'test-user-9@jisc.ac.uk',
-        locked: false,
         apiKey: '000000009'
     },
     {
@@ -97,7 +87,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Fatima',
         lastName: 'Akter',
         email: 'test-user-10@jisc.ac.uk',
-        locked: false,
         apiKey: '000000010'
     },
     {
@@ -106,7 +95,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Althea',
         lastName: 'De la Cruz',
         email: 'test-user-11@jisc.ac.uk',
-        locked: false,
         apiKey: '000000011'
     },
     {
@@ -115,7 +103,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Nathaniel',
         lastName: 'Hernandez',
         email: 'test-user-12@jisc.ac.uk',
-        locked: false,
         apiKey: '000000012'
     },
     {
@@ -124,7 +111,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Liam',
         lastName: 'Tremblay',
         email: 'test-user-13@jisc.ac.uk',
-        locked: false,
         apiKey: '000000013'
     },
     {
@@ -133,7 +119,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Sophia',
         lastName: 'MacDonald',
         email: 'test-user-14@jisc.ac.uk',
-        locked: false,
         apiKey: '000000014'
     },
     {
@@ -142,7 +127,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Ji-an',
         lastName: 'Choi',
         email: 'test-user-15@jisc.ac.uk',
-        locked: false,
         apiKey: '000000015'
     },
     {
@@ -151,7 +135,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Dmitry',
         lastName: 'Sokolov',
         email: 'test-user-16@jisc.ac.uk',
-        locked: false,
         apiKey: '000000016'
     },
     {
@@ -160,7 +143,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Isla',
         lastName: 'Murray',
         email: 'test-user-17@jisc.ac.uk',
-        locked: false,
         apiKey: '000000017'
     },
     {
@@ -169,7 +151,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Ines',
         lastName: 'Halimi',
         email: 'test-user-18@jisc.ac.uk',
-        locked: false,
         apiKey: '000000018'
     },
     {
@@ -178,7 +159,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Youssef',
         lastName: 'Alami',
         email: 'test-user-19@jisc.ac.uk',
-        locked: false,
         apiKey: '000000019'
     },
     {
@@ -187,7 +167,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Jackson',
         lastName: 'Fortin',
         email: 'test-user-20@jisc.ac.uk',
-        locked: false,
         apiKey: '000000020'
     },
     {
@@ -196,7 +175,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Patricia',
         lastName: 'Jones',
         email: 'test-user-21@jisc.ac.uk',
-        locked: false,
         apiKey: '000000021'
     },
     {
@@ -205,7 +183,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Sofia',
         lastName: 'Gomez',
         email: 'test-user-22@jisc.ac.uk',
-        locked: false,
         apiKey: '000000022'
     },
     {
@@ -214,7 +191,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Valentina',
         lastName: 'Gomez',
         email: 'test-user-23@jisc.ac.uk',
-        locked: false,
         apiKey: '000000023'
     },
     {
@@ -223,7 +199,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Ren',
         lastName: 'Kim',
         email: 'test-user-24@jisc.ac.uk',
-        locked: false,
         apiKey: '000000024'
     },
     {
@@ -232,7 +207,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Sophie',
         lastName: 'De Vries',
         email: 'test-user-25@jisc.ac.uk',
-        locked: false,
         apiKey: '000000025'
     },
     {
@@ -240,7 +214,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         orcid: '0026',
         firstName: 'Co-Author',
         lastName: 'One',
-        locked: false,
         apiKey: '000000026'
     },
     {
@@ -248,7 +221,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         orcid: '0027',
         firstName: 'Co-Author',
         lastName: 'Two',
-        locked: false,
         apiKey: '000000027'
     },
     {

--- a/api/prisma/seeds/local/unitTesting/publications.ts
+++ b/api/prisma/seeds/local/unitTesting/publications.ts
@@ -1238,15 +1238,16 @@ const publicationSeeds: Prisma.PublicationCreateInput[] = [
                 versionNumber: 1,
                 title: 'ARI Publication 1',
                 content:
-                    '<p>This problem is a UK government area of research interest (ARI) that was originally posted at <a href="https://ari.org.uk/">https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</p>' +
+                    // Static placeholder text added to each mapped ARI's content
+                    '<p><em>This problem is a UK government area of research interest (ARI) that was originally posted at <a href="https://ari.org.uk/">https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</em></p>' +
                     // ARI Question title
                     '<p>ARI Publication 1</p>' +
                     // Background information
                     '<p>Sample background information.</p>' +
                     // Contact details
-                    '<p>Contact details: Sample contact details.</p>' +
+                    '<p><strong>Contact details</strong></p><p>Sample contact details.</p>' +
                     // Related UKRI projects
-                    '<p>Related UKRI Projects:</p><ul><li><a href="https://gtr.ukri.org/projects?ref=ES%2FS007105%2F1">Urban Big Data Centre</a></li><li><a href="https://gtr.ukri.org/projects?ref=ES%2FL011921%2F1">Urban Big Data</a></li></ul>',
+                    '<p><strong>Related UKRI Projects</strong></p><ul><li><a href="https://gtr.ukri.org/projects?ref=ES%2FS007105%2F1">Urban Big Data Centre</a></li><li><a href="https://gtr.ukri.org/projects?ref=ES%2FL011921%2F1">Urban Big Data</a></li></ul>',
                 conflictOfInterestStatus: false,
                 user: { connect: { id: 'test-organisational-account-1' } },
                 publicationStatus: { create: { status: 'LIVE' } },

--- a/api/prisma/seeds/local/unitTesting/userMappings.ts
+++ b/api/prisma/seeds/local/unitTesting/userMappings.ts
@@ -1,0 +1,11 @@
+import { Prisma } from '@prisma/client';
+
+const userMappings: Prisma.UserMappingCreateManyInput[] = [
+    {
+        userId: 'test-organisational-account-1',
+        value: 'test ari department',
+        source: 'ARI'
+    }
+];
+
+export default userMappings;

--- a/api/prisma/seeds/local/unitTesting/users.ts
+++ b/api/prisma/seeds/local/unitTesting/users.ts
@@ -100,7 +100,7 @@ const userSeeds: Prisma.UserCreateInput[] = [
     },
     {
         id: 'test-organisational-account-1',
-        firstName: 'Test ARI Department (GB)',
+        firstName: 'Test ARI Department (UK)',
         role: 'ORGANISATION',
         apiKey: '000000012'
     },

--- a/api/prisma/seeds/local/unitTesting/users.ts
+++ b/api/prisma/seeds/local/unitTesting/users.ts
@@ -7,7 +7,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Science',
         lastName: 'Octopus',
         email: 'octopus@jisc.ac.uk',
-        locked: false,
         apiKey: 'kjahskjhuhaushkjhaskjhjkahsd'
     },
     {
@@ -16,7 +15,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Test',
         lastName: 'User 1',
         email: 'test-user-1@jisc.ac.uk',
-        locked: false,
         apiKey: '123456789'
     },
     {
@@ -25,7 +23,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Test',
         lastName: 'User 2',
         email: 'test-user-2@jisc.ac.uk',
-        locked: false,
         apiKey: '987654321'
     },
     {
@@ -34,7 +31,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Test',
         lastName: 'User 3',
         email: 'test-user-3@jisc.ac.uk',
-        locked: false,
         apiKey: '000000003'
     },
     {
@@ -43,7 +39,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Test',
         lastName: 'User 4',
         email: 'test-user-4@jisc.ac.uk',
-        locked: false,
         apiKey: '000000004',
         role: 'SUPER_USER'
     },
@@ -53,7 +48,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Test',
         lastName: 'CoAuthor 1',
         email: 'test-user-5@jisc.ac.uk',
-        locked: false,
         apiKey: '000000005'
     },
     {
@@ -62,7 +56,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Test',
         lastName: 'CoAuthor 2',
         email: 'test-user-6@jisc.ac.uk',
-        locked: false,
         apiKey: '000000006'
     },
     {
@@ -71,7 +64,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Test',
         lastName: 'CoAuthor 3',
         email: 'test-user-7@jisc.ac.uk',
-        locked: false,
         apiKey: '000000007'
     },
     {
@@ -80,7 +72,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Test',
         lastName: 'CoAuthor 4',
         email: 'test-user-8@jisc.ac.uk',
-        locked: false,
         apiKey: '000000008'
     },
     {
@@ -89,7 +80,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Test',
         lastName: 'CoAuthor 5',
         email: 'test-user-9@jisc.ac.uk',
-        locked: false,
         apiKey: '000000009'
     },
     {
@@ -98,7 +88,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Test',
         lastName: 'CoAuthor 6',
         email: 'test-user-10@jisc.ac.uk',
-        locked: false,
         apiKey: '000000010'
     },
     {
@@ -107,7 +96,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: '',
         lastName: '',
         email: 'test-user-11@jisc.ac.uk',
-        locked: false,
         apiKey: '000000011'
     },
     {

--- a/api/prisma/seeds/prod/users.ts
+++ b/api/prisma/seeds/prod/users.ts
@@ -7,7 +7,6 @@ const userSeeds: Prisma.UserCreateInput[] = [
         firstName: 'Science',
         lastName: 'Octopus',
         email: 'octopus@jisc.ac.uk',
-        locked: false,
         apiKey: process.env.OCTOPUS_API_KEY
     }
 ];

--- a/api/scripts/createTopicMappings.ts
+++ b/api/scripts/createTopicMappings.ts
@@ -1,0 +1,222 @@
+/**
+ * Use this script to import topic mappings from a data file at ./topic-mappings.json.
+ * The data in that file should match the "CreateTopicMappingData" type in this file.
+ *
+ * By default, the script will perform a dry run, aiming at the local/int environments.
+ * To change this, provide args as follows:
+ *
+ * npm run createTopicMappings -- environment=prod dryRun=false
+ */
+
+import * as client from '../src/lib/client';
+import * as fs from 'fs';
+import * as Helpers from 'lib/helpers';
+import * as I from 'interface';
+
+type CreateTopicMappingData = {
+    // The external source system to map data from.
+    source: I.PublicationImportSource;
+    // The title of the incoming topic.
+    title: string;
+    // The title of the existing topic in octopus.
+    octopusTitle: string;
+    // The ID of the existing topic in octopus on local/int environments.
+    intExistingTopicId: string;
+    // The ID of the existing topic in octopus on the prod environment.
+    prodExistingTopicId: string;
+    // Set to false to intentionally ignore an incoming topic value. Defaults to true.
+    isMapped: boolean;
+};
+
+const parseArguments = (): { environment: I.Environment; dryRun: boolean } => {
+    const args = Helpers.parseNpmScriptArgs();
+    const environmentArg = args.environment;
+
+    if (environmentArg && !(environmentArg === 'int' || environmentArg === 'prod')) {
+        throw new Error('Environment must be one of "int" or "prod"');
+    }
+
+    const dryRunArg = args.dryRun;
+
+    if (dryRunArg && !(dryRunArg === 'true' || dryRunArg === 'false')) {
+        throw new Error('dryRun must be one of "true" or "false"');
+    }
+
+    return {
+        environment: environmentArg === 'prod' ? 'prod' : 'int',
+        dryRun: dryRunArg === 'false' ? false : true
+    };
+};
+
+const readDataFromFile = (): { data: CreateTopicMappingData[]; error?: string } => {
+    const inputFileName = 'scripts/topic-mappings.json';
+
+    if (!fs.existsSync(inputFileName)) {
+        return {
+            data: [],
+            error: `Input file "${inputFileName}" not found.`
+        };
+    }
+
+    const fileData = JSON.parse(fs.readFileSync(inputFileName, 'utf8'));
+
+    return {
+        data: fileData
+    };
+};
+
+const validateData = async (
+    data: CreateTopicMappingData[],
+    environment: I.Environment = 'int'
+): Promise<{ valid: boolean; messages: string[] }> => {
+    let valid = true;
+    const messages: string[] = [];
+
+    // Ensure names are unique.
+    const uniqueNames = new Set();
+    const duplicateNames: string[] = [];
+
+    for (const item of data) {
+        const name = item.title;
+
+        if (uniqueNames.has(name)) {
+            duplicateNames.push(name);
+        } else {
+            uniqueNames.add(name);
+        }
+
+        if (item.isMapped) {
+            if (!(item.intExistingTopicId && item.prodExistingTopicId)) {
+                valid = false;
+                messages.push(
+                    `Topic mapping "${item.title}" does not have existing IDs provided for both environments.`
+                );
+            }
+
+            // Check DB for existing topic.
+            const existingTopic = await client.prisma.topic.findUnique({
+                where: {
+                    id: item[`${environment}ExistingTopicId`]
+                }
+            });
+
+            if (!existingTopic) {
+                valid = false;
+                messages.push(`Existing topic for mapping "${item.title}" could not be found in the database.`);
+            } else {
+                if (existingTopic.title !== item.octopusTitle) {
+                    valid = false;
+                    messages.push(
+                        `Existing topic for mapping "${item.title}" (${existingTopic.title}) has been found but the name doesn't match what was provided (${item.octopusTitle}).`
+                    );
+                }
+            }
+        }
+    }
+
+    if (duplicateNames.length) {
+        valid = false;
+        messages.push(`Duplicate names detected: ${duplicateNames.join(', ')}`);
+    }
+
+    return {
+        valid,
+        messages
+    };
+};
+
+type CreatedTopicMapping = {
+    isMapped: boolean;
+    title: string;
+    topic?: {
+        id: string;
+        title: string;
+    };
+};
+
+const createTopicMappings = async (
+    data: CreateTopicMappingData[],
+    environment: I.Environment = 'int',
+    dryRun?: boolean
+): Promise<CreatedTopicMapping[]> => {
+    const created: CreatedTopicMapping[] = [];
+
+    for (const mapping of data) {
+        let createdMapping;
+
+        if (!dryRun) {
+            try {
+                createdMapping = await client.prisma.topicMapping.create({
+                    data: {
+                        title: mapping.title,
+                        source: mapping.source,
+                        ...(mapping.isMapped
+                            ? { topicId: mapping[`${environment}ExistingTopicId`] }
+                            : { isMapped: false })
+                    },
+                    select: {
+                        isMapped: true,
+                        title: true,
+                        source: true,
+                        topic: {
+                            select: {
+                                id: true,
+                                title: true
+                            }
+                        }
+                    }
+                });
+            } catch (err) {
+                console.log(err);
+            } finally {
+                created.push({
+                    isMapped: createdMapping.isMapped,
+                    title: createdMapping.title,
+                    ...(createdMapping.topic && { topic: createdMapping.topic })
+                });
+            }
+        } else {
+            // Push mocked new topic mapping.
+            created.push({
+                isMapped: mapping.isMapped,
+                title: mapping.title.toLowerCase(), // prisma client extension lower cases title on save
+                ...(mapping.isMapped && {
+                    topic: {
+                        id: mapping[`${environment}ExistingTopicId`],
+                        title: mapping.octopusTitle
+                    }
+                })
+            });
+        }
+    }
+
+    return created;
+};
+
+const fileContents = readDataFromFile();
+
+if (fileContents.error) {
+    console.log('Read file error: ', fileContents.error);
+}
+
+const { environment, dryRun } = parseArguments();
+
+validateData(fileContents.data, environment)
+    .then((result) => {
+        if (result.valid) {
+            createTopicMappings(fileContents.data, environment, dryRun)
+                .then((createdMappings) => {
+                    console.log(
+                        dryRun
+                            ? 'Dry run complete.'
+                            : 'Real run complete.' +
+                                  ` Created ${createdMappings.length} mappings out of ${fileContents.data.length}.`
+                    );
+                    console.log(createdMappings);
+                })
+                .catch((err) => console.log(err));
+        } else {
+            console.log('Failed validation.', result);
+        }
+    })
+    .catch((err) => console.log(err));

--- a/api/scripts/createTopicMappings.ts
+++ b/api/scripts/createTopicMappings.ts
@@ -193,30 +193,29 @@ const createTopicMappings = async (
     return created;
 };
 
-const fileContents = readDataFromFile();
+const runScript = async (): Promise<void> => {
+    const fileContents = readDataFromFile();
 
-if (fileContents.error) {
-    console.log('Read file error: ', fileContents.error);
-}
+    if (fileContents.error) {
+        console.log('Read file error: ', fileContents.error);
+    }
 
-const { environment, dryRun } = parseArguments();
+    const { environment, dryRun } = parseArguments();
 
-validateData(fileContents.data, environment)
-    .then((result) => {
-        if (result.valid) {
-            createTopicMappings(fileContents.data, environment, dryRun)
-                .then((createdMappings) => {
-                    console.log(
-                        dryRun
-                            ? 'Dry run complete.'
-                            : 'Real run complete.' +
-                                  ` Created ${createdMappings.length} mappings out of ${fileContents.data.length}.`
-                    );
-                    console.log(createdMappings);
-                })
-                .catch((err) => console.log(err));
-        } else {
-            console.log('Failed validation.', result);
-        }
-    })
-    .catch((err) => console.log(err));
+    const result = await validateData(fileContents.data, environment);
+
+    if (result.valid) {
+        const createdMappings = await createTopicMappings(fileContents.data, environment, dryRun);
+        console.log(
+            dryRun
+                ? 'Dry run complete.'
+                : 'Real run complete.' +
+                      ` Created ${createdMappings.length} mappings out of ${fileContents.data.length}.`
+        );
+        console.log(createdMappings);
+    } else {
+        console.log('Failed validation.', result);
+    }
+};
+
+void runScript();

--- a/api/scripts/createUserMappings.ts
+++ b/api/scripts/createUserMappings.ts
@@ -186,30 +186,29 @@ const createUserMappings = async (
     return created;
 };
 
-const fileContents = readDataFromFile();
+const runScript = async (): Promise<void> => {
+    const fileContents = readDataFromFile();
 
-if (fileContents.error) {
-    console.log('Read file error: ', fileContents.error);
-}
+    if (fileContents.error) {
+        console.log('Read file error: ', fileContents.error);
+    }
 
-const { environment, dryRun } = parseArguments();
+    const { environment, dryRun } = parseArguments();
 
-validateData(fileContents.data, environment)
-    .then((result) => {
-        if (result.valid) {
-            createUserMappings(fileContents.data, environment, dryRun)
-                .then((createdMappings) => {
-                    console.log(
-                        dryRun
-                            ? 'Dry run complete.'
-                            : 'Real run complete.' +
-                                  ` Created ${createdMappings.length} mappings out of ${fileContents.data.length}.`
-                    );
-                    console.log(createdMappings);
-                })
-                .catch((err) => console.log(err));
-        } else {
-            console.log('Failed validation.', result);
-        }
-    })
-    .catch((err) => console.log(err));
+    const result = await validateData(fileContents.data, environment);
+
+    if (result.valid) {
+        const createdMappings = await createUserMappings(fileContents.data, environment, dryRun);
+        console.log(
+            dryRun
+                ? 'Dry run complete.'
+                : 'Real run complete.' +
+                      ` Created ${createdMappings.length} mappings out of ${fileContents.data.length}.`
+        );
+        console.log(createdMappings);
+    } else {
+        console.log('Failed validation.', result);
+    }
+};
+
+void runScript();

--- a/api/scripts/createUserMappings.ts
+++ b/api/scripts/createUserMappings.ts
@@ -1,0 +1,215 @@
+/**
+ * Use this script to import user mappings from a data file at ./user-mappings.json.
+ * The data in that file should match the "CreateUserMappingData" type in this file.
+ *
+ * By default, the script will perform a dry run, aiming at the local/int environments.
+ * To change this, provide args as follows:
+ *
+ * npm run createUserMappings -- environment=prod dryRun=false
+ */
+
+import * as client from '../src/lib/client';
+import * as fs from 'fs';
+import * as Helpers from 'lib/helpers';
+import * as I from 'interface';
+
+type CreateUserMappingData = {
+    // The external source system to map data from.
+    source: I.PublicationImportSource;
+    // The incoming value to map to a user.
+    value: string;
+    // The firstName of the existing user in octopus.
+    octopusUserName: string;
+    // The ID of the existing user in octopus on local/int environments.
+    intExistingUserId: string;
+    // The ID of the existing user in octopus on the prod environment.
+    prodExistingUserId: string;
+};
+
+const parseArguments = (): { environment: I.Environment; dryRun: boolean } => {
+    const args = Helpers.parseNpmScriptArgs();
+    const environmentArg = args.environment;
+
+    if (environmentArg && !(environmentArg === 'int' || environmentArg === 'prod')) {
+        throw new Error('Environment must be one of "int" or "prod"');
+    }
+
+    const dryRunArg = args.dryRun;
+
+    if (dryRunArg && !(dryRunArg === 'true' || dryRunArg === 'false')) {
+        throw new Error('dryRun must be one of "true" or "false"');
+    }
+
+    return {
+        environment: environmentArg === 'prod' ? 'prod' : 'int',
+        dryRun: dryRunArg === 'false' ? false : true
+    };
+};
+
+const readDataFromFile = (): { data: CreateUserMappingData[]; error?: string } => {
+    const inputFileName = 'scripts/user-mappings.json';
+
+    if (!fs.existsSync(inputFileName)) {
+        return {
+            data: [],
+            error: `Input file "${inputFileName}" not found.`
+        };
+    }
+
+    const fileData = JSON.parse(fs.readFileSync(inputFileName, 'utf8'));
+
+    return {
+        data: fileData
+    };
+};
+
+const validateData = async (
+    data: CreateUserMappingData[],
+    environment: I.Environment = 'int'
+): Promise<{ valid: boolean; messages: string[] }> => {
+    let valid = true;
+    const messages: string[] = [];
+
+    // Ensure values are unique.
+    const uniqueValues = new Set();
+    const duplicateValues: string[] = [];
+
+    for (const item of data) {
+        const value = item.value;
+
+        if (uniqueValues.has(value)) {
+            duplicateValues.push(value);
+        } else {
+            uniqueValues.add(value);
+        }
+
+        if (!(item.intExistingUserId && item.prodExistingUserId)) {
+            valid = false;
+            messages.push(`User mapping "${item.value}" does not have existing IDs provided for both environments.`);
+        }
+
+        // Check DB for existing user.
+        const existingUser = await client.prisma.user.findUnique({
+            where: {
+                id: item[`${environment}ExistingUserId`]
+            }
+        });
+
+        if (!existingUser) {
+            valid = false;
+            messages.push(`Existing user for mapping "${item.value}" could not be found in the database.`);
+        } else {
+            if (existingUser.firstName !== item.octopusUserName) {
+                valid = false;
+                messages.push(
+                    `Existing user for mapping "${item.value}" (${existingUser.firstName}) has been found but the name doesn't match what was provided (${item.octopusUserName}).`
+                );
+            }
+
+            if (existingUser.role !== 'ORGANISATION') {
+                valid = false;
+                messages.push(
+                    `Existing user for mapping "${item.value}" (${existingUser.firstName}) has been found but it is not an organisational account.`
+                );
+            }
+        }
+    }
+
+    if (duplicateValues.length) {
+        valid = false;
+        messages.push(`Duplicate values detected: ${duplicateValues.join(', ')}`);
+    }
+
+    return {
+        valid,
+        messages
+    };
+};
+
+type CreatedUserMapping = {
+    value: string;
+    user?: {
+        id: string;
+        firstName: string;
+    };
+};
+
+const createUserMappings = async (
+    data: CreateUserMappingData[],
+    environment: I.Environment = 'int',
+    dryRun?: boolean
+): Promise<CreatedUserMapping[]> => {
+    const created: CreatedUserMapping[] = [];
+
+    for (const mapping of data) {
+        let createdMapping;
+
+        if (!dryRun) {
+            try {
+                createdMapping = await client.prisma.userMapping.create({
+                    data: {
+                        value: mapping.value,
+                        source: mapping.source,
+                        userId: mapping[`${environment}ExistingUserId`]
+                    },
+                    select: {
+                        value: true,
+                        source: true,
+                        user: {
+                            select: {
+                                id: true,
+                                firstName: true
+                            }
+                        }
+                    }
+                });
+            } catch (err) {
+                console.log(err);
+            } finally {
+                created.push({
+                    value: createdMapping.value,
+                    user: createdMapping.user
+                });
+            }
+        } else {
+            // Push mocked new user mapping.
+            created.push({
+                value: mapping.value.toLowerCase(), // prisma client extension lower cases value on save
+                user: {
+                    id: mapping[`${environment}ExistingUserId`],
+                    firstName: mapping.octopusUserName
+                }
+            });
+        }
+    }
+
+    return created;
+};
+
+const fileContents = readDataFromFile();
+
+if (fileContents.error) {
+    console.log('Read file error: ', fileContents.error);
+}
+
+const { environment, dryRun } = parseArguments();
+
+validateData(fileContents.data, environment)
+    .then((result) => {
+        if (result.valid) {
+            createUserMappings(fileContents.data, environment, dryRun)
+                .then((createdMappings) => {
+                    console.log(
+                        dryRun
+                            ? 'Dry run complete.'
+                            : 'Real run complete.' +
+                                  ` Created ${createdMappings.length} mappings out of ${fileContents.data.length}.`
+                    );
+                    console.log(createdMappings);
+                })
+                .catch((err) => console.log(err));
+        } else {
+            console.log('Failed validation.', result);
+        }
+    })
+    .catch((err) => console.log(err));

--- a/api/scripts/fullAriImport.ts
+++ b/api/scripts/fullAriImport.ts
@@ -1,0 +1,84 @@
+import axios from 'axios';
+import * as dotenv from 'dotenv';
+import { expand } from 'dotenv-expand';
+
+// Important to do this so that environment variables are treated the same as in deployed code.
+expand(dotenv.config());
+
+import * as ariUtils from 'lib/integrations/ariUtils';
+import * as I from 'interface';
+
+const fullAriImport = async (): Promise<string> => {
+    const startTime = performance.now();
+    const ariResponse = await axios.get('https://ari.org.uk/api/questions?order_by=dateUpdated');
+    const firstPageAris = ariResponse.data.data;
+    // const paginationInfo = ariResponse.data.meta.pagination;
+
+    // Collect all ARIs in a variable.
+    // let aris = firstPageAris;
+    // For testing, just use 10
+    let aris = firstPageAris.slice(0, 10);
+    /**
+    let pageNumber = paginationInfo.current_page;
+    let nextPageUrl = paginationInfo.links.next;
+
+    // After a page has been retrieved, add the data to the aris variable,
+    // get the next page and repeat until reaching the last page.
+    while (pageNumber < paginationInfo.total_pages) {
+        // Get next page.
+        const nextPageResponse = await axios.get(nextPageUrl);
+        const nextPageAris = nextPageResponse.data.data;
+
+        // Add next page's ARIs to our variable.
+        aris.push(...nextPageAris);
+
+        // Set the things we need to repeat this.
+        const nextPagePaginationInfo = nextPageResponse.data.meta.pagination;
+        pageNumber = nextPagePaginationInfo.current_page;
+
+        // On the last run this will be undefined but that's fine because we won't need to repeat the loop.
+        nextPageUrl = nextPagePaginationInfo.links.next;
+    }
+
+    // In case something has caused this process to fail, perhaps the API changed, etc...
+    if (aris.length !== paginationInfo.total) {
+        throw new Error('Number of ARIs retrieved does not match reported total. Stopping.');
+    }
+         */
+
+    // Process all the ARIs.
+    const handledAris: I.HandledARI[] = [];
+    for (const ari of aris) {
+        const handleAri = await ariUtils.handleIncomingARI(ari);
+        handledAris.push(handleAri);
+        // Datacite test has a firewall that only 750 request per IP across a 5 minute period.
+        // Introducing a delay between each ARI handling (which may hit datacite - twice if creating a publication,
+        // or once if reversioning a publication) ensures we won't hit this limit.
+        // https://support.datacite.org/docs/is-there-a-rate-limit-for-making-requests-against-the-datacite-apis
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+
+    const createdAris = handledAris.filter((handle) => handle.actionTaken === 'create');
+
+    if (createdAris.length !== handledAris.length) {
+        console.log('Not every ARI was handled as a new creation!');
+        console.log(`${createdAris.length} were created as new publications.`);
+        const updatedAris = handledAris.filter((handle) => handle.actionTaken === 'update');
+        console.log(`${updatedAris.length} triggered updates to existing publications.`);
+        const unHandledAris = handledAris.filter((handle) => handle.actionTaken === 'none');
+        console.log(`${unHandledAris.length} were skipped altogether.`);
+    }
+
+    // For testing
+    console.log(handledAris);
+
+    const endTime = performance.now();
+    return `Finished. Created ${createdAris.length} publications from ${handledAris.length} ARI questions in ${(
+        (endTime - startTime) /
+        1000
+    ).toFixed(1)} seconds.`;
+};
+
+fullAriImport()
+    .then((message) => console.log(message))
+    .catch((err) => console.log(err));

--- a/api/scripts/user-mappings.json
+++ b/api/scripts/user-mappings.json
@@ -1,0 +1,156 @@
+[
+    {
+        "intExistingUserId": "clyheq7ko0001eg48k2id2jao",
+        "prodExistingUserId": "clyiew5ch000114njg612sd6u",
+        "octopusUserName": "Office of Police Chief Scientific Adviser (GB)",
+        "value": "UK Policing: Office of Police Chief Scientific Adviser",
+        "source": "ARI"
+    },
+    {
+        "intExistingUserId": "clyheq7kp0003eg48dlp686sc",
+        "prodExistingUserId": "clyiew5ci000314njsoou60nb",
+        "octopusUserName": "Department for Science, Innovation & Technology (GB)",
+        "value": "Department for Science, Innovation & Technology",
+        "source": "ARI"
+    },
+    {
+        "intExistingUserId": "clyheq7kp0005eg48dlythcrr",
+        "prodExistingUserId": "clyiew5ci000514njsitldlgy",
+        "octopusUserName": "Nuclear Decommissioning Authority (GB)",
+        "value": "Nuclear Decommissioning Authority",
+        "source": "ARI"
+    },
+    {
+        "intExistingUserId": "clyheq7kp0007eg48jc3ot4id",
+        "prodExistingUserId": "clyiew5cj000714nj0pxx1tf2",
+        "octopusUserName": "Office for Statistics Regulation (GB)",
+        "value": "Office for Statistics Regulation",
+        "source": "ARI"
+    },
+    {
+        "intExistingUserId": "clyheq7kp0009eg48m1tg5fxx",
+        "prodExistingUserId": "clyiew5cj000914njg28xv8pq",
+        "octopusUserName": "Metropolitan Police (GB)",
+        "value": "Metropolitan Police",
+        "source": "ARI"
+    },
+    {
+        "intExistingUserId": "clyheq7kq000beg48wlra7tm4",
+        "prodExistingUserId": "clyiew5cj000b14njchc5ok6q",
+        "octopusUserName": "Ministry of Justice (GB)",
+        "value": "Ministry of Justice",
+        "source": "ARI"
+    },
+    {
+        "intExistingUserId": "clyheq7kq000deg48a1gvgiuv",
+        "prodExistingUserId": "clyiew5ck000d14nji83mbuqa",
+        "octopusUserName": "Ministry of Defense (GB)",
+        "value": "Ministry of Defence",
+        "source": "ARI"
+    },
+    {
+        "intExistingUserId": "clyheq7kq000feg48xcu4ue2h",
+        "prodExistingUserId": "clyiew5ck000f14njfppcnvvl",
+        "octopusUserName": "Health and Safety Executive (GB)",
+        "value": "Health and Safety Executive",
+        "source": "ARI"
+    },
+    {
+        "intExistingUserId": "clyheq7kq000heg48srz2qf7s",
+        "prodExistingUserId": "clyiew5ck000h14njeyeuml1j",
+        "octopusUserName": "Home Office (GB)",
+        "value": "Home Office",
+        "source": "ARI"
+    },
+    {
+        "intExistingUserId": "clyheq7kr000jeg48uq3wh46r",
+        "prodExistingUserId": "clyiew5ck000j14nj4v9uwecs",
+        "octopusUserName": "Food Standards Agency (GB)",
+        "value": "Food Standards Agency",
+        "source": "ARI"
+    },
+    {
+        "intExistingUserId": "clyheq7kr000leg48rrycwbjb",
+        "prodExistingUserId": "clyiew5cl000l14njfq4hkqdd",
+        "octopusUserName": "Foreign, Commonwealth & Development Office (GB)",
+        "value": "Foreign, Commonwealth & Development Office",
+        "source": "ARI"
+    },
+    {
+        "intExistingUserId": "clyheq7kr000neg48k9n53zik",
+        "prodExistingUserId": "clyiew5cl000n14nji5byqxxq",
+        "octopusUserName": "Department for Work and Pensions (GB)",
+        "value": "Department for Work and Pensions",
+        "source": "ARI"
+    },
+    {
+        "intExistingUserId": "clyheq7kr000peg482et9g4zb",
+        "prodExistingUserId": "clyiew5cl000p14njksbc4txx",
+        "octopusUserName": "Department for Levelling Up, Housing and Communities (GB)",
+        "value": "Department for Levelling Up, Housing and Communities",
+        "source": "ARI"
+    },
+    {
+        "intExistingUserId": "clyheq7kr000reg484lhdl5e0",
+        "prodExistingUserId": "clyiew5cl000r14njni4tubz3",
+        "octopusUserName": "Department for International Trade (GB)",
+        "value": "Department for International Trade",
+        "source": "ARI"
+    },
+    {
+        "intExistingUserId": "clyheq7ks000teg48wgwhlqmh",
+        "prodExistingUserId": "clyiew5cm000t14njoa5jnvvz",
+        "octopusUserName": "Department for Health and Social Care (GB)",
+        "value": "Department for Health and Social Care",
+        "source": "ARI"
+    },
+    {
+        "intExistingUserId": "clyheq7ks000teg48wgwhlqmh",
+        "prodExistingUserId": "clyiew5cm000t14njoa5jnvvz",
+        "octopusUserName": "Department for Health and Social Care (GB)",
+        "value": "Department of Health and Social Care",
+        "source": "ARI"
+    },
+    {
+        "intExistingUserId": "clyheq7ks000veg48nu1n7mfa",
+        "prodExistingUserId": "clyiew5cn000v14njylmrzxxq",
+        "octopusUserName": "Department for Transport (GB)",
+        "value": "Department for Transport",
+        "source": "ARI"
+    },
+    {
+        "intExistingUserId": "clyheq7ks000xeg48iuio6m3m",
+        "prodExistingUserId": "clyiew5cn000x14njghqd4hen",
+        "octopusUserName": "Department for Education (GB)",
+        "value": "Department for Education",
+        "source": "ARI"
+    },
+    {
+        "intExistingUserId": "clyheq7ks000zeg48qrotkx5x",
+        "prodExistingUserId": "clyiew5cn000z14njl0c0pn2x",
+        "octopusUserName": "Department for Environment, Food & Rural Affairs (GB)",
+        "value": "Department for Environment, Food & Rural Affairs",
+        "source": "ARI"
+    },
+    {
+        "intExistingUserId": "clyheq7kt0011eg489wbiaxgv",
+        "prodExistingUserId": "clyiew5cn001114njt1y4yr53",
+        "octopusUserName": "Department for Digital, Culture, Media & Sport (GB)",
+        "value": "Department for Digital, Culture, Media & Sport",
+        "source": "ARI"
+    },
+    {
+        "intExistingUserId": "clyheq7kt0013eg48l8ukuwzn",
+        "prodExistingUserId": "clyiew5cn001314nj4brcj69p",
+        "octopusUserName": "Cabinet Office (GB)",
+        "value": "Cabinet Office",
+        "source": "ARI"
+    },
+    {
+        "intExistingUserId": "clyheq7kt0015eg48i58jtf3a",
+        "prodExistingUserId": "clyiew5co001514nj74cxyvgo",
+        "octopusUserName": "Department for Business, Energy & Industrial Strategy (GB)",
+        "value": "Department for Business, Energy & Industrial Strategy",
+        "source": "ARI"
+    }
+]

--- a/api/src/components/publication/controller.ts
+++ b/api/src/components/publication/controller.ts
@@ -189,19 +189,6 @@ export const create = async (
 
         const publication = await publicationService.create(event.body, event.user, directPublish, links);
 
-        if (directPublish) {
-            // Create a DOI for this version specifically and trigger post publish tasks.
-            const publishedVersion = await publicationVersionService.get(publication.id, 'latestLive');
-
-            if (publishedVersion) {
-                const versionWithDoi = await publicationVersionService.generateNewVersionDOI(publishedVersion, null);
-
-                if (versionWithDoi) {
-                    await publicationVersionService.postPublishHook(versionWithDoi);
-                }
-            }
-        }
-
         return response.json(201, publication);
     } catch (err) {
         console.log(err);

--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -136,6 +136,9 @@ export const get = async (id: string) => {
                 },
                 select: {
                     id: true,
+                    versionToId: true,
+                    publicationToId: true,
+                    draft: true,
                     publicationTo: {
                         select: {
                             id: true,
@@ -166,6 +169,9 @@ export const get = async (id: string) => {
                 },
                 select: {
                     id: true,
+                    versionToId: true,
+                    publicationFromId: true,
+                    draft: true,
                     publicationFrom: {
                         select: {
                             id: true,

--- a/api/src/components/topicMapping/__tests__/getTopicMapping.test.ts
+++ b/api/src/components/topicMapping/__tests__/getTopicMapping.test.ts
@@ -2,7 +2,7 @@ import * as testUtils from 'lib/testUtils';
 import * as topicMappingService from 'topicMapping/service';
 
 describe('Get a topic mapping', () => {
-    beforeEach(async () => {
+    beforeAll(async () => {
         await testUtils.clearDB();
         await testUtils.testSeed();
     });

--- a/api/src/components/userMapping/__tests__/getUserMapping.test.ts
+++ b/api/src/components/userMapping/__tests__/getUserMapping.test.ts
@@ -1,0 +1,28 @@
+import * as testUtils from 'lib/testUtils';
+import * as userMappingService from 'userMapping/service';
+
+describe('Get a user mapping', () => {
+    beforeAll(async () => {
+        await testUtils.clearDB();
+        await testUtils.testSeed();
+    });
+
+    test('Get a user mapping for a given external user name and source', async () => {
+        const getUserMapping = await userMappingService.get('test ARI department', 'ARI');
+
+        expect(getUserMapping).toEqual({
+            value: 'test ari department',
+            source: 'ARI',
+            user: {
+                id: 'test-organisational-account-1',
+                firstName: 'Test ARI Department (UK)'
+            }
+        });
+    });
+
+    test('Try to get a nonexistent user mapping', async () => {
+        const getUserMapping = await userMappingService.get('unmapped value', 'ARI');
+
+        expect(getUserMapping).toBeNull();
+    });
+});

--- a/api/src/components/userMapping/__tests__/getUserMapping.test.ts
+++ b/api/src/components/userMapping/__tests__/getUserMapping.test.ts
@@ -15,7 +15,8 @@ describe('Get a user mapping', () => {
             source: 'ARI',
             user: {
                 id: 'test-organisational-account-1',
-                firstName: 'Test ARI Department (UK)'
+                firstName: 'Test ARI Department (UK)',
+                defaultTopicId: 'test-topic-1'
             }
         });
     });

--- a/api/src/components/userMapping/service.ts
+++ b/api/src/components/userMapping/service.ts
@@ -1,23 +1,22 @@
 import * as client from 'lib/client';
 import * as I from 'interface';
 
-export const get = (title: string, source: I.PublicationImportSource) =>
-    client.prisma.topicMapping.findFirst({
+export const get = (value: string, source: I.PublicationImportSource) =>
+    client.prisma.userMapping.findFirst({
         where: {
-            title: {
-                equals: title,
+            value: {
+                equals: value,
                 mode: 'insensitive'
             },
             source
         },
         select: {
-            title: true,
+            value: true,
             source: true,
-            isMapped: true,
-            topic: {
+            user: {
                 select: {
                     id: true,
-                    title: true
+                    firstName: true
                 }
             }
         }

--- a/api/src/components/userMapping/service.ts
+++ b/api/src/components/userMapping/service.ts
@@ -17,12 +17,7 @@ export const get = (value: string, source: I.PublicationImportSource) =>
                 select: {
                     id: true,
                     firstName: true,
-                    defaultTopic: {
-                        select: {
-                            id: true,
-                            title: true
-                        }
-                    }
+                    defaultTopicId: true
                 }
             }
         }

--- a/api/src/components/userMapping/service.ts
+++ b/api/src/components/userMapping/service.ts
@@ -16,7 +16,13 @@ export const get = (value: string, source: I.PublicationImportSource) =>
             user: {
                 select: {
                     id: true,
-                    firstName: true
+                    firstName: true,
+                    defaultTopic: {
+                        select: {
+                            id: true,
+                            title: true
+                        }
+                    }
                 }
             }
         }

--- a/api/src/lib/client.ts
+++ b/api/src/lib/client.ts
@@ -27,25 +27,6 @@ export const prisma = new PrismaClient().$extends({
                 }
 
                 return query(args);
-            },
-            async updateMany({ args, query }) {
-                if (Array.isArray(args.data)) {
-                    args.data = args.data.map((item) => {
-                        if (typeof item.title === 'string') {
-                            return { ...item, title: item.title.toLowerCase() };
-                        } else {
-                            return item;
-                        }
-                    });
-
-                    return query(args);
-                } else {
-                    if (typeof args.data.title === 'string') {
-                        args.data = { ...args.data, title: args.data.title.toLowerCase() };
-                    }
-
-                    return query(args);
-                }
             }
         },
         userMapping: {
@@ -72,25 +53,6 @@ export const prisma = new PrismaClient().$extends({
                 }
 
                 return query(args);
-            },
-            async updateMany({ args, query }) {
-                if (Array.isArray(args.data)) {
-                    args.data = args.data.map((item) => {
-                        if (typeof item.value === 'string') {
-                            return { ...item, value: item.value.toLowerCase() };
-                        } else {
-                            return item;
-                        }
-                    });
-
-                    return query(args);
-                } else {
-                    if (typeof args.data.value === 'string') {
-                        args.data = { ...args.data, value: args.data.value.toLowerCase() };
-                    }
-
-                    return query(args);
-                }
             }
         }
     }

--- a/api/src/lib/client.ts
+++ b/api/src/lib/client.ts
@@ -4,11 +4,93 @@ import { Client } from '@opensearch-project/opensearch';
 export const prisma = new PrismaClient().$extends({
     query: {
         topicMapping: {
+            // Ensure all topic mapping titles are saved in lower case.
             async create({ args, query }) {
-                // Ensure all topic mapping titles are saved in lower case.
                 args.data = { ...args.data, title: args.data.title.toLowerCase() };
 
                 return query(args);
+            },
+            async createMany({ args, query }) {
+                if (Array.isArray(args.data)) {
+                    args.data = args.data.map((item) => ({ ...item, title: item.title.toLowerCase() }));
+
+                    return query(args);
+                } else {
+                    args.data = { ...args.data, title: args.data.title.toLowerCase() };
+
+                    return query(args);
+                }
+            },
+            async update({ args, query }) {
+                if (typeof args.data.title === 'string') {
+                    args.data = { ...args.data, title: args.data.title.toLowerCase() };
+                }
+
+                return query(args);
+            },
+            async updateMany({ args, query }) {
+                if (Array.isArray(args.data)) {
+                    args.data = args.data.map((item) => {
+                        if (typeof item.title === 'string') {
+                            return { ...item, title: item.title.toLowerCase() };
+                        } else {
+                            return item;
+                        }
+                    });
+
+                    return query(args);
+                } else {
+                    if (typeof args.data.title === 'string') {
+                        args.data = { ...args.data, title: args.data.title.toLowerCase() };
+                    }
+
+                    return query(args);
+                }
+            }
+        },
+        userMapping: {
+            // Likewise, user mapping values are saved in lower case.
+            async create({ args, query }) {
+                args.data = { ...args.data, value: args.data.value.toLowerCase() };
+
+                return query(args);
+            },
+            async createMany({ args, query }) {
+                if (Array.isArray(args.data)) {
+                    args.data = args.data.map((item) => ({ ...item, value: item.value.toLowerCase() }));
+
+                    return query(args);
+                } else {
+                    args.data = { ...args.data, value: args.data.value.toLowerCase() };
+
+                    return query(args);
+                }
+            },
+            async update({ args, query }) {
+                if (typeof args.data.value === 'string') {
+                    args.data = { ...args.data, value: args.data.value.toLowerCase() };
+                }
+
+                return query(args);
+            },
+            async updateMany({ args, query }) {
+                if (Array.isArray(args.data)) {
+                    args.data = args.data.map((item) => {
+                        if (typeof item.value === 'string') {
+                            return { ...item, value: item.value.toLowerCase() };
+                        } else {
+                            return item;
+                        }
+                    });
+
+                    return query(args);
+                } else {
+                    if (typeof args.data.value === 'string') {
+                        args.data = { ...args.data, value: args.data.value.toLowerCase() };
+                    }
+
+                    return query(args);
+                }
             }
         }
     }

--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -154,6 +154,19 @@ export const replaceHTMLLineBreaks = (html: string): string => {
     return html.replace(/\n|\r\n|\n\r|\r/g, '<br>');
 };
 
+// If a string is enclosed in matching quotes, remove them.
+export const stripEnclosingQuotes = (string: string): string => {
+    // String is enclosed in " or '
+    if (
+        (string.slice(0, 1) === '"' && string.slice(-1) === '"') ||
+        (string.slice(0, 1) === "'" && string.slice(-1) === "'")
+    ) {
+        return string.slice(1, -1);
+    } else {
+        return string;
+    }
+};
+
 // Check if two arrays are equal.
 export const compareArrays = <T>(a: Array<T>, b: Array<T>): boolean => {
     if (a === b) return true;

--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -196,3 +196,19 @@ export const abbreviateUserName = <T extends { firstName: string; lastName: stri
     // Default for organisational accounts and general fallback.
     return user.firstName;
 };
+
+// Parses args passed to an npm script in the following style:
+// npm run script -- arg=value another=somethingElse
+// and returns them as keys and values in an object.
+export const parseNpmScriptArgs = (): { [key: string]: string } => {
+    const args = process.argv.slice(2);
+    const parsedArgs = {};
+
+    args.forEach((arg) => {
+        const parts = arg.split('=');
+
+        parsedArgs[parts[0]] = parts[1];
+    });
+
+    return parsedArgs;
+};

--- a/api/src/lib/integrations/README.md
+++ b/api/src/lib/integrations/README.md
@@ -1,0 +1,41 @@
+# Integrations
+
+Octopus integrates with other systems in order to import their data and transform it into octopus publications.
+
+## General points
+
+### How publications from integrations are stored
+
+Publications imported via an integration with another system should have the following optional fields (from the Publication model) populated as follows:
+
+-   externalId
+    -   The ID of the source item on the other system. For example, a question imported from the ARI DB would have the question ID in this field.
+-   externalSource
+    -   A label for the external system the publication was imported from. There is a controlled list for this defined as an enum in the [Prisma schema](../../../prisma/schema.prisma).
+
+They should also always be owned by an organisational user account. That is, a user with the value `ORGANISATION` for the `role` field.
+
+## Specific integrations
+
+### ARI DB
+
+The ARI DB is a UK government database storing research questions that government departments are seeking to answer. More info can be found at the [website](https://ari.org.uk/).
+
+#### ARI import process
+
+On import, ARIs go through a handling flow:
+
+-   If no publication exists with the ARI's question ID in its `externalId` field, it is created as a new publication.
+-   If a publication does exist with the ARI's question ID in its `externalId` field, it is compared to the existing publication for changes.
+    -   If changes are found, the existing publication is reversioned with those changes applied.
+    -   If no changes are found, no action is taken.
+
+#### How ARI data is mapped to octopus data
+
+Various ARI fields are mapped to octpous ones in the `mapAriQuestionToPublicationVersion` function in [ariUtils.ts](./ariUtils.ts).
+
+Of particular importance is how ARIs are matched to an owning organisational user account. The mapping process expects an organisational account with the `department` field value from the ARI, followed by " (GB)" as its name (in the `firstName` user field). For example, an ARI with a department of "Ministry of Justice" should map to an organistional user with a firstName of "Ministry of Justice (GB)".
+
+Topics are also worth noting. If an ARI has values in its `topics` field, the mapping will check whether octopus has any TopicMappings in the database that match with them (where the title matches, case insensitive, and the mapping source is 'ARI') and associate the publication it creates/updates with the topic(s) from those mappings. If there are no topics listed on the ARI, the organisational user is expected to have a `defaultTopicId`, which is used as a fallback.
+
+ARIs can be archived (`isArchived` field). These are not imported by Octopus.

--- a/api/src/lib/integrations/README.md
+++ b/api/src/lib/integrations/README.md
@@ -34,8 +34,8 @@ On import, ARIs go through a handling flow:
 
 Various ARI fields are mapped to octpous ones in the `mapAriQuestionToPublicationVersion` function in [ariUtils.ts](./ariUtils.ts).
 
-Of particular importance is how ARIs are matched to an owning organisational user account. The mapping process expects an organisational account with the `department` field value from the ARI, followed by " (GB)" as its name (in the `firstName` user field). For example, an ARI with a department of "Ministry of Justice" should map to an organistional user with a firstName of "Ministry of Justice (GB)".
+Of particular importance is how ARIs are matched to an owning organisational user account. The mapping process expects a UserMapping to exist associating the `department` field value from the ARI (where the title matches, case insensitive, and the mapping source is 'ARI') with the user ID of an organisational account.
 
-Topics are also worth noting. If an ARI has values in its `topics` field, the mapping will check whether octopus has any TopicMappings in the database that match with them (where the title matches, case insensitive, and the mapping source is 'ARI') and associate the publication it creates/updates with the topic(s) from those mappings. If there are no topics listed on the ARI, the organisational user is expected to have a `defaultTopicId`, which is used as a fallback.
+Topics are mapped similarly. If an ARI has values in its `topics` field, the mapping will check whether octopus has any TopicMappings in the database that match with them and associate the publication it creates/updates with the topic(s) from those mappings. If there are no topics listed on the ARI, the organisational user is expected to have a `defaultTopicId`, which is used as a fallback.
 
 ARIs can be archived (`isArchived` field). These are not imported by Octopus.

--- a/api/src/lib/integrations/__tests__/ari.test.ts
+++ b/api/src/lib/integrations/__tests__/ari.test.ts
@@ -145,7 +145,19 @@ describe('ARI Mapping', () => {
         expect(mappingAttempt).toMatchObject({
             success: false,
             mappedData: null,
-            message: 'User not found for department: unrecognised department'
+            message: 'User not found for department: unrecognised department.'
+        });
+    });
+
+    test('ARI is not mapped if it is archived', async () => {
+        const mappingAttempt = await ariUtils.mapAriQuestionToPublicationVersion({
+            ...sampleARIQuestion,
+            isArchived: true
+        });
+        expect(mappingAttempt).toMatchObject({
+            success: false,
+            mappedData: null,
+            message: 'This ARI is archived so has not been mapped.'
         });
     });
 });
@@ -227,6 +239,16 @@ describe('ARI handling', () => {
             actionTaken: 'none',
             success: false,
             message: 'Invalid question ID format.'
+        });
+    });
+
+    test('Archived questions are rejected', async () => {
+        const handleARI = await ariUtils.handleIncomingARI({ ...sampleARIQuestion, isArchived: true });
+
+        expect(handleARI).toMatchObject({
+            actionTaken: 'none',
+            success: true,
+            message: 'Skipped because question is archived.'
         });
     });
 });

--- a/api/src/lib/integrations/__tests__/ari.test.ts
+++ b/api/src/lib/integrations/__tests__/ari.test.ts
@@ -130,6 +130,13 @@ describe('ARI Mapping', () => {
         });
     });
 
+    test('Department is matched to existing user', async () => {
+        const mappingAttempt = await ariUtils.mapAriQuestionToPublicationVersion(sampleARIQuestion);
+        expect(mappingAttempt).toMatchObject({
+            mappedData: { userId: 'test-organisational-account-1' }
+        });
+    });
+
     test('Publication is not mapped if department user is not found', async () => {
         const mappingAttempt = await ariUtils.mapAriQuestionToPublicationVersion({
             ...sampleARIQuestion,
@@ -161,6 +168,20 @@ describe('ARI handling', () => {
                 isLatestLiveVersion: true,
                 title: 'ARI Publication 1'
             }
+        });
+    });
+
+    test('ARI with unrecognised department is skipped', async () => {
+        const handleARI = await ariUtils.handleIncomingARI({
+            ...sampleARIQuestion,
+            department: 'Unrecognised Department name'
+        });
+
+        expect(handleARI).toMatchObject({
+            actionTaken: 'none',
+            success: false,
+            message:
+                'Failed to map ARI data to octopus data. User not found for department: Unrecognised Department name'
         });
     });
 

--- a/api/src/lib/integrations/__tests__/ari.test.ts
+++ b/api/src/lib/integrations/__tests__/ari.test.ts
@@ -102,12 +102,7 @@ describe('ARI Mapping', () => {
         expect(mappingAttempt).toMatchObject({
             success: true,
             mappedData: {
-                topics: [
-                    {
-                        id: 'test-topic-1a',
-                        title: 'Test sub-topic A'
-                    }
-                ]
+                topicIds: ['test-topic-1a']
             }
         });
     });
@@ -120,12 +115,7 @@ describe('ARI Mapping', () => {
         expect(mappingAttempt).toMatchObject({
             success: true,
             mappedData: {
-                topics: [
-                    {
-                        id: 'test-topic-1',
-                        title: 'Test topic'
-                    }
-                ]
+                topicIds: ['test-topic-1']
             }
         });
     });
@@ -171,6 +161,7 @@ describe('ARI handling', () => {
     test('Existing ARI publication with no changes is skipped', async () => {
         const handleARI = await ariUtils.handleIncomingARI(sampleARIQuestion);
 
+        // This test expects a seeded publication to exist in the unitTesting seed data matching sampleARIQuestion
         expect(handleARI).toMatchObject({
             actionTaken: 'none',
             success: true,
@@ -193,7 +184,7 @@ describe('ARI handling', () => {
             actionTaken: 'none',
             success: false,
             message:
-                'Failed to map ARI data to octopus data. User not found for department: Unrecognised Department name'
+                'Failed to map ARI data to octopus data. User not found for department: Unrecognised Department name.'
         });
     });
 
@@ -205,10 +196,28 @@ describe('ARI handling', () => {
             actionTaken: 'update',
             success: true,
             publicationVersion: {
+                // These fields should be different to v1.
                 id: 'ari-publication-1-v2',
                 versionNumber: 2,
                 isLatestLiveVersion: true,
-                title: 'ARI Publication 1 v2'
+                title: 'ARI Publication 1 v2',
+                // Content has changed because it includes the title on line 2.
+                content:
+                    '<p><em>This problem is a UK government area of research interest (ARI) that was originally posted at <a href="https://ari.org.uk/">https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</em></p>' +
+                    '<p>ARI Publication 1 v2</p>' +
+                    '<p>Sample background information.</p>' +
+                    '<p><strong>Contact details</strong></p><p>Sample contact details.</p>' +
+                    '<p><strong>Related UKRI Projects</strong></p><ul><li><a href="https://gtr.ukri.org/projects?ref=ES%2FS007105%2F1">Urban Big Data Centre</a></li><li><a href="https://gtr.ukri.org/projects?ref=ES%2FL011921%2F1">Urban Big Data</a></li></ul>',
+                // These fields should not have changed from v1.
+                keywords: ['field of research 1', 'field of research 2', 'tag 1', 'tag 2'],
+                topics: [
+                    {
+                        id: 'test-topic-1a'
+                    }
+                ],
+                user: {
+                    id: 'test-organisational-account-1'
+                }
             }
         });
     });
@@ -216,6 +225,7 @@ describe('ARI handling', () => {
     test('ARI with no existing publication has a publication created', async () => {
         const handleARI = await ariUtils.handleIncomingARI({ ...sampleARIQuestion, questionId: 123457 });
 
+        // Ensure all the fields that are mapped have been set.
         expect(handleARI).toMatchObject({
             actionTaken: 'create',
             success: true,
@@ -223,6 +233,14 @@ describe('ARI handling', () => {
                 versionNumber: 1,
                 isLatestLiveVersion: true,
                 title: 'ARI Publication 1',
+                content:
+                    // Mapped content - see ARI mapping tests for explanation.
+                    '<p><em>This problem is a UK government area of research interest (ARI) that was originally posted at <a href="https://ari.org.uk/">https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</em></p>' +
+                    '<p>ARI Publication 1</p>' +
+                    '<p>Sample background information.</p>' +
+                    '<p><strong>Contact details</strong></p><p>Sample contact details.</p>' +
+                    '<p><strong>Related UKRI Projects</strong></p><ul><li><a href="https://gtr.ukri.org/projects?ref=ES%2FS007105%2F1">Urban Big Data Centre</a></li><li><a href="https://gtr.ukri.org/projects?ref=ES%2FL011921%2F1">Urban Big Data</a></li></ul>',
+                keywords: ['field of research 1', 'field of research 2', 'tag 1', 'tag 2'],
                 publication: {
                     externalId: '123457',
                     externalSource: 'ARI',
@@ -230,9 +248,12 @@ describe('ARI handling', () => {
                 },
                 topics: [
                     {
-                        id: 'test-topic-1'
+                        id: 'test-topic-1a'
                     }
-                ]
+                ],
+                user: {
+                    id: 'test-organisational-account-1'
+                }
             }
         });
     });

--- a/api/src/lib/integrations/__tests__/ari.test.ts
+++ b/api/src/lib/integrations/__tests__/ari.test.ts
@@ -55,15 +55,15 @@ describe('ARI Mapping', () => {
             mappedData: {
                 content:
                     // Static placeholder text added to each mapped ARI's content
-                    '<p>This problem is a UK government area of research interest (ARI) that was originally posted at <a href="https://ari.org.uk/">https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</p>' +
+                    '<p><em>This problem is a UK government area of research interest (ARI) that was originally posted at <a href="https://ari.org.uk/">https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</em></p>' +
                     // ARI Question title
                     '<p>ARI Publication 1</p>' +
                     // Background information
                     '<p>Sample background information.</p>' +
                     // Contact details
-                    '<p>Contact details: Sample contact details.</p>' +
+                    '<p><strong>Contact details</strong></p><p>Sample contact details.</p>' +
                     // Related UKRI projects
-                    '<p>Related UKRI Projects:</p><ul><li><a href="https://gtr.ukri.org/projects?ref=ES%2FS007105%2F1">Urban Big Data Centre</a></li><li><a href="https://gtr.ukri.org/projects?ref=ES%2FL011921%2F1">Urban Big Data</a></li></ul>'
+                    '<p><strong>Related UKRI Projects</strong></p><ul><li><a href="https://gtr.ukri.org/projects?ref=ES%2FS007105%2F1">Urban Big Data Centre</a></li><li><a href="https://gtr.ukri.org/projects?ref=ES%2FL011921%2F1">Urban Big Data</a></li></ul>'
             }
         });
     });
@@ -79,12 +79,12 @@ describe('ARI Mapping', () => {
             success: true,
             mappedData: {
                 content:
-                    '<p>This problem is a UK government area of research interest (ARI) that was originally posted at <a href="https://ari.org.uk/">https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</p><p>ARI Publication 1</p>' +
+                    '<p><em>This problem is a UK government area of research interest (ARI) that was originally posted at <a href="https://ari.org.uk/">https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</em></p><p>ARI Publication 1</p>' +
                     // Background information
                     '<p>Background information line 1.<br>Background information line 2.<br><br>Background information line 3.</p>' +
                     // Contact details
-                    '<p>Contact details: Contact details line 1.<br>Contact details line 2.<br><br>Contact details line 3.</p>' +
-                    '<p>Related UKRI Projects:</p><ul><li><a href="https://gtr.ukri.org/projects?ref=ES%2FS007105%2F1">Urban Big Data Centre</a></li><li><a href="https://gtr.ukri.org/projects?ref=ES%2FL011921%2F1">Urban Big Data</a></li></ul>'
+                    '<p><strong>Contact details</strong></p><p>Contact details line 1.<br>Contact details line 2.<br><br>Contact details line 3.</p>' +
+                    '<p><strong>Related UKRI Projects</strong></p><ul><li><a href="https://gtr.ukri.org/projects?ref=ES%2FS007105%2F1">Urban Big Data Centre</a></li><li><a href="https://gtr.ukri.org/projects?ref=ES%2FL011921%2F1">Urban Big Data</a></li></ul>'
             }
         });
     });
@@ -227,7 +227,12 @@ describe('ARI handling', () => {
                     externalId: '123457',
                     externalSource: 'ARI',
                     type: 'PROBLEM'
-                }
+                },
+                topics: [
+                    {
+                        id: 'test-topic-1'
+                    }
+                ]
             }
         });
     });

--- a/api/src/lib/integrations/ariUtils.ts
+++ b/api/src/lib/integrations/ariUtils.ts
@@ -140,14 +140,7 @@ export const detectChangesToARIPublication = (
     return somethingChanged ? changes : false;
 };
 
-export const handleIncomingARI = async (
-    question: I.ARIQuestion
-): Promise<{
-    actionTaken: I.ARIHandlingAction;
-    success: boolean;
-    message?: string;
-    publicationVersion?: I.PublicationVersion;
-}> => {
+export const handleIncomingARI = async (question: I.ARIQuestion): Promise<I.HandledARI> => {
     // Validate question ID.
     // Quite random criteria for now - value is typed as a number which
     // stops us checking the type. May be revisited later.

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -1054,3 +1054,10 @@ export type MappedARIQuestion = {
 };
 
 export type ARIHandlingAction = 'create' | 'update' | 'none';
+
+export interface HandledARI {
+    actionTaken: ARIHandlingAction;
+    success: boolean;
+    message?: string;
+    publicationVersion?: PublicationVersion;
+}

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -1047,7 +1047,7 @@ export type MappedARIQuestion = {
     title: string;
     content: string;
     keywords: string[];
-    topics: Pick<PublicationVersion['topics'][number], 'id' | 'title'>[];
+    topicIds: string[];
     externalId: string;
     externalSource: 'ARI';
     userId: User['id'];

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -99,6 +99,9 @@
             "user/*": [
                 "src/components/user/*"
             ],
+            "userMapping/*": [
+                "src/components/userMapping/*"
+            ],
             "verification/*": [
                 "src/components/verification/*"
             ]


### PR DESCRIPTION
The purpose of this PR was to create a script to ingest all of the existing ARIs, to set octopus up for smaller, regular weekly ingests.

Also included in this is a new prisma model for user mappings - this was agreed as a more robust way to map incoming ARI Departments to octopus user accounts that we can reuse for other external sources. Also created some scripts and data to populate these on deployed environments.

The work also surfaced a few issues with ARI mapping/importing which have been straightened out, some of which are:
- ARIs with `isArchived` set are skipped.
- The HTML written for the content field of ARI publications has been tweaked a bit.

Other minor fixes:
- Fixed an incorrect topic mapping; "climatechange" to "climate change".
- Remove the locked field from seed data where it's false because that is the default.
- Move post-publish tasks for direct publishing to service from controller.

---

### Acceptance Criteria:

- All ARIs on ARI DB exist on Octopus as research problems published by the relevant department.

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [x] Documentation updated

---

### Tests:

E2E
![Screenshot 2024-08-19 142141](https://github.com/user-attachments/assets/006b7388-5f80-49b5-a209-20b54456b1d3)

API
![Screenshot 2024-08-20 115453](https://github.com/user-attachments/assets/ef417935-54cd-439c-ab25-d8eecd83e2b0)


---

### Screenshots:

Local output from script:
![Screenshot 2024-08-19 161627](https://github.com/user-attachments/assets/93358a15-18b6-4dc9-958e-d3d2179bbbd3)

