### PR TITLE
OC-910 fix: stop log message repeating unnecessarily

### DIFF
--- a/api/src/components/integrations/service.ts
+++ b/api/src/components/integrations/service.ts
@@ -41,7 +41,7 @@ export const incrementalAriIngest = async (): Promise<void> => {
         const pageAris = response.data.data;
 
         for (const pageAri of pageAris) {
-            if (mostRecentStart && new Date(pageAri.dateUpdated) < new Date(mostRecentStart)) {
+            if (mostRecentStart && new Date(pageAri.dateUpdated) < new Date(mostRecentStart) && !timeOverlap) {
                 timeOverlap = true;
                 console.log('Time overlap - reached an ARI older than the most recent ingest start time.');
             }


### PR DESCRIPTION
This is a small fix PR to stop an if check from repeatedly passing and repeating a log message that was only intended to appear once.