### PR TITLE
OC-930: Hide co-author email addresses from other co-authors

### DIFF
--- a/api/docs/api.yml
+++ b/api/docs/api.yml
@@ -1233,6 +1233,7 @@ components:
       description: Whether the coauthor has confirmed their involvement in the publication.
     CoAuthorEmail:
       type: string
+      description: Sometimes not returned if the user doesn't have permission to see it.
     CoAuthorId:
       type: string
     CoAuthorIsIndependent:
@@ -1243,12 +1244,21 @@ components:
       description: ID of the octopus user linked to this CoAuthor object.
       nullable: true
     CoAuthorResponse:
+      oneOf:
+        - $ref: "#/components/schemas/CoAuthorResponsePrivate"
+        - $ref: "#/components/schemas/CoAuthorResponsePublic"
+    CoAuthorResponsePrivate:
+      allOf:
+        - $ref: "#/components/schemas/CoAuthorResponsePublic"
+        - type: object
+          properties:
+            email:
+              $ref: "#/components/schemas/CoAuthorEmail"
+    CoAuthorResponsePublic:
       type: object
       properties:
         id:
           $ref: "#/components/schemas/CoAuthorId"
-        email:
-          $ref: "#/components/schemas/CoAuthorEmail"
         linkedUser:
           $ref: "#/components/schemas/CoAuthorLinkedUser"
         publicationVersionId:
@@ -1534,6 +1544,18 @@ components:
       description: ORCiD ID. Not used for organisational accounts.
       nullable: true
     UserResponse:
+      oneOf:
+        - $ref: "#/components/schemas/UserResponsePrivate"
+        - $ref: "#/components/schemas/UserResponsePublic"
+    UserResponsePrivate:
+      allOf:
+        - $ref: "#/components/schemas/UserResponsePublic"
+        - type: object
+          properties:
+            email:
+              type: string
+              description: Only returned if the requester has permission to see it (usually, that they are the user in question).
+    UserResponsePublic:
       type: object
       properties:
         id:
@@ -1544,8 +1566,6 @@ components:
           $ref: "#/components/schemas/UserFirstName"
         lastName:
           $ref: "#/components/schemas/UserLastName"
-        email:
-          type: string
         createdAt:
           type: string
           format: date-time

--- a/api/src/components/coauthor/__tests__/getCoAuthors.test.ts
+++ b/api/src/components/coauthor/__tests__/getCoAuthors.test.ts
@@ -46,6 +46,15 @@ describe('Get co-authors of a publication version', () => {
             .query({ apiKey: '000000006' });
 
         expect(getCoAuthors.status).toEqual(200);
+        // Only the email of the requesting coauthor themselves should be returned.
+        const coAuthors = getCoAuthors.body;
+        coAuthors.forEach((coAuthor) => {
+            if (coAuthor.linkedUser === 'test-user-6') {
+                expect(coAuthor).toHaveProperty('email');
+            } else {
+                expect(coAuthor).not.toHaveProperty('email');
+            }
+        });
     });
 
     test('Authenticated user who is not a confirmed co-author cannot get co-authors', async () => {

--- a/api/src/components/coauthor/controller.ts
+++ b/api/src/components/coauthor/controller.ts
@@ -47,7 +47,21 @@ export const getAll = async (
             });
         }
 
-        return response.json(200, version.coAuthors);
+        // Redact emails of other co-authors unless the user is the corresponding author.
+        const coAuthorsWithRedactedEmails =
+            event.user.id === version.createdBy
+                ? coAuthors
+                : coAuthors.map((coAuthor) => {
+                      if (coAuthor.linkedUser === event.user.id) {
+                          return coAuthor;
+                      } else {
+                          const { email, ...rest } = coAuthor;
+
+                          return rest;
+                      }
+                  });
+
+        return response.json(200, coAuthorsWithRedactedEmails);
     } catch (err) {
         console.log(err);
 


### PR DESCRIPTION
The purpose of this PR was to ensure that coauthors cannot see the emails of other coauthors from API responses (corresponding authors are allowed to see these however).

---

### Acceptance Criteria:

Co-authors are not sent the email addresses of other co-authors via the API.

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [x] Documentation updated

---

### Tests:

E2E
![Screenshot 2024-10-08 154623](https://github.com/user-attachments/assets/365433ca-7a79-446d-bd66-a80761f23668)

API
![Screenshot 2024-10-08 155701](https://github.com/user-attachments/assets/5335a98f-ae25-499d-b88e-133684539967)

---

### Screenshots:

In all these examples a third author is being viewed separate to the two making the requests.

Corresponding author sees emails in response to API call made on publication page
![Screenshot 2024-10-08 160756](https://github.com/user-attachments/assets/676763cd-10c7-4989-96aa-246acbd43584)

Coauthor does not
![Screenshot 2024-10-08 161016](https://github.com/user-attachments/assets/ebc01b55-1ffd-49a9-bb5c-6be9ed68f795)

Corresponding author can get emails from calling getCoauthors API function directly
![Screenshot 2024-10-08 161157](https://github.com/user-attachments/assets/eed80cae-47b8-470e-848a-ed811a03ea48)

Coauthor cannot
![Screenshot 2024-10-08 161227](https://github.com/user-attachments/assets/871f7c11-4d08-4557-a8f3-f93b885d315a)
