### PR TITLE
OC-932: Deploy ARI integration for specific departments

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -40,3 +40,4 @@ TRIGGER_ARI_INGEST_API_KEY=12345
 
 SLACK_CHANNEL_EMAIL=example@mailinator.com
 INGEST_REPORT_RECIPIENTS=example.one@mailinator.com,example.two@mailinator.com
+PARTICIPATING_ARI_USER_IDS=abc123,def456,ghi789

--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -108,6 +108,7 @@ services:
             - LIST_USERS_API_KEY=123456789
             - TRIGGER_ARI_INGEST_API_KEY=123456789
             - INGEST_REPORT_RECIPIENTS=example.jisc@mailinator.com
+            - PARTICIPATING_ARI_USER_IDS=
 
 volumes:
     opensearch-data1:

--- a/api/serverless-offline.yml
+++ b/api/serverless-offline.yml
@@ -44,6 +44,7 @@ provider:
         LIST_USERS_API_KEY: ${env:LIST_USERS_API_KEY}
         TRIGGER_ARI_INGEST_API_KEY: ${env:TRIGGER_ARI_INGEST_API_KEY}
         INGEST_REPORT_RECIPIENTS: ${env:INGEST_REPORT_RECIPIENTS}
+        PARTICIPATING_ARI_USER_IDS: ${env:PARTICIPATING_ARI_USER_IDS}
     deploymentBucket:
         tags:
             Project: Octopus

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -52,6 +52,7 @@ provider:
         SLACK_CHANNEL_EMAIL: ${ssm:/slack_channel_email_${self:provider.stage}_octopus}
         TRIGGER_ARI_INGEST_API_KEY: ${ssm:/trigger_ari_ingest_api_key_${self:provider.stage}_octopus}
         INGEST_REPORT_RECIPIENTS: ${ssm:/ingest_report_recipients_${self:provider.stage}_octopus}
+        PARTICIPATING_ARI_USER_IDS: ${ssm:/participating_ari_user_ids_${self:provider.stage}_octopus}
     deploymentBucket:
         tags:
             Project: Octopus

--- a/api/src/components/integration/README.md
+++ b/api/src/components/integration/README.md
@@ -23,6 +23,13 @@ The ARI DB is a UK government database storing research questions that governmen
 
 #### ARI import process
 
+ARIs can be excluded from the import process for one of these reasons:
+
+-   The `isArchived` field is `true`.
+-   The `department` field doesn't correspond to one of our participating departments.
+    -   These are defined in an environment variable (`PARTICIPATING_ARI_USER_IDS`) as a comma-separated list of octopus user IDs. Each ID corresponds to the organisational account representing an ARI department.
+    -   At import time, the user mapping table is consulted to get the expected names the departments have on the ARI DB side. As such, user mappings must also exist in the octopus DB for a department to be included properly.
+
 On import, ARIs go through a handling flow:
 
 -   If no publication exists with the ARI's question ID in its `externalId` field, it is created as a new publication.
@@ -37,5 +44,3 @@ Various ARI fields are mapped to octopus ones in the `mapAriQuestionToPublicatio
 Of particular importance is how ARIs are matched to an owning organisational user account. The mapping process expects a UserMapping to exist associating the `department` field value from the ARI (where the title matches, case insensitive, and the mapping source is 'ARI') with the user ID of an organisational account.
 
 Topics are mapped similarly. If an ARI has values in its `topics` field, the mapping will check whether octopus has any TopicMappings in the database that match with them and associate the publication it creates/updates with the topic(s) from those mappings. If there are no topics listed on the ARI, the organisational user is expected to have a `defaultTopicId`, which is used as a fallback.
-
-ARIs can be archived (`isArchived` field). These are not imported by Octopus.

--- a/api/src/components/integration/ariUtils.ts
+++ b/api/src/components/integration/ariUtils.ts
@@ -360,3 +360,13 @@ export const handleIncomingARI = async (question: I.ARIQuestion, dryRun?: boolea
 };
 
 export const ariEndpoint = 'https://ari.org.uk/api/questions?order_by=dateUpdated';
+
+// Returns the mapped ARI department names for a given set of octopus organisational user IDs.
+export const getParticipatingDepartmentNames = async (): Promise<string[]> => {
+    const participatingDepartmentIds = process.env.PARTICIPATING_ARI_USER_IDS?.split(',') ?? [];
+    const queryResults = await Promise.all(
+        participatingDepartmentIds.map((userId) => client.prisma.userMapping.findMany({ where: { userId } }))
+    );
+
+    return queryResults.flatMap((userMappings) => userMappings.map((userMapping) => userMapping.value));
+};


### PR DESCRIPTION
Government departments want to display high quality ARIs to ensure they can engage with the research community effectively. I need ministerial sign-off to change existing (outdated) ARIs, so I may take a while to update them. This means on octopus we have to be able to import ARIs from some departments, but not others.

This area being changed (which ARIs are imported) isn't covered in tests so these haven't been run, but it has been tested locally.

---

### Acceptance Criteria:

- A whitelist exists of government departments that have opted in to the ARI integration
- For both the initial ingest, and the weekly updates (endpoint), if the department for a given ARI is not on the whitelist, the record is skipped
    - Skipping records does not contribute towards the count of 5 records before stopping the ingest, nor towards the date started/finished matching (i.e. the ingest will not stop due to checking records for depts that have not opted in yet).

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [x] Documentation updated
