### PR TITLE
OC-899-fix: update prisma binary target

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -1,7 +1,7 @@
 generator client {
     provider        = "prisma-client-js"
     previewFeatures = ["fullTextSearch"]
-    binaryTargets   = ["native", "rhel-openssl-1.0.x"]
+    binaryTargets   = ["native", "rhel-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
The purpose of this PR was to change the binary targets for prisma. It seems that the nodeJS 20 runtime environment for lambda requires a newer target for prisma to generate client code.