### PR TITLE
OC-941: Stop including emails in user publications response

### DIFF
--- a/api/src/components/user/service.ts
+++ b/api/src/components/user/service.ts
@@ -273,7 +273,6 @@ export const getPublications = async (
                             id: true,
                             linkedUser: true,
                             confirmedCoAuthor: true,
-                            email: true,
                             user: {
                                 select: {
                                     orcid: true,

--- a/ui/src/components/Publication/SimpleResult/index.tsx
+++ b/ui/src/components/Publication/SimpleResult/index.tsx
@@ -95,12 +95,13 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
                     </span>
                     {draftExistsWithPermission && (
                         <span>
-                            {latestVersion.user.id === props.user.id
-                                ? ' (Corresponding Author)'
-                                : latestVersion.coAuthors.find((coAuthor) => coAuthor.linkedUser === props.user.id)
-                                  ? ' (Author)'
-                                  : latestVersion.coAuthors.find((coAuthor) => coAuthor.email === props.user.email) &&
-                                    ' (Invited)'}
+                            {
+                                latestVersion.user.id === props.user.id
+                                    ? ' (Corresponding Author)'
+                                    : latestVersion.coAuthors.find((coAuthor) => coAuthor.linkedUser === props.user.id)
+                                      ? ' (Author)'
+                                      : ' (Invited)' // We can infer that they are an unconfirmed coauthor.
+                            }
                         </span>
                     )}
                 </p>
@@ -114,9 +115,23 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
                             Status: {Helpers.getPublicationStatusByAuthor(draftVersion, props.user)}
                         </p>
                         {props.user.id !== draftVersion.user.id ? (
-                            draftVersion.coAuthors.some(
-                                (coAuthor) => coAuthor.email === props.user.email && !coAuthor.linkedUser
-                            ) ? (
+                            // Confirmed coauthor.
+                            draftVersion.coAuthors.some((coAuthor) => coAuthor.linkedUser === props.user.id) ? (
+                                <>
+                                    <p>
+                                        <Components.Link
+                                            href={`${Config.urls.viewUser.path}/${draftVersion.user.id}`}
+                                            className="underline"
+                                        >
+                                            {draftVersion.user.firstName.substring(0, 1)}. {draftVersion.user.lastName}
+                                        </Components.Link>{' '}
+                                        is working on a new draft version
+                                    </p>
+                                    {viewDraftButton}
+                                    {requestControl}
+                                </>
+                            ) : (
+                                // Unconfirmed coauthor.
                                 <>
                                     <p>
                                         <Components.Link
@@ -133,20 +148,6 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
                                         title="Confirm Involvement"
                                         className="mt-5 w-fit bg-green-600 px-3 text-white-50 children:border-none children:text-white-50"
                                     />
-                                </>
-                            ) : (
-                                <>
-                                    <p>
-                                        <Components.Link
-                                            href={`${Config.urls.viewUser.path}/${draftVersion.user.id}`}
-                                            className="underline"
-                                        >
-                                            {draftVersion.user.firstName.substring(0, 1)}. {draftVersion.user.lastName}
-                                        </Components.Link>{' '}
-                                        is working on a new draft version
-                                    </p>
-                                    {viewDraftButton}
-                                    {requestControl}
                                 </>
                             )
                         ) : draftVersion.currentStatus === 'LOCKED' ? (


### PR DESCRIPTION
The purpose of this PR was to stop including emails in the response of the getUserPublications endpoint. We don't need them for the tasks the endpoint is called to do.

---

### Acceptance Criteria:

Email addresses are not included in the response to the getUserPublications endpoint.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

API
![Screenshot 2024-10-16 130934](https://github.com/user-attachments/assets/86fdf0f7-1150-41ed-84ae-9ccf1353a574)

E2E
![Screenshot 2024-10-16 144627](https://github.com/user-attachments/assets/855f27c1-43c3-4865-87f0-272ad04c12e5)

---

### Screenshots:

Response on public author page
![Screenshot 2024-10-16 151110](https://github.com/user-attachments/assets/b534da8a-4408-4c96-81fb-fd231901d307)

Response on my account page
![Screenshot 2024-10-16 151042](https://github.com/user-attachments/assets/912670cf-8b8d-47c4-99b8-8c3c61f44401)

