### PR TITLE
OC-921: High severity security issue in NextJS

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,12 +1,10 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { devices } from '@playwright/test';
 import * as dotenv from 'dotenv';
+import path from 'path';
 
-/**
- * Read environment variables from .env file.
- * https://github.com/motdotla/dotenv
- */
-dotenv.config();
+// Read from ".env" file.
+dotenv.config({ path: path.resolve(__dirname, '.env') });
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -2,6 +2,7 @@ import * as Helpers from '../helpers';
 import { expect, test, Page, Browser } from '@playwright/test';
 import { PageModel } from '../PageModel';
 import cuid2 from '@paralleldrive/cuid2';
+import path from 'path';
 
 const createPublication = async (page: Page, publicationTitle: string, pubType: string) => {
     await page.goto(`/create`);
@@ -1892,6 +1893,7 @@ test.describe('Publication flow + co-authors', () => {
 
 test.describe('Publication Flow + File import', () => {
     let page: Page;
+    const assetsDirName = path.join(__dirname, '../../assets/');
 
     test.beforeAll(async ({ browser }) => {
         page = await Helpers.getPageAsUser(browser);
@@ -1912,7 +1914,7 @@ test.describe('Publication Flow + File import', () => {
         );
 
         // import initial playwright file
-        await Helpers.openFileImportModal(page, 'assets/Playwright.docx');
+        await Helpers.openFileImportModal(page, assetsDirName + 'Playwright.docx');
         await page.locator(PageModel.publish.insertButton).click();
 
         // Ensure modal has closed and file import
@@ -1920,7 +1922,7 @@ test.describe('Publication Flow + File import', () => {
         await expect(page.locator(PageModel.publish.text.editor)).toContainText('File Import – Playwright');
 
         // replace playwright file
-        await Helpers.openFileImportModal(page, 'assets/Playwright - Replace.docx');
+        await Helpers.openFileImportModal(page, assetsDirName + 'Playwright - Replace.docx');
         await page.locator(PageModel.publish.replaceButton).click();
 
         // Ensure modal has closed and file import
@@ -1966,12 +1968,12 @@ test.describe('Publication Flow + File import', () => {
         ]);
 
         const validImageFiles = [
-            'assets/apng-image-test.png',
-            'assets/avif-image-test.avif',
-            'assets/gif-image-test.gif',
-            'assets/jpeg-image-test.jpeg',
-            'assets/jpg-image-test.jpg',
-            'assets/webp-image-test.webp'
+            assetsDirName + 'apng-image-test.png',
+            assetsDirName + 'avif-image-test.avif',
+            assetsDirName + 'gif-image-test.gif',
+            assetsDirName + 'jpeg-image-test.jpeg',
+            assetsDirName + 'jpg-image-test.jpg',
+            assetsDirName + 'webp-image-test.webp'
         ];
 
         // import correct file formats
@@ -1993,7 +1995,7 @@ test.describe('Publication Flow + File import', () => {
         await expect(page.locator('button[title="Upload image"]')).not.toBeVisible();
         for (const image of validImageFiles) {
             await expect(
-                page.locator(`div[contenteditable="true"] img[title="${image.split('assets/').pop()}"]`)
+                page.locator(`div[contenteditable="true"] img[title="${image.split(assetsDirName).pop()}"]`)
             ).toBeVisible();
         }
 
@@ -2003,7 +2005,7 @@ test.describe('Publication Flow + File import', () => {
             page.waitForEvent('filechooser'),
             page.click('label[for="file-upload"]')
         ]);
-        await fileChooser2.setFiles(['assets/Playwright.docx']);
+        await fileChooser2.setFiles([assetsDirName + 'Playwright.docx']);
         await page.click('button[title="Upload image"]');
         await expect(page.getByText('Failed to upload "Playwright.docx". The format is not supported.')).toBeVisible();
     });

--- a/ui/next-env.d.ts
+++ b/ui/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -35,7 +35,7 @@
                 "jsonwebtoken": "^9.0.2",
                 "luxon": "^3.4.4",
                 "mammoth": "^1.7.0",
-                "next": "^14.1.3",
+                "next": "^14.2.13",
                 "next-nprogress-bar": "^2.3.5",
                 "react": "^18.2.0",
                 "react-beautiful-dnd": "^13.1.1",
@@ -1978,9 +1978,9 @@
             }
         },
         "node_modules/@next/env": {
-            "version": "14.1.3",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-14.1.3.tgz",
-            "integrity": "sha512-VhgXTvrgeBRxNPjyfBsDIMvgsKDxjlpw4IAUsHCX8Gjl1vtHUYRT3+xfQ/wwvLPDd/6kqfLqk9Pt4+7gysuCKQ=="
+            "version": "14.2.13",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.13.tgz",
+            "integrity": "sha512-s3lh6K8cbW1h5Nga7NNeXrbe0+2jIIYK9YaA9T7IufDWnZpozdFUp6Hf0d5rNWUKu4fEuSX2rCKlGjCrtylfDw=="
         },
         "node_modules/@next/eslint-plugin-next": {
             "version": "14.1.3",
@@ -2038,9 +2038,9 @@
             }
         },
         "node_modules/@next/swc-darwin-arm64": {
-            "version": "14.1.3",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.1.3.tgz",
-            "integrity": "sha512-LALu0yIBPRiG9ANrD5ncB3pjpO0Gli9ZLhxdOu6ZUNf3x1r3ea1rd9Q+4xxUkGrUXLqKVK9/lDkpYIJaCJ6AHQ==",
+            "version": "14.2.13",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.13.tgz",
+            "integrity": "sha512-IkAmQEa2Htq+wHACBxOsslt+jMoV3msvxCn0WFSfJSkv/scy+i/EukBKNad36grRxywaXUYJc9mxEGkeIs8Bzg==",
             "cpu": [
                 "arm64"
             ],
@@ -2053,9 +2053,9 @@
             }
         },
         "node_modules/@next/swc-darwin-x64": {
-            "version": "14.1.3",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.3.tgz",
-            "integrity": "sha512-E/9WQeXxkqw2dfcn5UcjApFgUq73jqNKaE5bysDm58hEUdUGedVrnRhblhJM7HbCZNhtVl0j+6TXsK0PuzXTCg==",
+            "version": "14.2.13",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.13.tgz",
+            "integrity": "sha512-Dv1RBGs2TTjkwEnFMVL5XIfJEavnLqqwYSD6LXgTPdEy/u6FlSrLBSSfe1pcfqhFEXRAgVL3Wpjibe5wXJzWog==",
             "cpu": [
                 "x64"
             ],
@@ -2068,9 +2068,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "14.1.3",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.1.3.tgz",
-            "integrity": "sha512-USArX9B+3rZSXYLFvgy0NVWQgqh6LHWDmMt38O4lmiJNQcwazeI6xRvSsliDLKt+78KChVacNiwvOMbl6g6BBw==",
+            "version": "14.2.13",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.13.tgz",
+            "integrity": "sha512-yB1tYEFFqo4ZNWkwrJultbsw7NPAAxlPXURXioRl9SdW6aIefOLS+0TEsKrWBtbJ9moTDgU3HRILL6QBQnMevg==",
             "cpu": [
                 "arm64"
             ],
@@ -2083,9 +2083,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "14.1.3",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.1.3.tgz",
-            "integrity": "sha512-esk1RkRBLSIEp1qaQXv1+s6ZdYzuVCnDAZySpa62iFTMGTisCyNQmqyCTL9P+cLJ4N9FKCI3ojtSfsyPHJDQNw==",
+            "version": "14.2.13",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.13.tgz",
+            "integrity": "sha512-v5jZ/FV/eHGoWhMKYrsAweQ7CWb8xsWGM/8m1mwwZQ/sutJjoFaXchwK4pX8NqwImILEvQmZWyb8pPTcP7htWg==",
             "cpu": [
                 "arm64"
             ],
@@ -2098,9 +2098,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-gnu": {
-            "version": "14.1.3",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.1.3.tgz",
-            "integrity": "sha512-8uOgRlYEYiKo0L8YGeS+3TudHVDWDjPVDUcST+z+dUzgBbTEwSSIaSgF/vkcC1T/iwl4QX9iuUyUdQEl0Kxalg==",
+            "version": "14.2.13",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.13.tgz",
+            "integrity": "sha512-aVc7m4YL7ViiRv7SOXK3RplXzOEe/qQzRA5R2vpXboHABs3w8vtFslGTz+5tKiQzWUmTmBNVW0UQdhkKRORmGA==",
             "cpu": [
                 "x64"
             ],
@@ -2113,9 +2113,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-musl": {
-            "version": "14.1.3",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.1.3.tgz",
-            "integrity": "sha512-DX2zqz05ziElLoxskgHasaJBREC5Y9TJcbR2LYqu4r7naff25B4iXkfXWfcp69uD75/0URmmoSgT8JclJtrBoQ==",
+            "version": "14.2.13",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.13.tgz",
+            "integrity": "sha512-4wWY7/OsSaJOOKvMsu1Teylku7vKyTuocvDLTZQq0TYv9OjiYYWt63PiE1nTuZnqQ4RPvME7Xai+9enoiN0Wrg==",
             "cpu": [
                 "x64"
             ],
@@ -2128,9 +2128,9 @@
             }
         },
         "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "14.1.3",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.3.tgz",
-            "integrity": "sha512-HjssFsCdsD4GHstXSQxsi2l70F/5FsRTRQp8xNgmQs15SxUfUJRvSI9qKny/jLkY3gLgiCR3+6A7wzzK0DBlfA==",
+            "version": "14.2.13",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.13.tgz",
+            "integrity": "sha512-uP1XkqCqV2NVH9+g2sC7qIw+w2tRbcMiXFEbMihkQ8B1+V6m28sshBwAB0SDmOe0u44ne1vFU66+gx/28RsBVQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2143,9 +2143,9 @@
             }
         },
         "node_modules/@next/swc-win32-ia32-msvc": {
-            "version": "14.1.3",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.3.tgz",
-            "integrity": "sha512-DRuxD5axfDM1/Ue4VahwSxl1O5rn61hX8/sF0HY8y0iCbpqdxw3rB3QasdHn/LJ6Wb2y5DoWzXcz3L1Cr+Thrw==",
+            "version": "14.2.13",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.13.tgz",
+            "integrity": "sha512-V26ezyjPqQpDBV4lcWIh8B/QICQ4v+M5Bo9ykLN+sqeKKBxJVDpEc6biDVyluTXTC40f5IqCU0ttth7Es2ZuMw==",
             "cpu": [
                 "ia32"
             ],
@@ -2158,9 +2158,9 @@
             }
         },
         "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "14.1.3",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.3.tgz",
-            "integrity": "sha512-uC2DaDoWH7h1P/aJ4Fok3Xiw6P0Lo4ez7NbowW2VGNXw/Xv6tOuLUcxhBYZxsSUJtpeknCi8/fvnSpyCFp4Rcg==",
+            "version": "14.2.13",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.13.tgz",
+            "integrity": "sha512-WwzOEAFBGhlDHE5Z73mNU8CO8mqMNLqaG+AO9ETmzdCQlJhVtWZnOl2+rqgVQS+YHunjOWptdFmNfbpwcUuEsw==",
             "cpu": [
                 "x64"
             ],
@@ -2501,11 +2501,17 @@
                 "next": ">= 9.5.5"
             }
         },
