### PR TITLE
OC-912: Duplicate account emails cause author pages to show pubs from other accs

### DIFF
--- a/api/src/components/user/service.ts
+++ b/api/src/components/user/service.ts
@@ -180,15 +180,17 @@ export const getPublications = async (
                     }
                 }
             },
-            // User is an unconfirmed coauthor on at least one version
-            ...(user?.email
+            // They are an unconfirmed coauthor on at least one version (if the user is requesting their own publications)
+            ...(isAccountOwner && user?.email
                 ? [
                       {
                           versions: {
                               some: {
                                   coAuthors: {
                                       some: {
-                                          email: user.email
+                                          email: user.email,
+                                          approvalRequested: true,
+                                          linkedUser: null
                                       }
                                   }
                               }

--- a/api/src/components/user/service.ts
+++ b/api/src/components/user/service.ts
@@ -180,8 +180,11 @@ export const getPublications = async (
                     }
                 }
             },
-            // They are an unconfirmed coauthor on at least one version (if the user is requesting their own publications)
-            ...(isAccountOwner && user?.email
+            // They are an unconfirmed coauthor on at least one version
+            // (if the user is requesting their own publications and including DRAFT/LOCKED ones)
+            ...(isAccountOwner &&
+            user?.email &&
+            versionStatusArray?.some((status) => status === 'DRAFT' || status === 'LOCKED')
                 ? [
                       {
                           versions: {

--- a/e2e/tests/LoggedIn/topic.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/topic.e2e.spec.ts
@@ -41,7 +41,7 @@ test.describe('Topic page', () => {
         await page.locator(PageModel.header.myBookmarksButton).click();
         await page.waitForURL('**/my-bookmarks');
 
-        await expect(page.locator(PageModel.myBookmarks.topicBookmark)).toBeVisible();
+        await expect(page.locator(PageModel.myBookmarks.bookmarkedTopicLink)).toBeVisible();
     });
 
     test('Remove a topic bookmark from topic page', async ({ browser }) => {
@@ -57,7 +57,7 @@ test.describe('Topic page', () => {
         await page.locator(PageModel.header.usernameButton).click();
         await page.locator(PageModel.header.myBookmarksButton).click();
 
-        await expect(page.locator(PageModel.myBookmarks.topicBookmark)).not.toBeVisible();
+        await expect(page.locator(PageModel.myBookmarks.bookmarkedTopicLink)).not.toBeVisible();
     });
 
     test('Remove a topic bookmark from My Bookmarks page', async ({ browser }) => {
@@ -70,6 +70,6 @@ test.describe('Topic page', () => {
         await page.locator(PageModel.header.myBookmarksButton).click();
         await expect(page.locator(PageModel.myBookmarks.removeTopicBookmark)).toBeVisible();
         await page.locator(PageModel.myBookmarks.removeTopicBookmark).click();
-        await expect(page.locator(PageModel.myBookmarks.topicBookmark)).not.toBeVisible();
+        await expect(page.locator(PageModel.myBookmarks.bookmarkedTopicLink)).not.toBeVisible();
     });
 });

--- a/e2e/tests/PageModel.ts
+++ b/e2e/tests/PageModel.ts
@@ -147,8 +147,8 @@ export const PageModel = {
         liveAuthorPageButton: 'a:has-text("View my public author page")'
     },
     myBookmarks: {
-        publicationBookmark: 'a[href="/publications/cl3fz14dr0001es6i5ji51rq4"]',
-        topicBookmark: 'a[href="/topics/cly468yyb00177ryzsvccai51"]',
+        bookmarkedPublicationLink: 'a[href="/publications/cl3fz14dr0001es6i5ji51rq4"]',
+        bookmarkedTopicLink: 'a[href="/topics/cly468yyb00177ryzsvccai51"]',
         removeTopicBookmark: 'a[href="/topics/cly468yyb00177ryzsvccai51"] + button[aria-label="Remove bookmark"]'
     },
     publish: {


### PR DESCRIPTION
The purpose of this PR was to fix a bug where one user's account page could show another user's publications if they shared an email address.

This was happening because the "get user publications" endpoint included a condition to get publications with a coauthor sharing the user's email address (indicating that they had been added, but not confirmed themselves, as a coauthor on the publication).

This can't occur with general users, due to details coming from orcid which uses unique email addresses, but can happen with organisational ones.

This condition is only relevant when showing users their own publications on the "my account" page. This fix ensures that it will only be applied on requests from there (as far as the UI is concerned) and narrows down the criteria as much as possible where it was too general before.

---

### Acceptance Criteria:

- On the public profile page, publications with an unconfirmed coauthor record sharing the profile user's email address are not shown

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

E2E
![Screenshot 2024-09-16 123010](https://github.com/user-attachments/assets/16eec3a6-0526-4594-b8da-3cad359e306d)

API
![Screenshot 2024-09-16 132859](https://github.com/user-attachments/assets/3da16c33-4c91-43c7-8400-90f02d1d286c)

