### PR TITLE
OC-910: Update weekly ingest to store and check dates

### DIFF
--- a/api/prisma/migrations/20240911122447_ingest_logs_table/migration.sql
+++ b/api/prisma/migrations/20240911122447_ingest_logs_table/migration.sql
@@ -1,0 +1,9 @@
+-- CreateTable
+CREATE TABLE "IngestLog" (
+    "id" TEXT NOT NULL,
+    "source" "PublicationImportSource" NOT NULL,
+    "start" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "end" TIMESTAMP(3),
+
+    CONSTRAINT "IngestLog_pkey" PRIMARY KEY ("id")
+);

--- a/api/prisma/migrations/20240911151436_remove_old_bookmark_model/migration.sql
+++ b/api/prisma/migrations/20240911151436_remove_old_bookmark_model/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - You are about to drop the `PublicationBookmarks` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "PublicationBookmarks" DROP CONSTRAINT "PublicationBookmarks_publicationId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "PublicationBookmarks" DROP CONSTRAINT "PublicationBookmarks_userId_fkey";
+
+-- DropTable
+DROP TABLE "PublicationBookmarks";

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -315,6 +315,13 @@ model AdditionalInformation {
     publicationVersion   PublicationVersion @relation(fields: [publicationVersionId], references: [id], onDelete: Cascade)
 }
 
