### PR TITLE
OC-885 fix: make cron expression valid

### DIFF
--- a/api/serverless-config-default.yml
+++ b/api/serverless-config-default.yml
@@ -497,5 +497,5 @@ functions:
         handler: src/components/integrations/service.incrementalAriIngest
         events:
             - schedule:
-                rate: cron(0 5 * * TUE *) # Every Tuesday at 5 a.m.
+                rate: cron(0 5 ? * TUE *) # Every Tuesday at 5 a.m.
                 enabled: ${self:custom.scheduledAriIngestEnabled.${opt:stage}, false}


### PR DESCRIPTION
The purpose of this PR was to fix an issue with #681 where the cron expression in the serverless function definition wasn't valid so it wouldn't deploy properly.

---

### Acceptance Criteria:

Octopus deploys to int without an error.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Screenshots:
![Screenshot 2024-09-04 114016](https://github.com/user-attachments/assets/a523b2a2-cbb6-4c9b-b3b3-3f33361c05ad)

