### PR TITLE
OC-902: Update mail lambda functions to use python 3.12

### DIFF
--- a/infra/modules/ses/main.tf
+++ b/infra/modules/ses/main.tf
@@ -106,7 +106,7 @@ resource "aws_lambda_function" "forward_mail" {
   count            = length(keys(local.email_address_map))
   function_name    = "mail-${var.environment}-${replace(nonsensitive(element(keys(local.email_address_map), count.index)), "/@|\\./", "-")}"
   handler          = "lambda_function.lambda_handler"
-  runtime          = "python3.8"
+  runtime          = "python3.12"
   filename         = "${path.module}/forward-mail.zip"
   source_code_hash = filebase64sha256("${path.module}/forward-mail.zip")
   role             = aws_iam_role.inbound_email_role.arn


### PR DESCRIPTION
The purpose of this PR was to update the runtime of our mail functions which have been using python3.8, which goes out of support on 14/10/24.

This has already been deployed.

---

### Acceptance Criteria:

Mail forwarding lambda functions are using python 3.12 runtime and still work.

---

### Checklist:

- [ ] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Screenshots:

Confirmed that mail is still received via these forwarding functions:
![Screenshot 2024-10-03 131437](https://github.com/user-attachments/assets/e0a9c6d0-3018-4c5c-91af-47690e557df4)