### PR TITLE
OC-934: Add spaces to topics failing to match

### DIFF
--- a/api/prisma/seeds/local/dev/topicMappings.ts
+++ b/api/prisma/seeds/local/dev/topicMappings.ts
@@ -481,7 +481,7 @@ const topicMappings: Prisma.TopicMappingCreateManyInput[] = [
         isMapped: true
     },
     {
-        title: 'Creditand debt',
+        title: 'Credit and debt',
         source: 'ARI',
         topicId: 'clkv6upos02ual2rswg7o0a6m',
         isMapped: true
@@ -1386,7 +1386,7 @@ const topicMappings: Prisma.TopicMappingCreateManyInput[] = [
         isMapped: true
     },
     {
-        title: 'Industrialaccident and incident',
+        title: 'Industrial accident and incident',
         source: 'ARI',
         topicId: 'cly468zj3004k7ryzr5nnrthn',
         isMapped: true


### PR DESCRIPTION
The purpose of this PR was to correct typos in two topic names that are failing to match on ARI imports.

This corrects the seed data - separately, the mappings have been updated in the int and prod DBs.

---

### Acceptance Criteria:

The topic mappings 'creditand debt' and 'industrialaccident and incident' have been corrected to 'credit and debt' / 'industrial accident and incident'.