### PR TITLE
OC-909: Configure ARIs to display a single DOI

### DIFF
--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -464,19 +464,14 @@ export const create = async (
     });
 
     if (directPublish) {
-        // Create a DOI for this version specifically and trigger post publish tasks.
         const publishedVersion = await publicationVersionService.get(publication.id, 'latestLive');
 
         if (publishedVersion) {
-            const versionWithDoi = await publicationVersionService.generateNewVersionDOI(publishedVersion, null);
+            // Run post publish tasks, except PDF generation.
+            await publicationVersionService.postPublishHook(publishedVersion, true);
+            const upToDatePublication = await get(publication.id);
 
-            if (versionWithDoi) {
-                // Run post publish tasks, except PDF generation.
-                await publicationVersionService.postPublishHook(versionWithDoi, true);
-                const upToDatePublication = await get(publication.id);
-
-                return upToDatePublication;
-            }
+            return upToDatePublication;
         }
     }
 

--- a/api/src/components/publicationVersion/__tests__/createPublicationVersion.test.ts
+++ b/api/src/components/publicationVersion/__tests__/createPublicationVersion.test.ts
@@ -105,4 +105,15 @@ describe('Create new publication versions', () => {
         expect(newPublicationVersion.status).toEqual(400);
         expect(newPublicationVersion.body.message).toEqual('Peer reviews cannot be reversioned.');
     });
+
+    test('ARIs cannot be reversioned', async () => {
+        const newPublicationVersion = await testUtils.agent
+            .post('/publications/ari-publication-1/publication-versions')
+            .query({
+                apiKey: '000000012'
+            });
+
+        expect(newPublicationVersion.status).toEqual(400);
+        expect(newPublicationVersion.body.message).toEqual('ARI publications cannot be reversioned.');
+    });
 });

--- a/api/src/components/publicationVersion/controller.ts
+++ b/api/src/components/publicationVersion/controller.ts
@@ -290,20 +290,7 @@ export const updateStatus = async (
             }
         }
 
-        // Publication version is being made LIVE
-
-        let previousPublicationVersion: I.PublicationVersion | null = null;
-
-        if (publicationVersion.versionNumber > 1) {
-            previousPublicationVersion = await publicationVersionService.get(
-                publicationVersion.versionOf,
-                publicationVersion.versionNumber - 1
-            );
-        }
-
-        // Create a DOI for this version specifically.
-        await publicationVersionService.generateNewVersionDOI(publicationVersion, previousPublicationVersion);
-
+        // Publication version is being made LIVE and is valid.
         // Publish version.
         await publicationVersionService.updateStatus(publicationVersion.id, 'LIVE');
 
