### PR TITLE
OC-928: Remove emails from JSON exports

### DIFF
--- a/api/serverless-config-default.yml
+++ b/api/serverless-config-default.yml
@@ -191,7 +191,7 @@ functions:
                 cors: true
     # CoAuthors
     getCoAuthors:
-        handler: src/components/coauthor/routes.get
+        handler: src/components/coauthor/routes.getAll
         events:
             - http:
                 path: ${self:custom.versions.v1}/publication-versions/{publicationVersionId}/coauthors

--- a/api/src/components/coauthor/__tests__/getCoAuthors.test.ts
+++ b/api/src/components/coauthor/__tests__/getCoAuthors.test.ts
@@ -1,0 +1,67 @@
+import * as testUtils from 'lib/testUtils';
+
+describe('Get co-authors of a publication version', () => {
+    beforeAll(async () => {
+        await testUtils.clearDB();
+        await testUtils.testSeed();
+    });
+
+    test('Corresponding author can get co-authors', async () => {
+        const getCoAuthors = await testUtils.agent
+            .get('/publication-versions/publication-problem-draft-v1/coauthors')
+            .query({ apiKey: '000000005' });
+
+        expect(getCoAuthors.status).toEqual(200);
+        expect(getCoAuthors.body).toMatchObject([
+            {
+                id: 'coauthor-test-user-5-problem-draft',
+                email: 'test-user-5@jisc.ac.uk',
+                confirmedCoAuthor: true,
+                linkedUser: 'test-user-5',
+                isIndependent: true,
+                affiliations: []
+            },
+            {
+                id: 'coauthor-test-user-6-problem-draft',
+                email: 'test-user-6@jisc.ac.uk',
+                confirmedCoAuthor: true,
+                linkedUser: 'test-user-6'
+            },
+            {
+                id: 'coauthor-test-user-7-problem-draft',
+                email: 'test-user-7@jisc.ac.uk',
+                confirmedCoAuthor: false
+            },
+            {
+                id: 'coauthor-test-user-8-problem-draft',
+                email: 'test-user-8@jisc.ac.uk',
+                confirmedCoAuthor: false
+            }
+        ]);
+    });
+
+    test('Co-author can get co-authors', async () => {
+        const getCoAuthors = await testUtils.agent
+            .get('/publication-versions/publication-problem-draft-v1/coauthors')
+            .query({ apiKey: '000000006' });
+
+        expect(getCoAuthors.status).toEqual(200);
+    });
+
+    test('Authenticated user who is not a confirmed co-author cannot get co-authors', async () => {
+        const getCoAuthors = await testUtils.agent
+            .get('/publication-versions/publication-problem-draft-v1/coauthors')
+            .query({ apiKey: '000000007' });
+
+        expect(getCoAuthors.status).toEqual(403);
+        expect(getCoAuthors.body.message).toEqual(
+            'You do not have permission to view the co-authors of this publication version.'
+        );
+    });
+
+    test('Anonymous user cannot get co-authors', async () => {
+        const getCoAuthors = await testUtils.agent.get('/publication-versions/publication-problem-draft-v1/coauthors');
+
+        expect(getCoAuthors.status).toEqual(401);
+    });
+});

--- a/api/src/components/coauthor/routes.ts
+++ b/api/src/components/coauthor/routes.ts
@@ -4,7 +4,7 @@ import * as middleware from 'middleware';
 import * as coAuthorController from 'coAuthor/controller';
 import * as coAuthorSchema from 'coAuthor/schema';
 
-export const get = middy(coAuthorController.get)
+export const getAll = middy(coAuthorController.getAll)
     .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))
     .use(middleware.httpJsonBodyParser())
     .use(middleware.authentication());

--- a/api/src/components/coauthor/service.ts
+++ b/api/src/components/coauthor/service.ts
@@ -233,7 +233,7 @@ export const updateRequestApprovalStatus = async (publicationVersionId: string, 
     return coAuthors;
 };
 
