### PR TITLE
OC-939: Ensure ARIs have organisational authors

### DIFF
--- a/api/src/components/publicationVersion/service.ts
+++ b/api/src/components/publicationVersion/service.ts
@@ -1431,7 +1431,7 @@ const createDOIPayload = async (
                     {
                         name: Helpers.abbreviateUserName(publicationVersion.user),
                         contributorType: 'ContactPerson',
-                        nameType: 'Personal',
+                        nameType: publicationVersion.user.role === 'ORGANISATION' ? 'Organizational' : 'Personal',
                         givenName: publicationVersion.user.firstName,
                         familyName: publicationVersion.user.lastName,
                         nameIdentifiers: [


### PR DESCRIPTION
Currently, ARIs are uploaded to datacite with an individual author type. They should be organisational authors instead. Whilst the “Creator” field allows organisational details to be entered in the same manner as an individual’s, the “Contributor” area does not allow this. Instead, the “nameType” should be set to “Organisational”.

---

### Acceptance Criteria:

- When minting a DOI for an ARI, the “nameType” value within the Contributor section is set as “Organizational” (US spelling) instead of “Personal”.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

API
![Screenshot 2024-10-24 144810](https://github.com/user-attachments/assets/9eee2e38-1a42-4a34-ac85-ff860551356f)

E2E
![Screenshot 2024-10-24 143549](https://github.com/user-attachments/assets/aaea794a-0b97-4228-898e-1025797b8f63)


---

### Screenshots:

XML metadata of an ARI publication on datacite before the change:
![Screenshot 2024-10-24 131857](https://github.com/user-attachments/assets/3bf626a2-cc26-497b-b618-a67e75c4203b)

And after:
![Screenshot 2024-10-24 131910](https://github.com/user-attachments/assets/87483870-509d-42bb-9f03-0cce0caf676c)
