### PR TITLE
OC-911: ARI ingest dry runs

### DIFF
--- a/api/serverless-config-default.yml
+++ b/api/serverless-config-default.yml
@@ -493,14 +493,19 @@ functions:
                 method: GET
                 cors: true
     # Integrations
-    incrementalAriIngest:
+    incrementalAriIngestHttp:
         handler: src/components/integration/routes.incrementalAriIngest
         timeout: 900
         events:
-            - schedule:
-                rate: cron(0 5 ? * TUE *) # Every Tuesday at 5 a.m.
-                enabled: ${self:custom.scheduledAriIngestEnabled.${opt:stage}, false}
             - http:
                 path: ${self:custom.versions.v1}/integrations/ari/incremental
                 method: POST
                 cors: true
+    # Commented out - for the time being ARI ingests will just be manually triggered.
+    # incrementalAriIngestScheduled:
+    #     handler: src/components/integration/controller.incrementalAriIngest
+    #     timeout: 900
+    #     events:
+    #         - schedule:
+    #             rate: cron(0 5 ? * TUE *) # Every Tuesday at 5 a.m.
+    #             enabled: ${self:custom.scheduledAriIngestEnabled.${opt:stage}, false}

--- a/api/src/components/integration/__tests__/ari.test.ts
+++ b/api/src/components/integration/__tests__/ari.test.ts
@@ -396,9 +396,16 @@ describe('ARI import processes', () => {
     test('Incremental import endpoint requires API key', async () => {
         const triggerImport = await testUtils.agent.post('/integrations/ari/incremental');
 
-        expect(triggerImport.status).toEqual(401);
+        expect(triggerImport.status).toEqual(400);
         expect(triggerImport.body).toMatchObject({
-            message: "Please provide a valid 'apiKey'."
+            message: [
+                {
+                    keyword: 'required',
+                    params: {
+                        missingProperty: 'apiKey'
+                    }
+                }
+            ]
         });
     });
 

--- a/api/src/components/integration/ariUtils.ts
+++ b/api/src/components/integration/ariUtils.ts
@@ -172,7 +172,7 @@ export const detectChangesToARIPublication = (
     return somethingChanged ? changes : false;
 };
 
-export const handleIncomingARI = async (question: I.ARIQuestion): Promise<I.HandledARI> => {
+export const handleIncomingARI = async (question: I.ARIQuestion, dryRun?: boolean): Promise<I.HandledARI> => {
     // Validate question ID.
     // Quite random criteria for now - value is typed as a number which
     // stops us checking the type. May be revisited later.
@@ -237,6 +237,14 @@ export const handleIncomingARI = async (question: I.ARIQuestion): Promise<I.Hand
 
     // If the ARI has not been ingested previously, a new research problem is created.
     if (!existingPublication) {
+        if (dryRun) {
+            return {
+                ...baseReturnObject,
+                actionTaken: 'create',
+                success: true
+            };
+        }
+
         const newPublication = await publicationService.create(
             { ...mappedData, type: 'PROBLEM', conflictOfInterestStatus: false },
             user,
@@ -287,6 +295,15 @@ export const handleIncomingARI = async (question: I.ARIQuestion): Promise<I.Hand
 
     if (changes) {
         console.log(`Changes found when handling ARI ${question.questionId}`, changes);
+
+        if (dryRun) {
+            return {
+                ...baseReturnObject,
+                actionTaken: 'update',
+                success: true
+            };
+        }
+
         // Data differs from what is in octopus, so update the publication.
         // Unlike manually created publications, these just have 1 version that
         // updates in-place so that we don't pollute datacite with lots of version DOIs.

--- a/api/src/components/integration/routes.ts
+++ b/api/src/components/integration/routes.ts
@@ -1,3 +1,9 @@
-import * as integrationController from 'integration/controller';
+import middy from '@middy/core';
 
-export const incrementalAriIngest = integrationController.incrementalAriIngest;
+import * as integrationController from 'integration/controller';
+import * as integrationSchema from 'integration/schema';
+import * as middleware from 'middleware';
+
+export const incrementalAriIngest = middy(integrationController.incrementalAriIngest)
+    .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))
+    .use(middleware.validator(integrationSchema.incrementalAriIngestHttp, 'queryStringParameters'));

--- a/api/src/components/integration/schema/incrementalAriIngestHttp.ts
+++ b/api/src/components/integration/schema/incrementalAriIngestHttp.ts
@@ -1,0 +1,17 @@
+import * as I from 'interface';
+
+const incrementalAriIngestHttpSchema: I.Schema = {
+    type: 'object',
+    properties: {
+        apiKey: {
+            type: 'string'
+        },
+        dryRun: {
+            type: 'boolean'
+        }
+    },
+    additionalProperties: false,
+    required: ['apiKey']
+};
+
+export default incrementalAriIngestHttpSchema;

--- a/api/src/components/integration/schema/index.ts
+++ b/api/src/components/integration/schema/index.ts
@@ -1,0 +1,1 @@
+export { default as incrementalAriIngestHttp } from './incrementalAriIngestHttp';

--- a/api/src/lib/email.ts
+++ b/api/src/lib/email.ts
@@ -941,7 +941,7 @@ export const incrementalAriIngestReport = async (options: {
                   createdCount + updatedCount / 2
               } additional seconds due to datacite API rate limits while creating/updating publications.`
             : '');
-    const detailsPrefix = `The ${dryRun ? 'simulated ' : ''} results of this run are as follows.`;
+    const detailsPrefix = `The ${dryRun ? 'simulated ' : ''}results of this run are as follows.`;
     const html = `
         <html>
             <body>

--- a/api/src/lib/email.ts
+++ b/api/src/lib/email.ts
@@ -928,17 +928,30 @@ export const incrementalAriIngestReport = async (options: {
     updatedCount: number;
     unrecognisedDepartments: string[];
     unrecognisedTopics: string[];
+    dryRun: boolean;
 }): Promise<void> => {
+    const { createdCount, dryRun, updatedCount } = options;
     const cleanDepartments = options.unrecognisedDepartments.map((department) => Helpers.getSafeHTML(department));
     const cleanTopics = options.unrecognisedTopics.map((topic) => Helpers.getSafeHTML(topic));
+    const intro = `Incremental ARI import ${dryRun ? 'dry ' : ''}run completed.`;
+    const timingInfo =
+        `Duration: ${options.durationSeconds} seconds.` +
+        (dryRun && (createdCount || updatedCount)
+            ? ` A real run would have taken a minimum of ${
+                  createdCount + updatedCount / 2
+              } additional seconds due to datacite API rate limits while creating/updating publications.`
+            : '');
+    const detailsPrefix = `The ${dryRun ? 'simulated ' : ''} results of this run are as follows.`;
     const html = `
         <html>
             <body>
-                <p>Incremental ARI import run completed in ${options.durationSeconds} seconds.</p>
+                <p>${intro}</p>
+                <p>${timingInfo}</p>
+                <p>${detailsPrefix}</p>
                 <ul>
-                    <li>ARIs checked: ${options.checkedCount}</li><li>Publications created: ${
-        options.createdCount
-    }</li><li>Publications updated: ${options.updatedCount}</li>
+                    <li>ARIs checked: ${options.checkedCount}</li>
+                    <li>Publications created: ${createdCount}</li>
+                    <li>Publications updated: ${updatedCount}</li>
                     ${
                         cleanDepartments.length
                             ? '<li>Unrecognised departments: <ul><li>' +
@@ -956,20 +969,18 @@ export const incrementalAriIngestReport = async (options: {
         </html>
     `;
     const text = `
-        Incremental ARI ingest run completed in ${options.durationSeconds} seconds.
-        ARIs checked: ${options.checkedCount}.
-        Publications created: ${options.createdCount}.
-        Publications updated: ${options.updatedCount}.
-        ${
-            options.unrecognisedDepartments.length
-                ? 'Unrecognised departments: "' + options.unrecognisedDepartments.join('", "') + '".'
-                : ''
-        }
-        ${
-            options.unrecognisedTopics.length
-                ? 'Unrecognised topics: "' + options.unrecognisedTopics.join('", "') + '".'
-                : ''
-        }`;
+${intro}
+${timingInfo}
+${detailsPrefix} 
+ARIs checked: ${options.checkedCount}.
+Publications created: ${options.createdCount}.
+Publications updated: ${options.updatedCount}.
+${
+    options.unrecognisedDepartments.length
+        ? 'Unrecognised departments: "' + options.unrecognisedDepartments.join('", "') + '".'
+        : ''
+}
+${options.unrecognisedTopics.length ? 'Unrecognised topics: "' + options.unrecognisedTopics.join('", "') + '".' : ''}`;
     await send({
         html,
         text,


### PR DESCRIPTION
The purpose of this PR was to add a dry run feature to the ARI integration. In order to test the ARI integration, and to avoid the risk of the ingest timing out if a high number of ARIs need to be updated/created, a dry run feature is needed to check how the ingest will behave before each run.

---

### Acceptance Criteria:

- The endpoint to run the ingest operation on int or prod now contains a dry run parameter
    - Enabling this option will cause the ingest to run without actually making any changes, including:
        - No new ARIs are created, nor any updates to existing ARIs
        - No updates to the log of previous ingests that was created as part of OC-910
        - The email (see OC-888) is still returned upon completion of the operation, including stats for what would’ve been created
---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

E2E
![Screenshot 2024-09-26 114359](https://github.com/user-attachments/assets/f1769cf8-c0f9-453a-8d2c-b3b5bd4bb71e)

API
![Screenshot 2024-09-26 115625](https://github.com/user-attachments/assets/4585e197-356f-495d-a910-136e92517ff0)

---

### Screenshots:

Note that the double space before "results" was fixed in a later commit after these screenshots were taken.

Dry run email (HTML/text):
![Screenshot 2024-09-26 103729](https://github.com/user-attachments/assets/4afc5179-4c8f-48f0-a6a7-5cc4189575fc)
![Screenshot 2024-09-26 103839](https://github.com/user-attachments/assets/2e994545-4cc0-41bc-ad31-fa19bf117a3c)

Subsequent real run email (HTML/text):
![Screenshot 2024-09-26 103903](https://github.com/user-attachments/assets/535160a9-d4ca-4a83-9e30-0198a48cf36f)
![Screenshot 2024-09-26 103910](https://github.com/user-attachments/assets/f0d831d9-a80f-4a55-b05d-4d21523d9aa8)

This is what would be output in the email if the dry run was run without any ARIs having been imported previously (we are aware the topics are not recognised):
![Screenshot 2024-09-26 093553](https://github.com/user-attachments/assets/60133367-741b-409a-8609-8c40ab81fb9f)
