### PR TITLE
OC-851: Explanatory hotspot for cross links

### DIFF
--- a/ui/src/__tests__/components/Publication/RelatedPublications.test.tsx
+++ b/ui/src/__tests__/components/Publication/RelatedPublications.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react';
 import * as Components from '@/components';
 import * as TestUtils from '@/testUtils';
 
-describe('No crosslinks / general', () => {
+describe('No crosslinks', () => {
     beforeEach(() => {
         render(
             <Components.RelatedPublications
@@ -26,17 +26,12 @@ describe('No crosslinks / general', () => {
         expect(screen.queryByText('Most relevant')).not.toBeInTheDocument();
         expect(screen.queryByText('Most recent')).not.toBeInTheDocument();
     });
-    it('Link to FAQ is present', () => {
-        const link = screen.getByRole('link');
-        expect(link).toHaveAttribute('href', '/faq#related_publications');
-        expect(link).toHaveTextContent('What is this?');
-    });
 });
 
 const crosslinkBase = TestUtils.testCrosslink;
 const title = crosslinkBase.linkedPublication.latestLiveVersion.title;
 
-describe('Recent and relevant crosslinks', () => {
+describe('Recent and relevant crosslinks / general tests', () => {
     beforeEach(() => {
         render(
             <Components.RelatedPublications
@@ -94,6 +89,12 @@ describe('Recent and relevant crosslinks', () => {
     it('3 relevant crosslinks are shown', () => {
         const recentSection = document.getElementsByTagName('section')[2];
         expect(within(recentSection).getAllByText(title)).toHaveLength(3);
+    });
+
+    it('Link to FAQ is present', () => {
+        const link = screen.getByRole('link', { name: 'Related publications section in FAQ' });
+        expect(link).toHaveTextContent('What is this?');
+        expect(link).toHaveAttribute('href', '/faq#related_publications');
     });
 });
 

--- a/ui/src/__tests__/components/Publication/RelatedPublications.test.tsx
+++ b/ui/src/__tests__/components/Publication/RelatedPublications.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react';
 import * as Components from '@/components';
 import * as TestUtils from '@/testUtils';
 
-describe('No crosslinks', () => {
+describe('No crosslinks / general', () => {
     beforeEach(() => {
         render(
             <Components.RelatedPublications
@@ -25,6 +25,11 @@ describe('No crosslinks', () => {
     it('Neither category label is shown', () => {
         expect(screen.queryByText('Most relevant')).not.toBeInTheDocument();
         expect(screen.queryByText('Most recent')).not.toBeInTheDocument();
+    });
+    it('Link to FAQ is present', () => {
+        const link = screen.getByRole('link');
+        expect(link).toHaveAttribute('href', '/faq#related_publications');
+        expect(link).toHaveTextContent('What is this?');
     });
 });
 

--- a/ui/src/components/Button/index.tsx
+++ b/ui/src/components/Button/index.tsx
@@ -53,8 +53,8 @@ const Button: React.FC<Props> = (props): React.ReactElement | null => {
             transition-colors
             duration-500
             border-b-2
-            border-b-teal-400
-            dark:border-b-teal-500
+            border-b-teal-500
+            dark:border-b-teal-400
             ${props.childClassName ?? ''}
             `;
     }, [props.endIcon, props.padding, props.startIcon, props.textSize]);

--- a/ui/src/components/Publication/RelatedPublications/index.tsx
+++ b/ui/src/components/Publication/RelatedPublications/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import * as Components from '@/components';
+import * as Config from '@/config';
 import * as Interfaces from '@/interfaces';
 import * as OutlineIcons from '@heroicons/react/24/outline';
 import * as Stores from '@/stores';
@@ -31,14 +32,18 @@ const RelatedPublications: React.FC<Props> = (props) => {
         // TODO: Remove this condition when crosslinking is fully released.
         (process.env.NEXT_PUBLIC_STAGE === 'local' || !!totalCrosslinks) && (
             <Components.AccordionSection id={props.id} title={'Related Publications'}>
-                <div className="space-y-4 px-6 py-4">
-                    <span className="flex text-teal-600 dark:text-teal-200 font-montserrat gap-4">
-                        <OutlineIcons.InformationCircleIcon
-                            className="w-6 text-teal-600 dark:text-teal-200"
-                            title={`This area displays publications that have been identified by other readers as being related to this one. ${user ? 'You can' : 'Log in to'} vote on how appropriate a link is, or add your own suggestions.`}
-                        />
-                        User suggested links
-                    </span>
+                <div className="flex flex-col space-y-4 px-6 py-4">
+                    <Components.Button
+                        title="Crosslinking section in author guide"
+                        className="self-end"
+                        endIcon={
+                            <OutlineIcons.InformationCircleIcon className="w-6 text-teal-600 dark:text-teal-200" />
+                        }
+                        openNew={true}
+                        href={Config.urls.faq.path + '#related_publications'}
+                    >
+                        <span className="text-teal-600 dark:text-teal-200">What is this?</span>
+                    </Components.Button>
                     {!!recent.length && (
                         <section className="flex flex-col">
                             {!!relevant.length && (

--- a/ui/src/components/Publication/RelatedPublications/index.tsx
+++ b/ui/src/components/Publication/RelatedPublications/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import * as Components from '@/components';
 import * as Interfaces from '@/interfaces';
+import * as OutlineIcons from '@heroicons/react/24/outline';
 import * as Stores from '@/stores';
 import * as Types from '@/types';
 
@@ -31,6 +32,13 @@ const RelatedPublications: React.FC<Props> = (props) => {
         (process.env.NEXT_PUBLIC_STAGE === 'local' || !!totalCrosslinks) && (
             <Components.AccordionSection id={props.id} title={'Related Publications'}>
                 <div className="space-y-4 px-6 py-4">
+                    <span className="flex text-teal-600 dark:text-teal-200 font-montserrat gap-4">
+                        <OutlineIcons.InformationCircleIcon
+                            className="w-6 text-teal-600 dark:text-teal-200"
+                            title={`This area displays publications that have been identified by other readers as being related to this one. ${user ? 'You can' : 'Log in to'} vote on how appropriate a link is, or add your own suggestions.`}
+                        />
+                        User suggested links
+                    </span>
                     {!!recent.length && (
                         <section className="flex flex-col">
                             {!!relevant.length && (

--- a/ui/src/components/Publication/RelatedPublications/index.tsx
+++ b/ui/src/components/Publication/RelatedPublications/index.tsx
@@ -34,7 +34,7 @@ const RelatedPublications: React.FC<Props> = (props) => {
             <Components.AccordionSection id={props.id} title={'Related Publications'}>
                 <div className="flex flex-col space-y-4 px-6 py-4">
                     <Components.Button
-                        title="Crosslinking section in author guide"
+                        title="Related publications section in FAQ"
                         className="self-end"
                         endIcon={
                             <OutlineIcons.InformationCircleIcon className="w-6 text-teal-600 dark:text-teal-200" />

--- a/ui/src/pages/faq.tsx
+++ b/ui/src/pages/faq.tsx
@@ -208,7 +208,7 @@ const faqContents = [
         heading: 'How are related publications identified?',
         content: `
             <p className="mb-2">To avoid bias, Octopus does not use any sort of algorithm to identify related publications. Instead, whilst viewing a publication that has already been published, the related publications area displays publications that have been identified by readers as being related to the one currently being viewed.</p>
-            <p className="mb-2">To make sure that this section contains useful links, after clicking through to a related publication, you are able to vote on whether or not you think it is in some way relevant to the one just came from.</p>
+            <p className="mb-2">To make sure that this section contains useful links, after clicking through to a related publication, you are able to vote on whether or not you think it is in some way relevant to the one you just came from.</p>
             <p>If you know of another publication that is relevant to the one you are viewing, you can also use the “Suggest a link” option to add it to the list.</p>
         `
     }

--- a/ui/src/pages/faq.tsx
+++ b/ui/src/pages/faq.tsx
@@ -200,6 +200,17 @@ const faqContents = [
             <p className="mb-2">Both of these methods will log you out of Octopus. If you attempt to log in again after revoking access you&apos;ll be asked to "give Octopus permission to access your ORCID record" again.</p>
             <p>You will not be able to log into Octopus again without granting permission to access your ORCID record.</p>
         `
+    },
+    {
+        title: 'How are related publications identified?',
+        href: 'related_publications',
+        id: 'related_publications',
+        heading: 'How are related publications identified?',
+        content: `
+            <p className="mb-2">To avoid bias, Octopus does not use any sort of algorithm to identify related publications. Instead, whilst viewing a publication that has already been published, the related publications area displays publications that have been identified by readers as being related to the one currently being viewed.</p>
+            <p className="mb-2">To make sure that this section contains useful links, after clicking through to a related publication, you are able to vote on whether or not you think it is in some way relevant to the one just came from.</p>
+            <p>If you know of another publication that is relevant to the one you are viewing, you can also use the “Suggest a link” option to add it to the list.</p>
+        `
     }
 ];
 


### PR DESCRIPTION
As a user, I should have an explanation of what cross links are and how to use them.

---

### Acceptance Criteria:

- In the suggested links area:
    - Whilst logged in, a link is present below the area title, above the list of publications, displayed via link style text reading “What is this?” and an “info” type icon pointing to the “How are related publications identified?” section of the FAQ
    - The FAQ includes a new “How are related publications identified?” section. Copy as follows: 
```
How are related publications identified?

To avoid bias, Octopus does not use any sort of algorithm to identify related publications. Instead, whilst viewing a publication that has already been published, the related publications area displays publications that have been identified by readers as being related to the one currently being viewed.
To make sure that this section contains useful links, after clicking through to a related publication, you are able to vote on whether or not you think it is in some way relevant to the one just came from. 
If you know of another publication that is relevant to the one you are viewing, you can also use the “Suggest a link” option to add it to the list.
```
---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [x] Documentation updated

---

### Tests:

E2E
![Screenshot 2024-10-18 095537](https://github.com/user-attachments/assets/a3c9f098-d162-4281-9a14-c05392515509)

UI
![Screenshot 2024-10-18 100235](https://github.com/user-attachments/assets/47297034-e947-4a94-8da0-d45d80a9d41a)

---

### Screenshots:
![Screenshot 2024-10-18 100545](https://github.com/user-attachments/assets/b31865bb-63ad-426d-b9ae-57aafa1ff078)