+model IngestLog {
+    id     String                  @id @default(cuid())
+    source PublicationImportSource
+    start  DateTime                @default(now())
+    end    DateTime?
+}
+
 enum EventType {
     REQUEST_CONTROL
 }

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -10,34 +10,33 @@ datasource db {
 }
 
 model User {
-    id                   String                 @id @default(cuid())
-    orcid                String?                @unique
-    orcidAccessToken     String?
-    firstName            String
-    lastName             String?
-    email                String?
-    role                 Role                   @default(USER)
-    locked               Boolean                @default(false)
-    apiKey               String                 @unique @default(uuid())
-    ror                  String?
-    url                  String?
-    createdAt            DateTime               @default(now())
-    updatedAt            DateTime               @updatedAt
-    employment           Json[]
-    works                Json[]
-    education            Json[]
-    coAuthors            CoAuthors[]
-    publicationVersions  PublicationVersion[]
-    PublicationFlags     PublicationFlags[]
-    flagComments         FlagComments[]
-    Images               Images[]
-    PublicationBookmarks PublicationBookmarks[]
-    bookmarks            Bookmark[]
-    crosslinks           Crosslink[]
-    crosslinkVotes       CrosslinkVote[]
-    defaultTopicId       String?
-    defaultTopic         Topic?                 @relation(fields: [defaultTopicId], references: [id])
-    mappings             UserMapping[]
+    id                  String               @id @default(cuid())
+    orcid               String?              @unique
+    orcidAccessToken    String?
+    firstName           String
+    lastName            String?
+    email               String?
+    role                Role                 @default(USER)
+    locked              Boolean              @default(false)
+    apiKey              String               @unique @default(uuid())
+    ror                 String?
+    url                 String?
+    createdAt           DateTime             @default(now())
+    updatedAt           DateTime             @updatedAt
+    employment          Json[]
+    works               Json[]
+    education           Json[]
+    coAuthors           CoAuthors[]
+    publicationVersions PublicationVersion[]
+    PublicationFlags    PublicationFlags[]
+    flagComments        FlagComments[]
+    Images              Images[]
+    bookmarks           Bookmark[]
+    crosslinks          Crosslink[]
+    crosslinkVotes      CrosslinkVote[]
+    defaultTopicId      String?
+    defaultTopic        Topic?               @relation(fields: [defaultTopicId], references: [id])
+    mappings            UserMapping[]
 }
 
 model Verification {
@@ -60,24 +59,23 @@ model Images {
 }
 
 model Publication {
-    id                   String                   @id @default(cuid())
-    url_slug             String                   @unique @default(cuid())
-    type                 PublicationType
-    doi                  String
-    publicationFlags     PublicationFlags[]
-    PublicationBookmarks PublicationBookmarks[]
-    linkedTo             Links[]                  @relation("from")
-    linkedFrom           Links[]                  @relation("to")
-    versions             PublicationVersion[]
+    id               String                   @id @default(cuid())
+    url_slug         String                   @unique @default(cuid())
+    type             PublicationType
+    doi              String
+    publicationFlags PublicationFlags[]
+    linkedTo         Links[]                  @relation("from")
+    linkedFrom       Links[]                  @relation("to")
+    versions         PublicationVersion[]
     // These reverse relations are needed by prisma, but we shouldn't use them in the application.
     // Prisma doesn't allow symmetrical many-to-many self relations.
     // There must be an "asymmetrical" relationship (e.g. from and to) in the schema. In practice, we will treat
     // crosslink entities as having a pair of publications associated that are of equal importance.
-    crosslinksFrom       Crosslink[]              @relation("crosslinkFrom")
-    crosslinksTo         Crosslink[]              @relation("crosslinkTo")
+    crosslinksFrom   Crosslink[]              @relation("crosslinkFrom")
+    crosslinksTo     Crosslink[]              @relation("crosslinkTo")
     // Populated when a publication has been imported from an external source.
-    externalId           String?
-    externalSource       PublicationImportSource?
+    externalId       String?
+    externalSource   PublicationImportSource?
 }
 
 model PublicationVersion {
@@ -202,17 +200,6 @@ model FlagComments {
     createdAt DateTime         @default(now())
     user      User             @relation(fields: [createdBy], references: [id], onDelete: Cascade)
     flag      PublicationFlags @relation(fields: [flagId], references: [id], onDelete: Cascade)
-}
-
-model PublicationBookmarks {
-    id            String      @id @default(cuid())
-    publicationId String
-    userId        String
-    createdAt     DateTime    @default(now())
-    publication   Publication @relation(fields: [publicationId], references: [id], onDelete: Cascade)
-    user          User        @relation(fields: [userId], references: [id], onDelete: Cascade)
-
-    @@unique([publicationId, userId])
 }
 
 model Topic {

--- a/api/prisma/seeds/index.ts
+++ b/api/prisma/seeds/index.ts
@@ -9,6 +9,7 @@ export { default as prodPublications } from './prod/publications';
 export { default as prodUsers } from './prod/users';
 export { default as testBookmarks } from './local/unitTesting/bookmarks';
 export { default as testEvents } from './local/unitTesting/events';
+export { default as testIngestLogs } from './local/unitTesting/ingestLogs';
 export { default as testPublications } from './local/unitTesting/publications';
 export { default as testReferences } from './local/unitTesting/references';
 export { default as testTopicMappings } from './local/unitTesting/topicMappings';

--- a/api/prisma/seeds/local/unitTesting/ingestLogs.ts
+++ b/api/prisma/seeds/local/unitTesting/ingestLogs.ts
@@ -1,0 +1,12 @@
+import { Prisma } from '@prisma/client';
+
+const ingestLogs: Prisma.IngestLogCreateManyInput[] = [
+    {
+        id: 'ingest-log-1',
+        source: 'ARI',
+        start: '2024-09-11T12:53:00.000Z',
+        end: '2024-09-11T12:54:00.000Z'
+    }
+];
+
+export default ingestLogs;

--- a/api/src/components/ingestLog/__tests__/ingestLog.test.ts
+++ b/api/src/components/ingestLog/__tests__/ingestLog.test.ts
@@ -1,0 +1,39 @@
+import * as client from 'lib/client';
+import * as ingestLogService from 'ingestLog/service';
+import * as testUtils from 'lib/testUtils';
+
+beforeEach(async () => {
+    await testUtils.clearDB();
+    await testUtils.testSeed();
+});
+
+describe('Ingest log functions', () => {
+    test('Create an ingest log', async () => {
+        const createLog = await ingestLogService.create('ARI');
+        expect(createLog.source).toEqual('ARI');
+        expect(createLog.start).toBeInstanceOf(Date);
+        expect(createLog.end).toBeNull();
+    });
+
+    test('Set the end time of an ingest log', async () => {
+        const now = new Date();
+        const setEndTime = await ingestLogService.setEndTime('ingest-log-1', now);
+        expect(setEndTime).toMatchObject({
+            id: 'ingest-log-1',
+            start: new Date('2024-09-11T12:53:00.000Z'),
+            end: now,
+            source: 'ARI'
+        });
+    });
+
+    test('Get most recent start time', async () => {
+        const mostRecentStart = await ingestLogService.getMostRecentStartTime('ARI');
+        expect(mostRecentStart).toEqual(new Date('2024-09-11T12:53:00.000Z'));
+    });
+
+    test('Most recent start is null if no run that ended successfully is present', async () => {
+        await client.prisma.ingestLog.update({ where: { id: 'ingest-log-1' }, data: { end: null } });
+        const mostRecentStart = await ingestLogService.getMostRecentStartTime('ARI');
+        expect(mostRecentStart).toBeNull();
+    });
+});

--- a/api/src/components/ingestLog/service.ts
+++ b/api/src/components/ingestLog/service.ts
@@ -1,0 +1,38 @@
+import * as client from 'lib/client';
+import * as I from 'lib/interface';
+
+export const create = (source: I.PublicationImportSource) => client.prisma.ingestLog.create({ data: { source } });
+
+export const setEndTime = (id: string, end: Date) =>
+    client.prisma.ingestLog.update({
+        where: {
+            id
+        },
+        data: {
+            end
+        }
+    });
+
+export const getMostRecentStartTime = async (source: I.PublicationImportSource): Promise<Date | null> => {
+    const mostRecentStartQuery = await client.prisma.ingestLog.findFirst({
+        where: {
+            source,
+            // Successful runs only.
+            end: {
+                not: null
+            }
+        },
+        orderBy: {
+            start: 'desc'
+        },
+        select: {
+            start: true
+        }
+    });
+
+    if (mostRecentStartQuery) {
+        return mostRecentStartQuery.start;
+    } else {
+        return null;
+    }
+};

--- a/api/src/components/integrations/service.ts
+++ b/api/src/components/integrations/service.ts
@@ -1,15 +1,35 @@
 import axios from 'axios';
 import * as ariUtils from 'lib/integrations/ariUtils';
+import * as ingestLogService from 'ingestLog/service';
+
+const MAX_UNCHANGED_STREAK = 5;
 
 /**
  * Incremental ARI ingest.
  * Paginates through ARI questions from the ARI DB API and handles incoming ARIs.
- * If it encounters MAX_UNCHANGED_STREAK ARIs in a row not requiring changes, it stops.
+ * It stops when both of the following conditions are true:
+ *   - It encounters MAX_UNCHANGED_STREAK ARIs in a row not requiring changes.
+ *   - It encounters an ARI with dateUpdated before the start time of the most
+ *       recent successful ingest (if this start time is available).
  */
 export const incrementalAriIngest = async (): Promise<void> => {
+    // Get most start time of last successful run to help us know when to stop.
+    const mostRecentStart = await ingestLogService.getMostRecentStartTime('ARI');
+
+    if (!mostRecentStart) {
+        console.log(
+            `Unable to get most recent start time. This job will stop when it encounters ${MAX_UNCHANGED_STREAK} unchanged ARIs, regardless of their dateUpdated value.`
+        );
+    }
+
+    // Log start time.
+    const log = await ingestLogService.create('ARI');
+
     // Count sequential unchanged ARIs so that we can stop when the streak hits MAX_UNCHANGED_STREAK.
-    const MAX_UNCHANGED_STREAK = 5;
     let unchangedStreak = 0;
+
+    // Track whether we have passed the last successful import start time.
+    let timeOverlap = false;
 
     // Pagination loop.
     let pageUrl = ariUtils.ariEndpoint;
@@ -22,6 +42,10 @@ export const incrementalAriIngest = async (): Promise<void> => {
         const pageAris = response.data.data;
 
         for (const pageAri of pageAris) {
+            if (mostRecentStart && new Date(pageAri.dateUpdated) < new Date(mostRecentStart)) {
+                timeOverlap = true;
+            }
+
             if (!pageAri.isArchived) {
                 // Create, update, or skip this ARI as appropriate.
                 const handle = await ariUtils.handleIncomingARI(pageAri);
@@ -32,7 +56,8 @@ export const incrementalAriIngest = async (): Promise<void> => {
                     // Success is true and actionTaken is none so there were no changes found.
                     unchangedStreak++;
 
-                    if (unchangedStreak >= MAX_UNCHANGED_STREAK) {
+                    // Quit when we reach MAX_UNCHANGED_STREAK and are not knowingly processing ARIs newer than last ingest.
+                    if (unchangedStreak >= MAX_UNCHANGED_STREAK && (timeOverlap || !mostRecentStart)) {
                         break;
                     }
                 } else {
@@ -41,8 +66,18 @@ export const incrementalAriIngest = async (): Promise<void> => {
                     // Log action taken.
                     console.log(`ARI ${pageAri.questionId} handled successfully with action: ${handle.actionTaken}`);
                     writeCount++;
+
                     // Artificial delay to avoid hitting datacite rate limits with publication creates/updates.
-                    await new Promise((resolve) => setTimeout(resolve, 1000));
+                    // https://support.datacite.org/docs/is-there-a-rate-limit-for-making-requests-against-the-datacite-apis
+                    if (handle.actionTaken === 'create') {
+                        // Datacite is hit twice, to initialise DOI and get publication ID, then update DOI with data.
+                        await new Promise((resolve) => setTimeout(resolve, 1000));
+                    }
+
+                    if (handle.actionTaken === 'update') {
+                        // Datacite is hit once, to update the DOI with changes.
+                        await new Promise((resolve) => setTimeout(resolve, 500));
+                    }
                 }
             }
         }
@@ -51,7 +86,9 @@ export const incrementalAriIngest = async (): Promise<void> => {
         // On the last run this will be undefined but that's fine because we won't need to repeat the loop.
         paginationInfo = response.data.meta.pagination;
         pageUrl = paginationInfo.links.next;
-    } while (pageUrl && unchangedStreak < MAX_UNCHANGED_STREAK);
+    } while (pageUrl && unchangedStreak < MAX_UNCHANGED_STREAK && !timeOverlap);
 
+    // Log end time.
+    await ingestLogService.setEndTime(log.id, new Date());
     console.log(`Update complete. Updated ${writeCount} publication${writeCount !== 1 ? 's' : ''}.`);
 };

--- a/api/src/components/integrations/service.ts
+++ b/api/src/components/integrations/service.ts
@@ -2,8 +2,6 @@ import axios from 'axios';
 import * as ariUtils from 'lib/integrations/ariUtils';
 import * as ingestLogService from 'ingestLog/service';
 
-const MAX_UNCHANGED_STREAK = 5;
-
 /**
  * Incremental ARI ingest.
  * Paginates through ARI questions from the ARI DB API and handles incoming ARIs.
@@ -13,6 +11,7 @@ const MAX_UNCHANGED_STREAK = 5;
  *       recent successful ingest (if this start time is available).
  */
 export const incrementalAriIngest = async (): Promise<void> => {
+    const MAX_UNCHANGED_STREAK = 5;
     // Get most start time of last successful run to help us know when to stop.
     const mostRecentStart = await ingestLogService.getMostRecentStartTime('ARI');
 
@@ -44,6 +43,7 @@ export const incrementalAriIngest = async (): Promise<void> => {
         for (const pageAri of pageAris) {
             if (mostRecentStart && new Date(pageAri.dateUpdated) < new Date(mostRecentStart)) {
                 timeOverlap = true;
+                console.log('Time overlap - reached an ARI older than the most recent ingest start time.');
             }
 
             if (!pageAri.isArchived) {

--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -241,15 +241,15 @@ export const deletePublication = (id: string) =>
         }
     });
 
-export const createOpenSearchRecord = (data: I.OpenSearchPublication) =>
-    client.search.create({
+export const upsertOpenSearchRecord = (data: I.OpenSearchPublication) =>
+    client.search.update({
         index: 'publications',
         id: data.id,
-        body: data
+        body: {
+            doc: data,
+            doc_as_upsert: true
+        }
     });
-
-export const deleteOpenSearchRecord = (publicationId: string) =>
-    client.search.delete({ index: 'publications', id: publicationId });
 
 export const getOpenSearchPublications = (filters: I.OpenSearchPublicationFilters) => {
     const orderBy = filters.orderBy

--- a/api/src/lib/integrations/ariUtils.ts
+++ b/api/src/lib/integrations/ariUtils.ts
@@ -274,7 +274,7 @@ export const handleIncomingARI = async (question: I.ARIQuestion): Promise<I.Hand
         }
 
         // Everything is good, so ensure changes hit datacite and opensearch.
-        await publicationVersionService.postPublishHook(updatedVersion, true, true);
+        await publicationVersionService.postPublishHook(updatedVersion, true);
 
         return {
             actionTaken: 'update',

--- a/api/src/lib/testUtils.ts
+++ b/api/src/lib/testUtils.ts
@@ -117,7 +117,6 @@ export const clearDB = async (): Promise<void> => {
         client.prisma.event.deleteMany(),
         client.prisma.ingestLog.deleteMany(),
         client.prisma.publication.deleteMany(),
-        client.prisma.publicationBookmarks.deleteMany(),
         client.prisma.user.deleteMany(),
         client.prisma.topic.deleteMany(),
         client.prisma.topicMapping.deleteMany(),

--- a/api/src/lib/testUtils.ts
+++ b/api/src/lib/testUtils.ts
@@ -36,7 +36,12 @@ const createUsers = async (): Promise<void> => {
 // Seed the database with a smaller set of data, just enough to run the automated tests.
 export const testSeed = async (): Promise<void> => {
     // These don't depend on anything.
-    await createUsers();
+    await Promise.all([
+        createUsers(),
+        client.prisma.ingestLog.createMany({
+            data: seeds.testIngestLogs
+        })
+    ]);
     // These depend on users.
     await Promise.all([
         createPublications(),
@@ -108,29 +113,22 @@ export const openSearchSeed = async (): Promise<void> => {
 };
 
 export const clearDB = async (): Promise<void> => {
-    const deletePublicationStatuses = client.prisma.publicationStatus.deleteMany();
-    const deletePublications = client.prisma.publication.deleteMany();
-    const deleteTopics = client.prisma.topic.deleteMany();
-    const deleteTopicMappings = client.prisma.topicMapping.deleteMany();
-    const deleteUsers = client.prisma.user.deleteMany();
-    const deleteBookmarks = client.prisma.publicationBookmarks.deleteMany();
-    const deleteEvents = client.prisma.event.deleteMany();
-
     await client.prisma.$transaction([
-        deleteUsers,
-        deletePublications,
-        deleteTopics,
-        deleteTopicMappings,
-        deleteBookmarks,
-        deletePublicationStatuses,
-        deleteEvents
+        client.prisma.event.deleteMany(),
+        client.prisma.ingestLog.deleteMany(),
+        client.prisma.publication.deleteMany(),
+        client.prisma.publicationBookmarks.deleteMany(),
+        client.prisma.user.deleteMany(),
+        client.prisma.topic.deleteMany(),
+        client.prisma.topicMapping.deleteMany(),
+        client.prisma.publicationStatus.deleteMany()
     ]);
 
-    const doesIndexExists = await client.search.indices.exists({
+    const doesIndexExist = await client.search.indices.exists({
         index: 'publications'
     });
 
-    if (doesIndexExists.body) {
+    if (doesIndexExist.body) {
         await client.search.indices.delete({
             index: 'publications'
         });

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -72,6 +72,9 @@
             "image/*": [
                 "src/components/image/*"
             ],
+            "ingestLog/*": [
+                "src/components/ingestLog/*"
+            ],
             "link/*": [
                 "src/components/link/*"
             ],

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -81,9 +81,6 @@
             "publication/*": [
                 "src/components/publication/*"
             ],
-            "publicationBookmark/*": [
-                "src/components/publicationBookmark/*"
-            ],
             "publicationVersion/*": [
                 "src/components/publicationVersion/*"
             ],

--- a/e2e/tests/LoggedIn/search.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/search.e2e.spec.ts
@@ -47,6 +47,9 @@ test.describe('dateTo and dateFrom fields are persisted in URL query string', ()
         const dateToInput = page.locator(PageModel.search.dateToInput);
 
         await dateFromInput.fill(PageModel.search.dateFrom);
+        // Wait for request because filling the dateFrom field will trigger it, and filling in the next field
+        // before it's ready will stop it being added to the URL.
+        await page.waitForResponse((response) => response.url().includes('/publication-versions'));
         await dateToInput.fill(PageModel.search.dateTo);
 
         // expect dateFrom/dateTo input and URL to match selections


### PR DESCRIPTION
The purpose of this PR was to have a more reliable way of knowing when to stop our incremental ARI ingest job. Sometimes, real changes on the ARI side could be detected as not changed on the octopus side because they wouldn't result in changes to the octopus publication. Thus this item changes the criteria for stopping the job when:
- 5 ARIs in a row are found that don't present changes to what we have in octopus (previous condition)
- the job has encountered an ARI with dateUpdated before the start time of the most recent previous job (new condition)
    - N.B. the data is sorted by dateUpdated

This is achieved by adding an IngestLog model to the database where we can store data on ingest jobs such as their start and end times and check that on later runs.

In addition, this PR makes these changes:
- "PublicationBookmark" model is removed from prisma schema and where referenced in code
    - this is a legacy thing that should have been removed when PublicationBookmarks were migrated to Bookmark a while ago
- Elasticsearch (re)indexing when a publication is publish is reworked to use an "upsert" rather than a create (preceded by a delete if doc is pre-existing in index)
    - logging is added around this because the incremental ARI ingest seemed to hang at this point on its first run

---

### Acceptance Criteria:

- When the weekly ingest runs, the following is recorded:
    - Source (“ARI Database”)
    - Date & time started
    - Date & time ended
- When the weekly ingest is running, it will stop if both 5 records in a row are unchanged from what has already been ingested, and the last of these five records (?) shows a date updated older than the start time of the previous ingest
- In the post-publish tasks for updated publications, the search indexing step is changed to do an upsert instead of a delete + recreate.
    - Logging is added around this step
---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

E2E
![Screenshot 2024-09-12 093940](https://github.com/user-attachments/assets/04dbf3e9-cdfa-4e41-9345-d73617a2d864)

API
![Screenshot 2024-09-11 163239](https://github.com/user-attachments/assets/a10d0e12-1dc9-454b-b11c-d9155eb79fa4)

