### PR TITLE
OC-885: Weekly ARI ingest

### DIFF
--- a/api/prisma/seeds/local/unitTesting/publications.ts
+++ b/api/prisma/seeds/local/unitTesting/publications.ts
@@ -1239,7 +1239,7 @@ const publicationSeeds: Prisma.PublicationCreateInput[] = [
                 title: 'ARI Publication 1',
                 content:
                     // Static placeholder text added to each mapped ARI's content
-                    '<p><em>This problem is a UK government area of research interest (ARI) that was originally posted at <a href="https://ari.org.uk/">https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</em></p>' +
+                    "<p><em>This problem is a UK government area of research interest (ARI) that was originally posted at <a target='_blank' href='https://ari.org.uk/'>https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</em></p>" +
                     // ARI Question title
                     '<p>ARI Publication 1</p>' +
                     // Background information

--- a/api/scripts/fullAriImport.ts
+++ b/api/scripts/fullAriImport.ts
@@ -90,7 +90,7 @@ const fullAriImport = async (): Promise<string> => {
     }
 
     if (failed.length) {
-        console.log(`${failed.length} encounted some sort of issue and failed:`, failed);
+        console.log(`${failed.length} encountered some sort of issue and failed:`, failed);
     }
 
     const endTime = performance.now();

--- a/api/scripts/fullAriImport.ts
+++ b/api/scripts/fullAriImport.ts
@@ -43,39 +43,59 @@ const fullAriImport = async (): Promise<string> => {
     const aris = allAris.filter((ari) => !ari.isArchived);
 
     // Process all the ARIs.
-    const handledAris: I.HandledARI[] = [];
+    const failed: I.HandledARI[] = [];
+    let createdCount = 0;
+    let updatedCount = 0;
+    let skippedCount = 0;
 
     for (const ari of aris) {
         const handleAri = await ariUtils.handleIncomingARI(ari);
-        handledAris.push(handleAri);
 
-        // Datacite test has a firewall that only 750 request per IP across a 5 minute period.
-        // Introducing a delay between each ARI handling (which may hit datacite - twice if creating a publication,
-        // or once if reversioning a publication) ensures we won't hit this limit.
-        // https://support.datacite.org/docs/is-there-a-rate-limit-for-making-requests-against-the-datacite-apis
-        if (handleAri.actionTaken === 'create' || handleAri.actionTaken === 'update') {
-            await new Promise((resolve) => setTimeout(resolve, 1000));
+        if (handleAri.success) {
+            switch (handleAri.actionTaken) {
+                case 'create':
+                    createdCount++;
+                    // Datacite test has a firewall that only 750 request per IP across a 5 minute period.
+                    // https://support.datacite.org/docs/is-there-a-rate-limit-for-making-requests-against-the-datacite-apis
+                    // 5 minutes = 300 seconds. 300 / 750 = 0.4 seconds per request, so we take minimum 0.5s per hit to be safe.
+                    // We hit datacite twice when creating an ARI, so wait 1 second.
+                    await new Promise((resolve) => setTimeout(resolve, 1000));
+                    break;
+                case 'update':
+                    updatedCount++;
+                    // We hit datacite once when updating an ARI in place, so wait half a second.
+                    await new Promise((resolve) => setTimeout(resolve, 500));
+                    break;
+                case 'none':
+                    skippedCount++;
+                    break;
+            }
+        } else {
+            failed.push(handleAri);
         }
     }
 
-    const createdAris = handledAris.filter((handle) => handle.actionTaken === 'create');
+    if (createdCount) {
+        console.log(`${createdCount} were created as new publications.`);
+    }
 
-    if (createdAris.length !== handledAris.length) {
-        console.log('Not every ARI was handled as a new creation!');
-        console.log(`${createdAris.length} were created as new publications.`);
-        const updatedAris = handledAris.filter((handle) => handle.actionTaken === 'update');
-        console.log(`${updatedAris.length} triggered updates to existing publications.`);
-        const skippedAris = handledAris.filter((handle) => handle.actionTaken === 'none');
+    if (updatedCount) {
+        console.log(`${updatedCount} triggered updates to existing publications.`);
+    }
+
+    if (skippedCount) {
         console.log(
-            `${skippedAris.length} were skipped because they were found to exist in octopus and no changes were detected.`
+            `${skippedCount} were skipped because they were found to exist in octopus and no changes were detected.`
         );
-        const failedAris = handledAris.filter((handle) => handle.success === false);
-        console.log(`${failedAris.length} encounted some sort of issue and failed:`, failedAris);
+    }
+
+    if (failed.length) {
+        console.log(`${failed.length} encounted some sort of issue and failed:`, failed);
     }
 
     const endTime = performance.now();
 
-    return `Finished. Created ${createdAris.length} publications from ${handledAris.length} ARI questions in ${(
+    return `Finished. Successfully handled ${aris.length - failed.length} of ${aris.length} ARIs in ${(
         (endTime - startTime) /
         1000
     ).toFixed(1)} seconds.`;

--- a/api/scripts/fullAriImport.ts
+++ b/api/scripts/fullAriImport.ts
@@ -16,7 +16,7 @@ const fullAriImport = async (): Promise<string> => {
 
     // After a page has been retrieved, add the data to the aris variable,
     // get the next page and repeat until reaching the last page.
-    let pageUrl = 'https://ari.org.uk/api/questions?order_by=dateUpdated';
+    let pageUrl = ariUtils.ariEndpoint;
     // Updates with each loop. Contains total count which we need outside the loop.
     let paginationInfo;
 

--- a/api/serverless-config-default.yml
+++ b/api/serverless-config-default.yml
@@ -492,3 +492,8 @@ functions:
                 path: ${self:custom.versions.v1}/publications/{publicationId}/crosslinks
                 method: GET
                 cors: true
+    # Integrations
+    incrementalAriIngest:
+        handler: src/components/integrations/service.incrementalAriIngest
+        events:
+            - schedule: cron(0 5 * * TUE *) # Every Tuesday at 5 a.m.

--- a/api/serverless-config-default.yml
+++ b/api/serverless-config-default.yml
@@ -496,4 +496,6 @@ functions:
     incrementalAriIngest:
         handler: src/components/integrations/service.incrementalAriIngest
         events:
-            - schedule: cron(0 5 * * TUE *) # Every Tuesday at 5 a.m.
+            - schedule:
+                rate: cron(0 5 * * TUE *) # Every Tuesday at 5 a.m.
+                enabled: ${self:custom.scheduledAriIngestEnabled.${opt:stage}, false}

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -104,6 +104,8 @@ custom:
     prune:
         automatic: true
         number: 3
+    scheduledAriIngestEnabled:
+        int: true
 functions:
     - ${file(./serverless-config-default.yml):functions}
     - ${file(./serverless-config-deploy.yml):functions}

--- a/api/src/components/integrations/service.ts
+++ b/api/src/components/integrations/service.ts
@@ -1,6 +1,5 @@
 import axios from 'axios';
 import * as ariUtils from 'lib/integrations/ariUtils';
-import * as I from 'interface';
 
 /**
  * Incremental ARI ingest.
@@ -15,7 +14,7 @@ export const incrementalAriIngest = async (): Promise<void> => {
     // Pagination loop.
     let pageUrl = ariUtils.ariEndpoint;
     let paginationInfo;
-    const writes: I.HandledARI[] = [];
+    let writeCount = 0;
 
     do {
         // Get page.
@@ -41,7 +40,7 @@ export const incrementalAriIngest = async (): Promise<void> => {
                     unchangedStreak = 0;
                     // Log action taken.
                     console.log(`ARI ${pageAri.questionId} handled successfully with action: ${handle.actionTaken}`);
-                    writes.push(handle);
+                    writeCount++;
                     // Artificial delay to avoid hitting datacite rate limits with publication creates/updates.
                     await new Promise((resolve) => setTimeout(resolve, 1000));
                 }
@@ -54,5 +53,5 @@ export const incrementalAriIngest = async (): Promise<void> => {
         pageUrl = paginationInfo.links.next;
     } while (pageUrl && unchangedStreak < MAX_UNCHANGED_STREAK);
 
-    console.log(`Update complete. Updated ${writes.length} publication${writes.length > 1 ? 's' : ''}.`);
+    console.log(`Update complete. Updated ${writeCount} publication${writeCount !== 1 ? 's' : ''}.`);
 };

--- a/api/src/components/integrations/service.ts
+++ b/api/src/components/integrations/service.ts
@@ -1,0 +1,58 @@
+import axios from 'axios';
+import * as ariUtils from 'lib/integrations/ariUtils';
+import * as I from 'interface';
+
+/**
+ * Incremental ARI ingest.
+ * Paginates through ARI questions from the ARI DB API and handles incoming ARIs.
+ * If it encounters MAX_UNCHANGED_STREAK ARIs in a row not requiring changes, it stops.
+ */
+export const incrementalAriIngest = async (): Promise<void> => {
+    // Count sequential unchanged ARIs so that we can stop when the streak hits MAX_UNCHANGED_STREAK.
+    const MAX_UNCHANGED_STREAK = 5;
+    let unchangedStreak = 0;
+
+    // Pagination loop.
+    let pageUrl = ariUtils.ariEndpoint;
+    let paginationInfo;
+    const writes: I.HandledARI[] = [];
+
+    do {
+        // Get page.
+        const response = await axios.get(pageUrl);
+        const pageAris = response.data.data;
+
+        for (const pageAri of pageAris) {
+            if (!pageAri.isArchived) {
+                // Create, update, or skip this ARI as appropriate.
+                const handle = await ariUtils.handleIncomingARI(pageAri);
+
+                if (!handle.success) {
+                    console.log(`Error when handling ARI with question ID ${pageAri.questionId}: ${handle.message}`);
+                } else if (handle.actionTaken === 'none') {
+                    // Success is true and actionTaken is none so there were no changes found.
+                    unchangedStreak++;
+
+                    if (unchangedStreak >= MAX_UNCHANGED_STREAK) {
+                        break;
+                    }
+                } else {
+                    // This was not a skip so reset unchangedStreak counter.
+                    unchangedStreak = 0;
+                    // Log action taken.
+                    console.log(`ARI ${pageAri.questionId} handled successfully with action: ${handle.actionTaken}`);
+                    writes.push(handle);
+                    // Artificial delay to avoid hitting datacite rate limits with publication creates/updates.
+                    await new Promise((resolve) => setTimeout(resolve, 1000));
+                }
+            }
+        }
+
+        // Get the next page URL.
+        // On the last run this will be undefined but that's fine because we won't need to repeat the loop.
+        paginationInfo = response.data.meta.pagination;
+        pageUrl = paginationInfo.links.next;
+    } while (pageUrl && unchangedStreak < MAX_UNCHANGED_STREAK);
+
+    console.log(`Update complete. Updated ${writes.length} publication${writes.length > 1 ? 's' : ''}.`);
+};

--- a/api/src/components/publicationVersion/service.ts
+++ b/api/src/components/publicationVersion/service.ts
@@ -1663,100 +1663,108 @@ export const updateCanonicalDOI = async (
 // Actions that run after a version is published (changes status to LIVE).
 // Pulled out to a separate function because things may need to run when something is
 // published immediately (i.e. not going through full drafting workflow) and bypasses the updateStatus function.
-export const postPublishHook = async (publicationVersion: I.PublicationVersion, skipPdfGeneration?: boolean) => {
-    // Ensure links made from a PEER_REVIEW version point to the latest live version of the target publication.
-    if (publicationVersion.publication.type === 'PEER_REVIEW') {
-        const outdatedDraftLinks = await client.prisma.links.findMany({
-            where: {
-                publicationFromId: publicationVersion.versionOf,
-                draft: true,
-                versionTo: {
-                    isLatestLiveVersion: false
-                }
-            }
-        });
-
-        for (const outdatedDraftLink of outdatedDraftLinks) {
-            const latestVersionTo = await client.prisma.publicationVersion.findFirst({
+export const postPublishHook = async (
+    publicationVersion: I.PublicationVersion,
+    skipPdfGeneration?: boolean,
+    forceReindex?: boolean
+) => {
+    try {
+        // Ensure links made from a PEER_REVIEW version point to the latest live version of the target publication.
+        if (publicationVersion.publication.type === 'PEER_REVIEW') {
+            const outdatedDraftLinks = await client.prisma.links.findMany({
                 where: {
-                    versionOf: outdatedDraftLink.publicationToId,
-                    isLatestLiveVersion: true
+                    publicationFromId: publicationVersion.versionOf,
+                    draft: true,
+                    versionTo: {
+                        isLatestLiveVersion: false
+                    }
                 }
             });
 
-            if (latestVersionTo) {
-                await client.prisma.links.update({
+            for (const outdatedDraftLink of outdatedDraftLinks) {
+                const latestVersionTo = await client.prisma.publicationVersion.findFirst({
                     where: {
-                        id: outdatedDraftLink.id
-                    },
-                    data: {
-                        versionToId: latestVersionTo.id
+                        versionOf: outdatedDraftLink.publicationToId,
+                        isLatestLiveVersion: true
                     }
                 });
+
+                if (latestVersionTo) {
+                    await client.prisma.links.update({
+                        where: {
+                            id: outdatedDraftLink.id
+                        },
+                        data: {
+                            versionToId: latestVersionTo.id
+                        }
+                    });
+                }
             }
         }
-    }
 
-    // Update "draft" links.
-    await client.prisma.links.updateMany({
-        where: {
-            publicationFromId: publicationVersion.versionOf,
-            draft: true
-        },
-        data: {
-            draft: false
-        }
-    });
-
-    // Update previous version's "isLatestLiveVersion" flag.
-    if (publicationVersion.versionNumber > 1) {
-        await client.prisma.publicationVersion.updateMany({
+        // Update "draft" links.
+        await client.prisma.links.updateMany({
             where: {
-                versionOf: publicationVersion.versionOf,
-                versionNumber: publicationVersion.versionNumber - 1
+                publicationFromId: publicationVersion.versionOf,
+                draft: true
             },
             data: {
-                isLatestLiveVersion: false
+                draft: false
             }
         });
-    }
 
-    // Update the canonical DOI with the latest details from this version.
-    await updateCanonicalDOI(publicationVersion.publication.doi, publicationVersion);
-
-    if (publicationVersion.versionNumber > 1) {
-        // Delete old OpenSearch record.
-        await publicationService.deleteOpenSearchRecord(publicationVersion.versionOf);
-    }
-
-    // (Re)index publication in opensearch.
-    await publicationService.createOpenSearchRecord({
-        id: publicationVersion.versionOf,
-        type: publicationVersion.publication.type,
-        title: publicationVersion.title,
-        licence: publicationVersion.licence,
-        description: publicationVersion.description,
-        keywords: publicationVersion.keywords,
-        content: publicationVersion.content,
-        publishedDate: publicationVersion.publishedDate,
-        cleanContent: convert(publicationVersion.content)
-    });
-
-    // Delete all pending request control events for this publication version.
-    await eventService.deleteMany({
-        type: 'REQUEST_CONTROL',
-        data: {
-            path: ['publicationVersion', 'id'],
-            equals: publicationVersion.id
+        // Update previous version's "isLatestLiveVersion" flag.
+        if (publicationVersion.versionNumber > 1) {
+            await client.prisma.publicationVersion.updateMany({
+                where: {
+                    versionOf: publicationVersion.versionOf,
+                    versionNumber: publicationVersion.versionNumber - 1
+                },
+                data: {
+                    isLatestLiveVersion: false
+                }
+            });
         }
-    });
 
-    // Send message to the pdf generation queue.
-    // Skipped locally, as there is not an SQS que in localstack.
-    // Option to skip, e.g. in bulk import scripts, where instant pdf generation is not a priority.
-    // In both cases, the pdf will still be generated the first time it's requested.
-    if (process.env.STAGE !== 'local' && !skipPdfGeneration) {
-        await sqs.sendMessage(publicationVersion.versionOf);
+        // Update the canonical DOI with the latest details from this version.
+        await updateCanonicalDOI(publicationVersion.publication.doi, publicationVersion);
+
+        // (Re)index publication in opensearch.
+        if (publicationVersion.versionNumber > 1 || forceReindex) {
+            // Delete old OpenSearch record.
+            await publicationService.deleteOpenSearchRecord(publicationVersion.versionOf);
+        }
+
+        await publicationService.createOpenSearchRecord({
+            id: publicationVersion.versionOf,
+            type: publicationVersion.publication.type,
+            title: publicationVersion.title,
+            licence: publicationVersion.licence,
+            description: publicationVersion.description,
+            keywords: publicationVersion.keywords,
+            content: publicationVersion.content,
+            publishedDate: publicationVersion.publishedDate,
+            cleanContent: convert(publicationVersion.content)
+        });
+
+        // Delete all pending request control events for this publication version.
+        await eventService.deleteMany({
+            type: 'REQUEST_CONTROL',
+            data: {
+                path: ['publicationVersion', 'id'],
+                equals: publicationVersion.id
+            }
+        });
+
+        // Send message to the pdf generation queue.
+        // Skipped locally, as there is not an SQS que in localstack.
+        // Option to skip, e.g. in bulk import scripts, where instant pdf generation is not a priority.
+        // In both cases, the pdf will still be generated the first time it's requested.
+        if (process.env.STAGE !== 'local' && !skipPdfGeneration) {
+            await sqs.sendMessage(publicationVersion.versionOf);
+        }
+    } catch (err) {
+        console.log('Error in post-publish hook: ', err);
     }
 };
 

--- a/api/src/lib/__tests__/helpers.test.ts
+++ b/api/src/lib/__tests__/helpers.test.ts
@@ -6,8 +6,12 @@ describe('Comparing arrays', () => {
         const comparison = Helpers.compareArrays(array, array);
         expect(comparison).toBe(true);
     });
-    test('Same elements in different order are not considered equal', () => {
+    test('Same elements in different order are considered equal by default', () => {
         const comparison = Helpers.compareArrays([1, 2, 3], [3, 2, 1]);
+        expect(comparison).toBe(true);
+    });
+    test('Same elements in different order are not considered equal when strictOrder is set', () => {
+        const comparison = Helpers.compareArrays([1, 2, 3], [3, 2, 1], true);
         expect(comparison).toBe(false);
     });
     test('Comparisons use strict equality', () => {

--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -167,11 +167,16 @@ export const stripEnclosingQuotes = (string: string): string => {
     }
 };
 
-// Check if two arrays are equal.
-export const compareArrays = <T>(a: Array<T>, b: Array<T>): boolean => {
+// Check if two arrays are equal. By default, doesn't care about order.
+export const compareArrays = <T>(a: Array<T>, b: Array<T>, strictOrder?: boolean): boolean => {
     if (a === b) return true;
     if (a == null || b == null) return false;
     if (a.length !== b.length) return false;
+
+    if (!strictOrder) {
+        a.sort();
+        b.sort();
+    }
 
     for (let i = 0; i < a.length; ++i) {
         if (a[i] !== b[i]) return false;

--- a/api/src/lib/integrations/__tests__/ari.test.ts
+++ b/api/src/lib/integrations/__tests__/ari.test.ts
@@ -55,7 +55,7 @@ describe('ARI Mapping', () => {
             mappedData: {
                 content:
                     // Static placeholder text added to each mapped ARI's content
-                    '<p><em>This problem is a UK government area of research interest (ARI) that was originally posted at <a href="https://ari.org.uk/">https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</em></p>' +
+                    "<p><em>This problem is a UK government area of research interest (ARI) that was originally posted at <a target='_blank' href='https://ari.org.uk/'>https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</em></p>" +
                     // ARI Question title
                     '<p>ARI Publication 1</p>' +
                     // Background information
@@ -79,7 +79,7 @@ describe('ARI Mapping', () => {
             success: true,
             mappedData: {
                 content:
-                    '<p><em>This problem is a UK government area of research interest (ARI) that was originally posted at <a href="https://ari.org.uk/">https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</em></p><p>ARI Publication 1</p>' +
+                    "<p><em>This problem is a UK government area of research interest (ARI) that was originally posted at <a target='_blank' href='https://ari.org.uk/'>https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</em></p><p>ARI Publication 1</p>" +
                     // Background information
                     '<p>Background information line 1.<br>Background information line 2.<br><br>Background information line 3.</p>' +
                     // Contact details
@@ -247,7 +247,7 @@ describe('ARI handling', () => {
             success: true,
             publicationVersion: {
                 content:
-                    '<p><em>This problem is a UK government area of research interest (ARI) that was originally posted at <a href="https://ari.org.uk/">https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</em></p>' +
+                    "<p><em>This problem is a UK government area of research interest (ARI) that was originally posted at <a target='_blank' href='https://ari.org.uk/'>https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</em></p>" +
                     '<p>ARI Publication 1</p>' +
                     '<p>New background information.</p>' +
                     '<p><strong>Contact details</strong></p><p>New contact details.</p>' +
@@ -303,7 +303,7 @@ describe('ARI handling', () => {
                 title: 'ARI Publication 1',
                 content:
                     // Mapped content - see ARI mapping tests for explanation.
-                    '<p><em>This problem is a UK government area of research interest (ARI) that was originally posted at <a href="https://ari.org.uk/">https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</em></p>' +
+                    "<p><em>This problem is a UK government area of research interest (ARI) that was originally posted at <a target='_blank' href='https://ari.org.uk/'>https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</em></p>" +
                     '<p>ARI Publication 1</p>' +
                     '<p>Sample background information.</p>' +
                     '<p><strong>Contact details</strong></p><p>Sample contact details.</p>' +

--- a/api/src/lib/integrations/ariUtils.ts
+++ b/api/src/lib/integrations/ariUtils.ts
@@ -61,11 +61,11 @@ export const mapAriQuestionToPublicationVersion = async (
               .join('') +
           '</ul>'
         : '';
-    const content = Helpers.getSafeHTML(
-        [commonBoilerplateHTML, titleHTML, backgroundInformationHTML, contactDetailsHTML, relatedUKRIProjectsHTML].join(
-            ''
-        )
-    );
+    const content =
+        commonBoilerplateHTML +
+        Helpers.getSafeHTML(
+            [titleHTML, backgroundInformationHTML, contactDetailsHTML, relatedUKRIProjectsHTML].join('')
+        );
     // Ensure uniqueness.
     const keywords = [...new Set(fieldsOfResearch.concat(tags))];
 


### PR DESCRIPTION
The purpose of this PR was to add a way for octopus to stay up to date with ARIs from the ARI DB, including new ARIs, and updates to existing ones. The function hits ARI DB’s API weekly to detect changes and newly added records, and triggers creation/updating of ARIs on Octopus as needed.

Tested function locally by manual invocation and retested full ari import script since I changed that too.

- Deviated from the ACs on how we stop the job.
    - It seemed more robust to check that there are 5 unchanged ARIs in a row (our original plan) before stopping.
    - Going by the dateUpdated value is risky because we only have the most recent "updatedAt" value in octopus to go by. This would be slightly later than the time the last import began, so we risk missing ARIs that were updated in between our last job starting and the most recent save of that run occurring.
- Fixed an issue where keywords + topicIds were coming out of the mapping function with duplicates.
    - This can easily occur because we concatenate two different lists for keywords and two incoming topics from ARI could make to the same octopus topic causing a duplicate.
    - Made the "compareArrays" helper ignore order by default because prisma may not save these lists in the order they come from the mapping function (it doesn't matter).
- Added a target='_blank' to the boilerplate text for ARIs requested by Alex which required several test changes.
- Wrapped post publish hook in a try catch and added an option to force deletion and reindexing of opensearch document (before, for a version 1 publish, it would just index it, but we need to replace it if it's updating a v1 in place).
- Reworked fullAriImport script a bit so it is better suited to being used for mass updates, not just creates (for things like adding this target='_blank' to every ARI publication's content field)

---

### Acceptance Criteria:

- Each week, a request is made to ARI DB ([https://ari.org.uk/api/questions?order_by=dateUpdated](https://ari.org.uk/api/questions?order_by=dateUpdated) to gather recently created or updated ARIs
    - This operation is run on int every week on a Tuesday
    - Each ARI is scanned from the most recent first
        - If the “dateUpdated” value of an ARI is more recent than the last time the operation ran, it is handled
        - Each time the end of a page is reached, a new request is made for the next-newest page of records from ARI DB
---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

E2E
![Screenshot 2024-08-29 103357](https://github.com/user-attachments/assets/12ab3c22-da43-4c28-8296-09f0899d1551)

API
![Screenshot 2024-08-29 105809](https://github.com/user-attachments/assets/24314aa6-8160-4114-9bb6-5bec5a3aef87)
