### PR TITLE
OC-884 fix: Skip automatic PDF generation for direct publishes

### DIFF
--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -471,7 +471,8 @@ export const create = async (
             const versionWithDoi = await publicationVersionService.generateNewVersionDOI(publishedVersion, null);
 
             if (versionWithDoi) {
-                await publicationVersionService.postPublishHook(versionWithDoi);
+                // Run post publish tasks, except PDF generation.
+                await publicationVersionService.postPublishHook(versionWithDoi, true);
                 const upToDatePublication = await get(publication.id);
 
                 return upToDatePublication;


### PR DESCRIPTION
The purpose of this PR was to skip sending a message to the PDF generation queue when a publication is published directly. The PDF will still be generated if requested, just not automatically as it would be if triggered by the queue. PDF generation triggers a message sending to publications router with details from the PDF, but there's not a need for this for ARI publications at present.

---

### Acceptance Criteria:

- Directly published publications don't hit the PDF generation queue.