+        "node_modules/@swc/counter": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+            "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="
+        },
         "node_modules/@swc/helpers": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
-            "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
+            "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
             "dependencies": {
+                "@swc/counter": "^0.1.3",
                 "tslib": "^2.4.0"
             }
         },
@@ -11298,12 +11304,12 @@
             }
         },
         "node_modules/next": {
-            "version": "14.1.3",
-            "resolved": "https://registry.npmjs.org/next/-/next-14.1.3.tgz",
-            "integrity": "sha512-oexgMV2MapI0UIWiXKkixF8J8ORxpy64OuJ/J9oVUmIthXOUCcuVEZX+dtpgq7wIfIqtBwQsKEDXejcjTsan9g==",
+            "version": "14.2.13",
+            "resolved": "https://registry.npmjs.org/next/-/next-14.2.13.tgz",
+            "integrity": "sha512-BseY9YNw8QJSwLYD7hlZzl6QVDoSFHL/URN5K64kVEVpCsSOWeyjbIGK+dZUaRViHTaMQX8aqmnn0PHBbGZezg==",
             "dependencies": {
-                "@next/env": "14.1.3",
-                "@swc/helpers": "0.5.2",
+                "@next/env": "14.2.13",
+                "@swc/helpers": "0.5.5",
                 "busboy": "1.6.0",
                 "caniuse-lite": "^1.0.30001579",
                 "graceful-fs": "^4.2.11",
@@ -11317,24 +11323,28 @@
                 "node": ">=18.17.0"
             },
             "optionalDependencies": {
-                "@next/swc-darwin-arm64": "14.1.3",
-                "@next/swc-darwin-x64": "14.1.3",
-                "@next/swc-linux-arm64-gnu": "14.1.3",
-                "@next/swc-linux-arm64-musl": "14.1.3",
-                "@next/swc-linux-x64-gnu": "14.1.3",
-                "@next/swc-linux-x64-musl": "14.1.3",
-                "@next/swc-win32-arm64-msvc": "14.1.3",
-                "@next/swc-win32-ia32-msvc": "14.1.3",
-                "@next/swc-win32-x64-msvc": "14.1.3"
+                "@next/swc-darwin-arm64": "14.2.13",
+                "@next/swc-darwin-x64": "14.2.13",
+                "@next/swc-linux-arm64-gnu": "14.2.13",
+                "@next/swc-linux-arm64-musl": "14.2.13",
+                "@next/swc-linux-x64-gnu": "14.2.13",
+                "@next/swc-linux-x64-musl": "14.2.13",
+                "@next/swc-win32-arm64-msvc": "14.2.13",
+                "@next/swc-win32-ia32-msvc": "14.2.13",
+                "@next/swc-win32-x64-msvc": "14.2.13"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.1.0",
+                "@playwright/test": "^1.41.2",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "sass": "^1.3.0"
             },
             "peerDependenciesMeta": {
                 "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@playwright/test": {
                     "optional": true
                 },
                 "sass": {
@@ -16699,9 +16709,9 @@
             }
         },
         "@next/env": {
-            "version": "14.1.3",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-14.1.3.tgz",
-            "integrity": "sha512-VhgXTvrgeBRxNPjyfBsDIMvgsKDxjlpw4IAUsHCX8Gjl1vtHUYRT3+xfQ/wwvLPDd/6kqfLqk9Pt4+7gysuCKQ=="
+            "version": "14.2.13",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.13.tgz",
+            "integrity": "sha512-s3lh6K8cbW1h5Nga7NNeXrbe0+2jIIYK9YaA9T7IufDWnZpozdFUp6Hf0d5rNWUKu4fEuSX2rCKlGjCrtylfDw=="
         },
         "@next/eslint-plugin-next": {
             "version": "14.1.3",
@@ -16746,57 +16756,57 @@
             }
         },
         "@next/swc-darwin-arm64": {
-            "version": "14.1.3",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.1.3.tgz",
-            "integrity": "sha512-LALu0yIBPRiG9ANrD5ncB3pjpO0Gli9ZLhxdOu6ZUNf3x1r3ea1rd9Q+4xxUkGrUXLqKVK9/lDkpYIJaCJ6AHQ==",
+            "version": "14.2.13",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.13.tgz",
+            "integrity": "sha512-IkAmQEa2Htq+wHACBxOsslt+jMoV3msvxCn0WFSfJSkv/scy+i/EukBKNad36grRxywaXUYJc9mxEGkeIs8Bzg==",
             "optional": true
         },
         "@next/swc-darwin-x64": {
-            "version": "14.1.3",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.1.3.tgz",
-            "integrity": "sha512-E/9WQeXxkqw2dfcn5UcjApFgUq73jqNKaE5bysDm58hEUdUGedVrnRhblhJM7HbCZNhtVl0j+6TXsK0PuzXTCg==",
+            "version": "14.2.13",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.13.tgz",
+            "integrity": "sha512-Dv1RBGs2TTjkwEnFMVL5XIfJEavnLqqwYSD6LXgTPdEy/u6FlSrLBSSfe1pcfqhFEXRAgVL3Wpjibe5wXJzWog==",
             "optional": true
         },
         "@next/swc-linux-arm64-gnu": {
-            "version": "14.1.3",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.1.3.tgz",
-            "integrity": "sha512-USArX9B+3rZSXYLFvgy0NVWQgqh6LHWDmMt38O4lmiJNQcwazeI6xRvSsliDLKt+78KChVacNiwvOMbl6g6BBw==",
+            "version": "14.2.13",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.13.tgz",
+            "integrity": "sha512-yB1tYEFFqo4ZNWkwrJultbsw7NPAAxlPXURXioRl9SdW6aIefOLS+0TEsKrWBtbJ9moTDgU3HRILL6QBQnMevg==",
             "optional": true
         },
         "@next/swc-linux-arm64-musl": {
-            "version": "14.1.3",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.1.3.tgz",
-            "integrity": "sha512-esk1RkRBLSIEp1qaQXv1+s6ZdYzuVCnDAZySpa62iFTMGTisCyNQmqyCTL9P+cLJ4N9FKCI3ojtSfsyPHJDQNw==",
+            "version": "14.2.13",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.13.tgz",
+            "integrity": "sha512-v5jZ/FV/eHGoWhMKYrsAweQ7CWb8xsWGM/8m1mwwZQ/sutJjoFaXchwK4pX8NqwImILEvQmZWyb8pPTcP7htWg==",
             "optional": true
         },
         "@next/swc-linux-x64-gnu": {
-            "version": "14.1.3",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.1.3.tgz",
-            "integrity": "sha512-8uOgRlYEYiKo0L8YGeS+3TudHVDWDjPVDUcST+z+dUzgBbTEwSSIaSgF/vkcC1T/iwl4QX9iuUyUdQEl0Kxalg==",
+            "version": "14.2.13",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.13.tgz",
+            "integrity": "sha512-aVc7m4YL7ViiRv7SOXK3RplXzOEe/qQzRA5R2vpXboHABs3w8vtFslGTz+5tKiQzWUmTmBNVW0UQdhkKRORmGA==",
             "optional": true
         },
         "@next/swc-linux-x64-musl": {
-            "version": "14.1.3",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.1.3.tgz",
-            "integrity": "sha512-DX2zqz05ziElLoxskgHasaJBREC5Y9TJcbR2LYqu4r7naff25B4iXkfXWfcp69uD75/0URmmoSgT8JclJtrBoQ==",
+            "version": "14.2.13",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.13.tgz",
+            "integrity": "sha512-4wWY7/OsSaJOOKvMsu1Teylku7vKyTuocvDLTZQq0TYv9OjiYYWt63PiE1nTuZnqQ4RPvME7Xai+9enoiN0Wrg==",
             "optional": true
         },
         "@next/swc-win32-arm64-msvc": {
-            "version": "14.1.3",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.1.3.tgz",
-            "integrity": "sha512-HjssFsCdsD4GHstXSQxsi2l70F/5FsRTRQp8xNgmQs15SxUfUJRvSI9qKny/jLkY3gLgiCR3+6A7wzzK0DBlfA==",
+            "version": "14.2.13",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.13.tgz",
+            "integrity": "sha512-uP1XkqCqV2NVH9+g2sC7qIw+w2tRbcMiXFEbMihkQ8B1+V6m28sshBwAB0SDmOe0u44ne1vFU66+gx/28RsBVQ==",
             "optional": true
         },
         "@next/swc-win32-ia32-msvc": {
-            "version": "14.1.3",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.1.3.tgz",
-            "integrity": "sha512-DRuxD5axfDM1/Ue4VahwSxl1O5rn61hX8/sF0HY8y0iCbpqdxw3rB3QasdHn/LJ6Wb2y5DoWzXcz3L1Cr+Thrw==",
+            "version": "14.2.13",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.13.tgz",
+            "integrity": "sha512-V26ezyjPqQpDBV4lcWIh8B/QICQ4v+M5Bo9ykLN+sqeKKBxJVDpEc6biDVyluTXTC40f5IqCU0ttth7Es2ZuMw==",
             "optional": true
         },
         "@next/swc-win32-x64-msvc": {
-            "version": "14.1.3",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.1.3.tgz",
-            "integrity": "sha512-uC2DaDoWH7h1P/aJ4Fok3Xiw6P0Lo4ez7NbowW2VGNXw/Xv6tOuLUcxhBYZxsSUJtpeknCi8/fvnSpyCFp4Rcg==",
+            "version": "14.2.13",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.13.tgz",
+            "integrity": "sha512-WwzOEAFBGhlDHE5Z73mNU8CO8mqMNLqaG+AO9ETmzdCQlJhVtWZnOl2+rqgVQS+YHunjOWptdFmNfbpwcUuEsw==",
             "optional": true
         },
         "@noble/hashes": {
@@ -17074,11 +17084,17 @@
             "integrity": "sha512-H6wm5zroqtBcsu1lWG78UQC6X7qj66jQD0o36GRiMSLrABCKP/QwbyLykc7Q0xlxsseJW1IWwSwbBa+9jr6f5Q==",
             "requires": {}
         },
