### PR TITLE
OC-918: Fix high severity vulnerability in micromatch

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -183,3 +183,4 @@ This is a place to track where we have added dependency overrides in package.jso
 
 -   fast-xml-parser ^4.2.5: to address [dependabot alert](https://github.com/JiscSD/octopus/security/dependabot/59)
 -   http-cache-semantics ^4.1.1: to address [dependabot alert](https://github.com/JiscSD/octopus/security/dependabot/45)
+-   micromatch ^4.0.8: to address [snyk alert](https://security.snyk.io/vuln/SNYK-JS-MICROMATCH-6838728)

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -13446,19 +13446,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/lint-staged/node_modules/micromatch": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-            "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-            "dev": true,
-            "dependencies": {
-                "braces": "^3.0.2",
-                "picomatch": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=8.6"
-            }
-        },
         "node_modules/lint-staged/node_modules/mimic-fn": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -14077,9 +14064,9 @@
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-            "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dependencies": {
                 "braces": "^3.0.3",
                 "picomatch": "^2.3.1"

--- a/api/package.json
+++ b/api/package.json
@@ -96,6 +96,7 @@
     },
     "overrides": {
         "fast-xml-parser": "^4.2.5",
-        "http-cache-semantics": "^4.1.1"
+        "http-cache-semantics": "^4.1.1",
+        "micromatch": "^4.0.8"
     }
 }


### PR DESCRIPTION
The purpose of this PR was to address a vulnerability alerted to us by Snyk in the micromatch package.

It's included in the copy-webpack-plugin. I spent some time trying to see if we could stop using this plugin but I don't think we can. We need font+image files to be present in the build so that we can use fs.readFileSync on them when generating PDFs, and webpack doesn't seem to be able to do this by itself without the copy plugin (because the assets aren't included as import/require statements for webpack to detect). So it has been solved with a package.json override.

PDF generation still works fine after the update.

---

### Acceptance Criteria:

- micromatch is installed at >= 4.0.8

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [x] Documentation updated

---

### Tests:

E2E
![Screenshot 2024-09-19 110911](https://github.com/user-attachments/assets/f542c670-03ba-43cf-a53d-15794598f3ee)

API
![Screenshot 2024-09-19 112008](https://github.com/user-attachments/assets/0e8e1340-b14b-4adc-98d5-e1534101bd45)
