### PR TITLE
OC-935: Convey ARI category

### DIFF
--- a/api/prisma/seeds/local/unitTesting/publications.ts
+++ b/api/prisma/seeds/local/unitTesting/publications.ts
@@ -791,6 +791,8 @@ const publicationSeeds: Prisma.PublicationCreateInput[] = [
                 versionNumber: 1,
                 title: 'ARI Publication 1',
                 content:
+                    // Question group
+                    '<p><strong>Question group</strong></p>' +
                     // Static placeholder text added to each mapped ARI's content
                     "<p><em>This problem is a UK government area of research interest (ARI) that was originally posted at <a target='_blank' href='https://ari.org.uk/'>https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</em></p>" +
                     // ARI Question title
@@ -801,6 +803,7 @@ const publicationSeeds: Prisma.PublicationCreateInput[] = [
                     '<p><strong>Contact details</strong></p><p>Sample contact details.</p>' +
                     // Related UKRI projects
                     '<p><strong>Related UKRI Projects</strong></p><ul><li><a href="https://gtr.ukri.org/projects?ref=ES%2FS007105%2F1">Urban Big Data Centre</a></li><li><a href="https://gtr.ukri.org/projects?ref=ES%2FL011921%2F1">Urban Big Data</a></li></ul>',
+                description: 'Question group',
                 conflictOfInterestStatus: false,
                 user: { connect: { id: 'test-organisational-account-1' } },
                 publicationStatus: { create: { status: 'LIVE' } },

--- a/api/src/components/integration/__tests__/ari.test.ts
+++ b/api/src/components/integration/__tests__/ari.test.ts
@@ -12,7 +12,7 @@ const sampleARIQuestion: I.ARIQuestion = {
     question: 'ARI Publication 1',
     isArchived: false,
     department: 'Test ARI Department',
-    questionGroup: '',
+    questionGroup: 'Question group',
     backgroundInformation: 'Sample background information.',
     publicationDate: '2024-02-26 00:00:00',
     expiryDate: null,
@@ -55,6 +55,8 @@ describe('ARI Mapping', () => {
             success: true,
             mappedData: {
                 content:
+                    // Question group
+                    '<p><strong>Question group</strong></p>' +
                     // Static placeholder text added to each mapped ARI's content
                     "<p><em>This problem is a UK government area of research interest (ARI) that was originally posted at <a target='_blank' href='https://ari.org.uk/'>https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</em></p>" +
                     // ARI Question title
@@ -80,7 +82,7 @@ describe('ARI Mapping', () => {
             success: true,
             mappedData: {
                 content:
-                    "<p><em>This problem is a UK government area of research interest (ARI) that was originally posted at <a target='_blank' href='https://ari.org.uk/'>https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</em></p><p>ARI Publication 1</p>" +
+                    "<p><strong>Question group</strong></p><p><em>This problem is a UK government area of research interest (ARI) that was originally posted at <a target='_blank' href='https://ari.org.uk/'>https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</em></p><p>ARI Publication 1</p>" +
                     // Background information
                     '<p>Background information line 1.<br>Background information line 2.<br><br>Background information line 3.</p>' +
                     // Contact details
@@ -253,6 +255,7 @@ describe('ARI handling', () => {
     test('Content updates when mapped fields have changed', async () => {
         const handleARI = await ariUtils.handleIncomingARI({
             ...sampleARIQuestion,
+            questionGroup: 'New question group',
             backgroundInformation: 'New background information.',
             contactDetails: 'New contact details.',
             relatedUKRIProjects: [
@@ -268,11 +271,26 @@ describe('ARI handling', () => {
             success: true,
             publicationVersion: {
                 content:
+                    '<p><strong>New question group</strong></p>' +
                     "<p><em>This problem is a UK government area of research interest (ARI) that was originally posted at <a target='_blank' href='https://ari.org.uk/'>https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</em></p>" +
                     '<p>ARI Publication 1</p>' +
                     '<p>New background information.</p>' +
                     '<p><strong>Contact details</strong></p><p>New contact details.</p>' +
                     '<p><strong>Related UKRI Projects</strong></p><ul><li><a href="https://jisc.ac.uk">Test</a></li></ul>'
+            }
+        });
+    });
+
+    test('Description updates when questionGroup is changed', async () => {
+        const handleARI = await ariUtils.handleIncomingARI({
+            ...sampleARIQuestion,
+            questionGroup: 'New question group'
+        });
+        expect(handleARI).toMatchObject({
+            actionTaken: 'update',
+            success: true,
+            publicationVersion: {
+                description: 'New question group'
             }
         });
     });
@@ -343,6 +361,7 @@ describe('ARI handling', () => {
                 title: 'ARI Publication 1',
                 content:
                     // Mapped content - see ARI mapping tests for explanation.
+                    '<p><strong>Question group</strong></p>' +
                     "<p><em>This problem is a UK government area of research interest (ARI) that was originally posted at <a target='_blank' href='https://ari.org.uk/'>https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</em></p>" +
                     '<p>ARI Publication 1</p>' +
                     '<p>Sample background information.</p>' +

--- a/api/src/components/integration/ariUtils.ts
+++ b/api/src/components/integration/ariUtils.ts
@@ -1,5 +1,6 @@
 import * as client from 'lib/client';
 import * as coAuthorService from 'coAuthor/service';
+import * as config from 'config';
 import * as Helpers from 'lib/helpers';
 import * as I from 'interface';
 import * as publicationService from 'publication/service';
@@ -49,6 +50,7 @@ export const mapAriQuestionToPublicationVersion = async (
         department,
         fieldsOfResearch,
         question,
+        questionGroup,
         questionId,
         relatedUKRIProjects,
         tags,
@@ -56,6 +58,7 @@ export const mapAriQuestionToPublicationVersion = async (
     } = questionData;
     const title = question;
     // Compose content.
+    const questionGroupHTML = questionGroup ? `<p><strong>${questionGroup}</strong></p>` : '';
     const commonBoilerplateHTML =
         "<p><em>This problem is a UK government area of research interest (ARI) that was originally posted at <a target='_blank' href='https://ari.org.uk/'>https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</em></p>";
     const titleHTML = `<p>${question}</p>`;
@@ -71,6 +74,8 @@ export const mapAriQuestionToPublicationVersion = async (
           '</ul>'
         : '';
     const content =
+        Helpers.getSafeHTML(questionGroupHTML) +
+        // Don't run getSafeHTML on this because sanitize() removes the target attribute from the link.
         commonBoilerplateHTML +
         Helpers.getSafeHTML(
             [titleHTML, backgroundInformationHTML, contactDetailsHTML, relatedUKRIProjectsHTML].join('')
@@ -127,6 +132,10 @@ export const mapAriQuestionToPublicationVersion = async (
         mappedData: {
             title,
             content,
+            description:
+                questionGroup && questionGroup.length <= config.constants.publication.description.maxLength
+                    ? questionGroup
+                    : '',
             keywords,
             topicIds: finalTopicIds,
             externalSource: 'ARI',
@@ -148,12 +157,14 @@ export const detectChangesToARIPublication = (
     | {
           title?: FieldDiff<string>;
           content?: FieldDiff<string>;
+          description?: FieldDiff<string>;
           keywords?: FieldDiff<string[]>;
           topics?: FieldDiff<string[]>;
           userId?: FieldDiff<string>;
       } => {
     const titleMatch = ari.title === publicationVersion.title;
     const contentMatch = ari.content === publicationVersion.content;
+    const descriptionMatch = ari.description === publicationVersion.description;
     const keywordsMatch = Helpers.compareArrays(ari.keywords, publicationVersion.keywords);
     const publicationVersionTopicIds = publicationVersion.topics.map((topic) => topic.id);
     const topicsMatch = Helpers.compareArrays(ari.topicIds, publicationVersionTopicIds);
@@ -162,12 +173,13 @@ export const detectChangesToARIPublication = (
     const changes = {
         ...(!titleMatch ? { title: { new: ari.title, old: publicationVersion.title } } : {}),
         ...(!contentMatch ? { content: { new: ari.content, old: publicationVersion.content } } : {}),
+        ...(!descriptionMatch ? { description: { new: ari.description, old: publicationVersion.description } } : {}),
         ...(!keywordsMatch ? { keywords: { new: ari.keywords, old: publicationVersion.keywords } } : {}),
         ...(!topicsMatch ? { topics: { new: ari.topicIds, old: publicationVersionTopicIds } } : {}),
         ...(!userMatch ? { userId: { new: ari.userId, old: publicationVersion.user.id } } : {})
     };
 
-    const somethingChanged = !(titleMatch && contentMatch && keywordsMatch && topicsMatch && userMatch);
+    const somethingChanged = Object.keys(changes).length;
 
     return somethingChanged ? changes : false;
 };
@@ -311,6 +323,7 @@ export const handleIncomingARI = async (question: I.ARIQuestion, dryRun?: boolea
         let updatedVersion = await publicationVersionService.update(existingVersion.id, {
             ...(changes.title && { title: mappedData.title }),
             ...(changes.content && { content: mappedData.content }),
+            ...(changes.description && { description: mappedData.description }),
             ...(changes.keywords && { keywords: mappedData.keywords }),
             ...(changes.topics && { topics: { set: mappedData.topicIds.map((topicId) => ({ id: topicId })) } }),
             ...(changes.userId && { user: { connect: { id: mappedData.userId } } }),

--- a/api/src/components/publication/schema/createBody.ts
+++ b/api/src/components/publication/schema/createBody.ts
@@ -1,3 +1,4 @@
+import * as config from 'config';
 import * as Enum from 'enum';
 import * as I from 'interface';
 
@@ -30,7 +31,7 @@ const createPublicationBodySchema: I.Schema = {
         },
         description: {
             type: 'string',
-            maxLength: 160 // TODO: Re look at this cap
+            maxLength: config.constants.publication.description.maxLength
         },
         keywords: {
             type: 'array',

--- a/api/src/components/publicationVersion/schema/update.ts
+++ b/api/src/components/publicationVersion/schema/update.ts
@@ -1,3 +1,4 @@
+import * as config from 'config';
 import * as Enum from 'enum';
 import * as I from 'interface';
 
@@ -14,7 +15,7 @@ const updatePublicationVersionSchema: I.JSONSchemaType<I.UpdatePublicationVersio
         },
         description: {
             type: 'string',
-            maxLength: 160,
+            maxLength: config.constants.publication.description.maxLength,
             nullable: true
         },
         keywords: {

--- a/api/src/config/constants.ts
+++ b/api/src/config/constants.ts
@@ -1,0 +1,7 @@
+export default {
+    publication: {
+        description: {
+            maxLength: 160
+        }
+    }
+};

--- a/api/src/config/index.ts
+++ b/api/src/config/index.ts
@@ -1,1 +1,2 @@
 export { default as application } from './application';
+export { default as constants } from './constants';

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -1051,6 +1051,7 @@ export interface ARIQuestion {
 export type MappedARIQuestion = {
     title: string;
     content: string;
+    description: string;
     keywords: string[];
     topicIds: string[];
     externalId: string;


### PR DESCRIPTION
The purpose of this PR was to address issues a lack of context in some ARI publication titles. On the ARI side, they are often shown in context of their question group. Without this context the title can seem generic.

In order to make this context available in octopus the question group name should be mapped to the description field and the start of the content field on import.

---

### Acceptance Criteria:

- "questionGroup” is placed at the beginning of the publication, or in the “Short description” field so that it appears in search previews.
    - The text is a large, bold font size so that it clearly conveys that it is relevant to the title, and the publication as a whole.

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

API
![Screenshot 2024-10-15 160004](https://github.com/user-attachments/assets/1622bb9c-34d3-4035-b606-f92aa3fa3ca5)

---

### Screenshots:

Question group shown in search results
![Screenshot 2024-10-15 160629](https://github.com/user-attachments/assets/45387985-12a7-4ebc-8915-95dbc29e62bb)

Question group shown in beginning of content area on publication page
![Screenshot 2024-10-15 160645](https://github.com/user-attachments/assets/ca274cdb-e54e-4628-9ba0-3d7f8b28e83e)