+        "@swc/counter": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+            "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="
+        },
         "@swc/helpers": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
-            "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
+            "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
             "requires": {
+                "@swc/counter": "^0.1.3",
                 "tslib": "^2.4.0"
             }
         },
@@ -23557,21 +23573,21 @@
             "dev": true
         },
         "next": {
-            "version": "14.1.3",
-            "resolved": "https://registry.npmjs.org/next/-/next-14.1.3.tgz",
-            "integrity": "sha512-oexgMV2MapI0UIWiXKkixF8J8ORxpy64OuJ/J9oVUmIthXOUCcuVEZX+dtpgq7wIfIqtBwQsKEDXejcjTsan9g==",
+            "version": "14.2.13",
+            "resolved": "https://registry.npmjs.org/next/-/next-14.2.13.tgz",
+            "integrity": "sha512-BseY9YNw8QJSwLYD7hlZzl6QVDoSFHL/URN5K64kVEVpCsSOWeyjbIGK+dZUaRViHTaMQX8aqmnn0PHBbGZezg==",
             "requires": {
-                "@next/env": "14.1.3",
-                "@next/swc-darwin-arm64": "14.1.3",
-                "@next/swc-darwin-x64": "14.1.3",
-                "@next/swc-linux-arm64-gnu": "14.1.3",
-                "@next/swc-linux-arm64-musl": "14.1.3",
-                "@next/swc-linux-x64-gnu": "14.1.3",
-                "@next/swc-linux-x64-musl": "14.1.3",
-                "@next/swc-win32-arm64-msvc": "14.1.3",
-                "@next/swc-win32-ia32-msvc": "14.1.3",
-                "@next/swc-win32-x64-msvc": "14.1.3",
-                "@swc/helpers": "0.5.2",
+                "@next/env": "14.2.13",
+                "@next/swc-darwin-arm64": "14.2.13",
+                "@next/swc-darwin-x64": "14.2.13",
+                "@next/swc-linux-arm64-gnu": "14.2.13",
+                "@next/swc-linux-arm64-musl": "14.2.13",
+                "@next/swc-linux-x64-gnu": "14.2.13",
+                "@next/swc-linux-x64-musl": "14.2.13",
+                "@next/swc-win32-arm64-msvc": "14.2.13",
+                "@next/swc-win32-ia32-msvc": "14.2.13",
+                "@next/swc-win32-x64-msvc": "14.2.13",
+                "@swc/helpers": "0.5.5",
                 "busboy": "1.6.0",
                 "caniuse-lite": "^1.0.30001579",
                 "graceful-fs": "^4.2.11",

--- a/ui/package.json
+++ b/ui/package.json
@@ -50,7 +50,7 @@
         "jsonwebtoken": "^9.0.2",
         "luxon": "^3.4.4",
         "mammoth": "^1.7.0",
-        "next": "^14.1.3",
+        "next": "^14.2.13",
         "next-nprogress-bar": "^2.3.5",
         "react": "^18.2.0",
         "react-beautiful-dnd": "^13.1.1",


### PR DESCRIPTION
The purpose of this PR was to update nextJS in order to remediate a security issue reported by Snyk.

I cherry-picked a commit from another pending PR to get end to end tests to run, so that's why this presents changes to those files.

---

### Acceptance Criteria:

Octopus uses NextJS 14.2.10 or higher.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
![Screenshot 2024-09-25 130931](https://github.com/user-attachments/assets/332d3fbf-2404-463d-ba01-372a32f42488)

E2E
![Screenshot 2024-09-25 130857](https://github.com/user-attachments/assets/178753b0-8fcc-489d-a649-b17874e169e2)
