### PR TITLE
Increase timeout for ari import lambda

### DIFF
--- a/api/serverless-config-default.yml
+++ b/api/serverless-config-default.yml
@@ -495,6 +495,7 @@ functions:
     # Integrations
     incrementalAriIngest:
         handler: src/components/integrations/service.incrementalAriIngest
+        timeout: 900
         events:
             - schedule:
                 rate: cron(0 5 ? * TUE *) # Every Tuesday at 5 a.m.


### PR DESCRIPTION
The purpose of this PR was to make a quick fix that overrides the default lambda timeout of 30 seconds for our ARI import lambda to the maximum of 900 seconds because it timed out on its first test run. This is really a placeholder until we can build the solution in ECS.

---

### Acceptance Criteria:

ARI import lambda has the maximum timeout of 15 minutes.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