-export const createCorrespondingAuthor = async (publicationVersion: I.PublicationVersion) => {
+export const createCorrespondingCoAuthor = async (publicationVersion: I.PrivatePublicationVersion) => {
     const create = client.prisma.coAuthors.create({
         data: {
             email: publicationVersion.user.email || '',

--- a/api/src/components/event/service.ts
+++ b/api/src/components/event/service.ts
@@ -71,7 +71,7 @@ export const processRequestControlEvents = async (requestControlEvents: I.Reques
                     requesterId
                 } = requestControlEvent.data;
 
-                const publicationVersion = await publicationVersionService.getById(publicationVersionId);
+                const publicationVersion = await publicationVersionService.privateGetById(publicationVersionId);
                 const requester = await userService.get(requesterId, true);
 
                 if (!publicationVersion) {

--- a/api/src/components/flag/controller.ts
+++ b/api/src/components/flag/controller.ts
@@ -71,7 +71,7 @@ export const createFlag = async (
             });
         }
 
-        const publication = await publicationService.get(event.pathParameters.publicationId);
+        const publication = await publicationService.privateGet(event.pathParameters.publicationId);
 
         if (!publication) {
             return response.json(404, {

--- a/api/src/components/integration/ariUtils.ts
+++ b/api/src/components/integration/ariUtils.ts
@@ -320,15 +320,22 @@ export const handleIncomingARI = async (question: I.ARIQuestion, dryRun?: boolea
 
         // If user changed, update coAuthors.
         if (changes.userId) {
-            // Delete old coAuthor.
-            // There should only be one coAuthor but since this is an array, loop through to make it clean.
-            await Promise.all(existingVersion.coAuthors.map((coAuthor) => coAuthorService.deleteCoAuthor(coAuthor.id)));
             // Create a coAuthor based on the userId of the publicationVersion.
-            await coAuthorService.createCorrespondingAuthor(updatedVersion);
-            const versionWithUpdatedCoAuthors = await publicationVersionService.getById(updatedVersion.id);
+            // Get private version for compatibility with createCorrespondingCoAuthor.
+            const privateVersion = await publicationVersionService.privateGetById(updatedVersion.id);
 
-            if (versionWithUpdatedCoAuthors) {
-                updatedVersion = versionWithUpdatedCoAuthors;
+            if (privateVersion) {
+                // Delete old coAuthor.
+                // There should only be one coAuthor but since this is an array, loop through to make it clean.
+                await Promise.all(
+                    existingVersion.coAuthors.map((coAuthor) => coAuthorService.deleteCoAuthor(coAuthor.id))
+                );
+                await coAuthorService.createCorrespondingCoAuthor(privateVersion);
+                const versionWithUpdatedCoAuthors = await publicationVersionService.getById(updatedVersion.id);
+
+                if (versionWithUpdatedCoAuthors) {
+                    updatedVersion = versionWithUpdatedCoAuthors;
+                }
             }
         }
 

--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -15,191 +15,253 @@ export const isIdInUse = async (id: string) => {
     return Boolean(publication);
 };
 
-export const get = async (id: string) => {
-    const publication = await client.prisma.publication.findUnique({
-        where: {
-            id
-        },
+const defaultPublicationInclude = {
+    versions: {
         include: {
-            versions: {
-                include: {
+            user: {
+                select: {
+                    id: true,
+                    orcid: true,
+                    firstName: true,
+                    lastName: true,
+                    createdAt: true,
+                    updatedAt: true,
+                    role: true,
+                    url: true
+                }
+            },
+            publicationStatus: {
+                select: {
+                    status: true,
+                    createdAt: true,
+                    id: true
+                },
+                orderBy: {
+                    createdAt: 'desc'
+                }
+            },
+            funders: {
+                select: {
+                    id: true,
+                    city: true,
+                    country: true,
+                    name: true,
+                    link: true,
+                    ror: true,
+                    grantId: true
+                }
+            },
+            coAuthors: {
+                select: {
+                    id: true,
+                    linkedUser: true,
+                    publicationVersionId: true,
+                    confirmedCoAuthor: true,
+                    approvalRequested: true,
+                    createdAt: true,
+                    reminderDate: true,
+                    isIndependent: true,
+                    affiliations: true,
                     user: {
                         select: {
-                            id: true,
-                            orcid: true,
                             firstName: true,
                             lastName: true,
-                            email: true,
-                            createdAt: true,
-                            updatedAt: true,
+                            orcid: true,
                             role: true,
                             url: true
-                        }
-                    },
-                    publicationStatus: {
-                        select: {
-                            status: true,
-                            createdAt: true,
-                            id: true
-                        },
-                        orderBy: {
-                            createdAt: 'desc'
-                        }
-                    },
-                    funders: {
-                        select: {
-                            id: true,
-                            city: true,
-                            country: true,
-                            name: true,
-                            link: true,
-                            ror: true,
-                            grantId: true
-                        }
-                    },
-                    coAuthors: {
-                        select: {
-                            id: true,
-                            email: true,
-                            linkedUser: true,
-                            publicationVersionId: true,
-                            confirmedCoAuthor: true,
-                            approvalRequested: true,
-                            createdAt: true,
-                            reminderDate: true,
-                            isIndependent: true,
-                            affiliations: true,
-                            user: {
-                                select: {
-                                    firstName: true,
-                                    lastName: true,
-                                    orcid: true,
-                                    role: true,
-                                    url: true
-                                }
-                            }
-                        },
-                        orderBy: {
-                            position: 'asc'
-                        }
-                    },
-                    topics: {
-                        select: {
-                            id: true,
-                            title: true,
-                            createdAt: true
-                        }
-                    },
-                    additionalInformation: {
-                        select: {
-                            id: true,
-                            title: true,
-                            url: true,
-                            description: true,
-                            createdAt: true
                         }
                     }
                 },
                 orderBy: {
-                    versionNumber: 'asc'
+                    position: 'asc'
                 }
             },
-            publicationFlags: {
+            topics: {
                 select: {
                     id: true,
-                    category: true,
-                    resolved: true,
-                    createdBy: true,
+                    title: true,
+                    createdAt: true
+                }
+            },
+            additionalInformation: {
+                select: {
+                    id: true,
+                    title: true,
+                    url: true,
+                    description: true,
+                    createdAt: true
+                }
+            }
+        },
+        orderBy: {
+            versionNumber: 'asc'
+        }
+    },
+    publicationFlags: {
+        select: {
+            id: true,
+            category: true,
+            resolved: true,
+            createdBy: true,
+            createdAt: true,
+            user: {
+                select: {
+                    id: true,
+                    orcid: true,
+                    firstName: true,
+                    lastName: true,
                     createdAt: true,
-                    user: {
-                        select: {
-                            id: true,
-                            orcid: true,
-                            firstName: true,
-                            lastName: true,
-                            email: true,
-                            createdAt: true,
-                            updatedAt: true
-                        }
+                    updatedAt: true
+                }
+            }
+        }
+    },
+    linkedTo: {
+        where: {
+            publicationTo: {
+                versions: {
+                    some: {
+                        isLatestLiveVersion: true
                     }
                 }
-            },
-            linkedTo: {
-                where: {
-                    publicationTo: {
-                        versions: {
-                            some: {
-                                isLatestLiveVersion: true
-                            }
-                        }
-                    }
-                },
+            }
+        },
+        select: {
+            id: true,
+            versionToId: true,
+            publicationToId: true,
+            draft: true,
+            publicationTo: {
                 select: {
                     id: true,
-                    versionToId: true,
-                    publicationToId: true,
-                    draft: true,
-                    publicationTo: {
+                    type: true,
+                    doi: true,
+                    versions: {
                         select: {
-                            id: true,
-                            type: true,
-                            doi: true,
-                            versions: {
-                                select: {
-                                    title: true,
-                                    publishedDate: true,
-                                    currentStatus: true,
-                                    description: true,
-                                    keywords: true
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            linkedFrom: {
-                where: {
-                    publicationFrom: {
-                        versions: {
-                            some: {
-                                isLatestLiveVersion: true
-                            }
-                        }
-                    }
-                },
-                select: {
-                    id: true,
-                    versionToId: true,
-                    publicationFromId: true,
-                    draft: true,
-                    publicationFrom: {
-                        select: {
-                            id: true,
-                            type: true,
-                            doi: true,
-                            versions: {
-                                select: {
-                                    title: true,
-                                    publishedDate: true,
-                                    currentStatus: true,
-                                    description: true,
-                                    keywords: true
-                                }
-                            }
+                            title: true,
+                            publishedDate: true,
+                            currentStatus: true,
+                            description: true,
+                            keywords: true
                         }
                     }
                 }
             }
         }
+    },
+    linkedFrom: {
+        where: {
+            publicationFrom: {
+                versions: {
+                    some: {
+                        isLatestLiveVersion: true
+                    }
+                }
+            }
+        },
+        select: {
+            id: true,
+            versionToId: true,
+            publicationFromId: true,
+            draft: true,
+            publicationFrom: {
+                select: {
+                    id: true,
+                    type: true,
+                    doi: true,
+                    versions: {
+                        select: {
+                            title: true,
+                            publishedDate: true,
+                            currentStatus: true,
+                            description: true,
+                            keywords: true
+                        }
+                    }
+                }
+            }
+        }
+    }
+} satisfies Prisma.PublicationInclude;
+
+// Ugly, but extend the default include to include private information.
+const privatePublicationInclude = {
+    ...defaultPublicationInclude,
+    versions: {
+        ...defaultPublicationInclude.versions,
+        include: {
+            ...defaultPublicationInclude.versions.include,
+            user: {
+                ...defaultPublicationInclude.versions.include.user,
+                select: {
+                    ...defaultPublicationInclude.versions.include.user.select,
+                    email: true
+                }
+            },
+            coAuthors: {
+                ...defaultPublicationInclude.versions.include.coAuthors,
+                select: {
+                    ...defaultPublicationInclude.versions.include.coAuthors.select,
+                    email: true
+                }
+            }
+        }
+    },
+    publicationFlags: {
+        ...defaultPublicationInclude.publicationFlags,
+        select: {
+            ...defaultPublicationInclude.publicationFlags.select,
+            user: {
+                ...defaultPublicationInclude.publicationFlags.select.user,
+                select: {
+                    ...defaultPublicationInclude.publicationFlags.select.user.select,
+                    email: true
+                }
+            }
+        }
+    }
+};
+
+type DefaultFullPublication = Prisma.PublicationGetPayload<{ include: typeof defaultPublicationInclude }>;
+type PrivateFullPublication = Prisma.PublicationGetPayload<{ include: typeof privatePublicationInclude }>;
+
+const getPublicationCounts = (publication: DefaultFullPublication | PrivateFullPublication) => {
+    return {
+        flagCount: publication.publicationFlags.filter((flag) => !flag.resolved).length,
+        peerReviewCount: publication.linkedFrom.filter((child) => child.publicationFrom.type === 'PEER_REVIEW').length
+    };
+};
+
+export const get = async (id: string) => {
+    const publication = await client.prisma.publication.findUnique({
+        where: {
+            id
+        },
+        include: defaultPublicationInclude
     });
 
     // Provide counts
     return publication
         ? {
               ...publication,
-              flagCount: publication.publicationFlags.filter((flag) => !flag.resolved).length,
-              peerReviewCount: publication.linkedFrom.filter((child) => child.publicationFrom.type === 'PEER_REVIEW')
-                  .length
+              ...getPublicationCounts(publication)
+          }
+        : publication;
+};
+
+export const privateGet = async (id: string) => {
+    const publication = await client.prisma.publication.findUnique({
+        where: {
+            id
+        },
+        include: privatePublicationInclude
+    });
+
+    // Provide counts
+    return publication
+        ? {
+              ...publication,
+              ...getPublicationCounts(publication)
           }
         : publication;
 };

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -206,6 +206,10 @@ export interface OpenSearchPublicationFilters {
 }
 
 export type PublicationVersion = Exclude<Prisma.PromiseReturnType<typeof publicationVersionService.get>, null>;
+export type PrivatePublicationVersion = Exclude<
+    Prisma.PromiseReturnType<typeof publicationVersionService.privateGet>,
+    null
+>;
 
 /**
  * @description Links

--- a/ui/src/components/Publication/Creation/CoAuthor.tsx
+++ b/ui/src/components/Publication/Creation/CoAuthor.tsx
@@ -109,7 +109,6 @@ const CoAuthor: React.FC = (): React.ReactElement => {
         setCoAuthor(event.target.value);
     };
 
-    // Validate email for co author regex to use -
     const addCoAuthorToPublication = React.useCallback(async () => {
         setLoading(true);
 
@@ -117,7 +116,9 @@ const CoAuthor: React.FC = (): React.ReactElement => {
 
         // check to ensure co-author email is not already in the store/database
         const coAuthorEmail = coAuthor.trim().toLowerCase();
-        const emailDuplicate = authorsArray.some((author) => author.email.toLowerCase() === coAuthorEmail);
+        const emailDuplicate = authorsArray.some(
+            (author) => author.email && author.email.toLowerCase() === coAuthorEmail
+        );
         if (emailDuplicate) {
             setEmailDuplicated(true);
             setLoading(false);


### PR DESCRIPTION
The purpose of this PR was to solve an issue in which user emails are displayed in JSON exports for publications. This occurs in both the “user” section (corresponding author) and the co-authors section. This field should be omitted from JSON exports.

While working on this I checked where else email addresses are returned in API responses and corrected those as well.

In general the approach for keeping this clear and making things clearer with regard to typing, I separated these out into separate default + private versions of the same function but am open to critique of this approach.

---

### Acceptance Criteria:

Email addresses are not returned from the JSON export function.

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
![Screenshot 2024-10-07 145808](https://github.com/user-attachments/assets/dfc0ed8b-2e29-4e8b-aca0-9960481966d8)

API
![Screenshot 2024-10-07 122036](https://github.com/user-attachments/assets/c570b228-6384-4449-a8fb-19f61b2e89cb)

E2E
![Screenshot 2024-10-07 145044](https://github.com/user-attachments/assets/599e8986-4e97-4f33-95a1-81ac160d7ced)