@@ -386,6 +373,12 @@ export const create = async (
         if (latestPublicationVersion.publication.type === 'PEER_REVIEW') {
             return response.json(400, {
                 message: 'Peer reviews cannot be reversioned.'
+            });
+        }
+
+        if (latestPublicationVersion.publication.externalSource === 'ARI') {
+            return response.json(400, {
+                message: 'ARI publications cannot be reversioned.'
             });
         }
 

--- a/api/src/components/publicationVersion/service.ts
+++ b/api/src/components/publicationVersion/service.ts
@@ -1492,7 +1492,7 @@ const createDOIPayload = async (
             const { oldPublicationVersionDOIs } = data;
 
             // It's possible there will be no versioned DOIs at all.
-            // Peer reviews only get a canonical DOI. In this case, skip this part.
+            // Some types of publication only get a canonical DOI. In this case, skip this part.
             if (oldPublicationVersionDOIs.length || publicationVersion.doi) {
                 const publicationVersionDOIs = [...oldPublicationVersionDOIs, publicationVersion.doi].map((doi) => ({
                     relatedIdentifier: doi,
@@ -1588,14 +1588,23 @@ const updatePreviousPublicationVersionDOI = async (
     return response.data;
 };
 
+const isExemptFromReversioning = (publicationVersion: I.PublicationVersion) => {
+    const isPeerReview = publicationVersion.publication.type === 'PEER_REVIEW';
+    const isARI = publicationVersion.publication.externalSource === 'ARI';
+
+    return isPeerReview || isARI;
+};
+
 // Create a separate DOI for a specific publication version.
-// Returns the updated version.
+// Returns the updated version with a DOI, or null if this publication doesn't use reversioning,
+// and thus doesn't have versioned DOIs.
 export const generateNewVersionDOI = async (
     publicationVersion: I.PublicationVersion,
     previousPublicationVersion?: I.PublicationVersion | null
 ) => {
-    // Peer Reviews do not need this as they can only have 1 version
-    if (publicationVersion.publication.type !== 'PEER_REVIEW') {
+    if (isExemptFromReversioning(publicationVersion)) {
+        return null;
+    } else {
         const newPublicationVersionDOI = await createPublicationVersionDOI(
             publicationVersion,
             previousPublicationVersion?.doi as string
@@ -1625,9 +1634,9 @@ export const updateCanonicalDOI = async (
         throw Error('Supplied version is not current');
     }
 
-    // Unless this is a peer review (which doesn't get versioned DOIs, as they only have 1 version)
+    // Unless this is exempt from reversioning (so doesn't get versioned DOIs),
     // we need to have the DOI of the version so we can reference it in the canonical DOI's metadata.
-    if (!latestPublicationVersion.doi && latestPublicationVersion.publication.type !== 'PEER_REVIEW') {
+    if (!latestPublicationVersion.doi && !isExemptFromReversioning(latestPublicationVersion)) {
         throw Error("Supplied version doesn't have a valid DOI.");
     }
 
@@ -1713,8 +1722,10 @@ export const postPublishHook = async (
             }
         });
 
-        // Update previous version's "isLatestLiveVersion" flag.
+        let previousVersion: I.PublicationVersion | null = null;
+
         if (publicationVersion.versionNumber > 1) {
+            // Update previous version's "isLatestLiveVersion" flag.
             await client.prisma.publicationVersion.updateMany({
                 where: {
                     versionOf: publicationVersion.versionOf,
@@ -1724,10 +1735,26 @@ export const postPublishHook = async (
                     isLatestLiveVersion: false
                 }
             });
+
+            // Get previous version to feed into DOI updates.
+            previousVersion = await client.prisma.publicationVersion.findFirst({
+                where: {
+                    versionOf: publicationVersion.versionOf,
+                    versionNumber: publicationVersion.versionNumber - 1
+                },
+                include: defaultPublicationVersionInclude
+            });
+        }
+
+        let versionWithDOI: I.PublicationVersion | null = null;
+
+        if (!isExemptFromReversioning(publicationVersion)) {
+            versionWithDOI = await generateNewVersionDOI(publicationVersion, previousVersion);
         }
 
         // Update the canonical DOI with the latest details from this version.
-        await updateCanonicalDOI(publicationVersion.publication.doi, publicationVersion);
+        // If we have a version with a DOI, pass that, but if not just pass one without.
+        await updateCanonicalDOI(publicationVersion.publication.doi, versionWithDOI || publicationVersion);
 
         // (Re)index publication in opensearch.
         if (publicationVersion.versionNumber > 1 || forceReindex) {

--- a/api/src/lib/integrations/__tests__/ari.test.ts
+++ b/api/src/lib/integrations/__tests__/ari.test.ts
@@ -191,6 +191,12 @@ describe('ARI handling', () => {
                 title: 'ARI Publication 1 v2'
             }
         });
+        // Published date should have changed.
+        const publishedDate = handleARI.publicationVersion?.publishedDate;
+
+        if (publishedDate) {
+            expect(new Date(publishedDate).toISOString()).not.toEqual('2024-07-16T14:06:00.000Z');
+        }
     });
 
     test('Changed department updates user and coauthor', async () => {

--- a/api/src/lib/integrations/ariUtils.ts
+++ b/api/src/lib/integrations/ariUtils.ts
@@ -243,7 +243,6 @@ export const handleIncomingARI = async (question: I.ARIQuestion): Promise<I.Hand
         };
     }
 
-    // Compare all mapped fields.
     const changes = detectChangesToARIPublication(mappedData, existingVersion);
 
     if (changes) {
@@ -251,12 +250,15 @@ export const handleIncomingARI = async (question: I.ARIQuestion): Promise<I.Hand
         // Data differs from what is in octopus, so update the publication.
         // Unlike manually created publications, these just have 1 version that
         // updates in-place so that we don't pollute datacite with lots of version DOIs.
+        const now = new Date().toISOString();
         let updatedVersion = await publicationVersionService.update(existingVersion.id, {
             ...(changes.title && { title: mappedData.title }),
             ...(changes.content && { content: mappedData.content }),
             ...(changes.keywords && { keywords: mappedData.keywords }),
             ...(changes.topics && { topics: { set: mappedData.topicIds.map((topicId) => ({ id: topicId })) } }),
-            ...(changes.userId && { user: { connect: { id: mappedData.userId } } })
+            ...(changes.userId && { user: { connect: { id: mappedData.userId } } }),
+            publishedDate: now,
+            updatedAt: now
         });
 
         // If user changed, update coAuthors.

--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -930,6 +930,7 @@ const addCoAuthorsAndRequestApproval = async (page: Page, coAuthors: Helpers.Tes
 
 test.describe('Publication flow + co-authors', () => {
     test('Create a PROBLEM publication with co-authors', async ({ browser }) => {
+        test.slow();
         const page = await Helpers.getPageAsUser(browser);
 
         // create new publication and fill in other required fields

--- a/ui/src/components/Publication/SidebarCard/General/index.tsx
+++ b/ui/src/components/Publication/SidebarCard/General/index.tsx
@@ -14,6 +14,7 @@ type Props = {
 };
 
 const General: React.FC<Props> = (props): React.ReactElement => {
+    const isExemptFromReversioning = Helpers.isPublicationVersionExemptFromReversioning(props.publicationVersion);
     const multipleVersions = !props.publicationVersion.isLatestVersion || props.publicationVersion.versionNumber > 1;
     const peerReviews = props.linkedFrom.filter((publication) => publication.type === 'PEER_REVIEW');
     const thisVersionPeerReviewCount = peerReviews.filter(
@@ -118,7 +119,7 @@ const General: React.FC<Props> = (props): React.ReactElement => {
                 <>
                     <div className="flex">
                         <span className="mr-2 text-sm font-semibold text-grey-800 transition-colors duration-500 dark:text-grey-100">
-                            Peer Reviews (This Version): ({thisVersionPeerReviewCount})
+                            Peer Reviews{!isExemptFromReversioning && ' (This Version)'}: ({thisVersionPeerReviewCount})
                         </span>
                     </div>
                     {multipleVersions && (

--- a/ui/src/components/Publication/SidebarCard/General/index.tsx
+++ b/ui/src/components/Publication/SidebarCard/General/index.tsx
@@ -22,7 +22,7 @@ const General: React.FC<Props> = (props): React.ReactElement => {
 
     const activeFlags = React.useMemo(() => props.flags.filter((flag) => !flag.resolved), [props.flags]);
 
-    const showVersionDoi = props.publicationVersion.doi && props.publicationVersion.publication.type !== 'PEER_REVIEW';
+    const showVersionDoi = props.publicationVersion.doi;
     const versionDoiUrl = Config.values.doiBaseUrl + props.publicationVersion.doi;
     const versionlessDoiUrl = Config.values.doiBaseUrl + props.publicationVersion.publication.doi;
 

--- a/ui/src/lib/helpers.tsx
+++ b/ui/src/lib/helpers.tsx
@@ -642,3 +642,10 @@ export const abbreviateUserName = <
     // Default for organisational accounts and general fallback.
     return user.firstName;
 };
+
+export const isPublicationVersionExemptFromReversioning = (publicationVersion: Interfaces.PublicationVersion) => {
+    const { publication } = publicationVersion;
+    const isPeerReview = publication.type === 'PEER_REVIEW';
+    const isARI = publication.externalSource === 'ARI';
+    return isPeerReview || isARI;
+};

--- a/ui/src/lib/interfaces.ts
+++ b/ui/src/lib/interfaces.ts
@@ -54,6 +54,8 @@ export interface CorePublication {
     type: Types.PublicationType;
     doi: string | null;
     url_slug: string;
+    externalId?: string;
+    externalSource?: Types.PublicationImportSource;
     flagCount?: number;
     peerReviewCount?: number;
 }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -344,3 +344,5 @@ export type PartialPublicationVersion = Pick<
     | 'coAuthors'
     | 'currentStatus'
 >;
+
+export type PublicationImportSource = 'ARI';

--- a/ui/src/pages/publications/[id]/versions/[versionId].tsx
+++ b/ui/src/pages/publications/[id]/versions/[versionId].tsx
@@ -191,11 +191,11 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
     );
 
     const { data: publication } = useSWR<
-        Pick<Interfaces.Publication, 'id' | 'type'> & {
+        Pick<Interfaces.Publication, 'id' | 'type' | 'externalSource'> & {
             versions: Types.PartialPublicationVersion[];
         }
     >(
-        `${Config.endpoints.publications}/${props.publicationId}?fields=id,type,versions(id,doi,currentStatus,versionOf,versionNumber,createdBy,publishedDate,isLatestLiveVersion,isLatestVersion,coAuthors)`
+        `${Config.endpoints.publications}/${props.publicationId}?fields=id,type,externalSource,versions(id,doi,currentStatus,versionOf,versionNumber,createdBy,publishedDate,isLatestLiveVersion,isLatestVersion,coAuthors)`
     );
 
     const { data: controlRequests = [], isLoading: isLoadingControlRequests } = useSWR<Interfaces.ControlRequest[]>(
@@ -231,7 +231,8 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
     const showEthicalStatement =
         publicationVersion?.publication.type === 'DATA' && Boolean(publicationVersion.ethicalStatement);
     const showRedFlags = !!flags.length;
-    const showVersionsAccordion = publication && publication.type !== 'PEER_REVIEW' && !isLoadingControlRequests;
+    const isExemptFromReversioning = publication?.type === 'PEER_REVIEW' || publication?.externalSource === 'ARI';
+    const showVersionsAccordion = publication && !isExemptFromReversioning && !isLoadingControlRequests;
 
     if (showReferences) list.push({ title: 'References', href: 'references' });
     if (showChildProblems || showParentPublications)

--- a/ui/src/pages/publications/[id]/versions/[versionId].tsx
+++ b/ui/src/pages/publications/[id]/versions/[versionId].tsx
@@ -231,7 +231,8 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
     const showEthicalStatement =
         publicationVersion?.publication.type === 'DATA' && Boolean(publicationVersion.ethicalStatement);
     const showRedFlags = !!flags.length;
-    const isExemptFromReversioning = publication?.type === 'PEER_REVIEW' || publication?.externalSource === 'ARI';
+    const isExemptFromReversioning =
+        publicationVersion && Helpers.isPublicationVersionExemptFromReversioning(publicationVersion);
     const showVersionsAccordion = publication && !isExemptFromReversioning && !isLoadingControlRequests;
 
     if (showReferences) list.push({ title: 'References', href: 'references' });


### PR DESCRIPTION
The purpose of this PR was to ensure that, in relation to ARI publications (which only take one version), users do not see a versioned DOI if only one version will ever exist. They should be informed of updates to the DOI via the publication date.

---

### Acceptance Criteria:

- DOIs for publications with a source of “ARI” are configured like peer reviews, with only a single DOI used instead of the pair of versionless/versioned DOIs
    - The UI for ARIs is updated to not include versioning-related UI such as the version dropdown
- When updated, the “publication date” on ARIs are updated to the current date

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

E2E
![Screenshot 2024-09-10 155300](https://github.com/user-attachments/assets/82e45613-9292-4810-8b3c-5b0c941545bc)

API
![Screenshot 2024-09-10 160659](https://github.com/user-attachments/assets/87e613e2-534d-4009-b7b4-2473650980e5)

UI
![Screenshot 2024-09-10 160857](https://github.com/user-attachments/assets/bfbcc2e8-1224-4e22-b9d9-b96e38208cee)

---

### Screenshots:

Versioned publication with version accordion, and mention of versions in sidebar
![Screenshot 2024-09-10 163010](https://github.com/user-attachments/assets/9944c1ff-b4ff-48ab-ae5c-3cd7f75306aa)

ARI, without these features
![Screenshot 2024-09-10 163021](https://github.com/user-attachments/assets/1440fefd-1b97-4992-922e-ee6e1456d441)
