### PR TITLE
OC-939 fix: Use organizational name type for creators too

### DIFF
--- a/api/src/components/publicationVersion/service.ts
+++ b/api/src/components/publicationVersion/service.ts
@@ -1275,7 +1275,7 @@ const createCreatorObject = (user: I.DataCiteUser): I.DataCiteCreator => {
         name: Helpers.abbreviateUserName(user), // datacite expects full name in lastname, firstname order
         givenName: user?.firstName,
         familyName: user?.lastName,
-        nameType: 'Personal',
+        nameType: user.role === 'ORGANISATION' ? 'Organizational' : 'Personal',
         nameIdentifiers: [
             {
                 nameIdentifier: user?.orcid ? user?.orcid : 'ORCID iD not provided',
@@ -1332,7 +1332,8 @@ const createDOIPayload = async (
                     firstName: author.user.firstName,
                     lastName: author.user.lastName,
                     orcid: author.user.orcid,
-                    affiliations: author.affiliations as unknown as I.MappedOrcidAffiliation[]
+                    affiliations: author.affiliations as unknown as I.MappedOrcidAffiliation[],
+                    role: author.user.role
                 })
             );
         }
@@ -1346,7 +1347,8 @@ const createDOIPayload = async (
                 firstName: publicationVersion.user.firstName,
                 lastName: publicationVersion.user.lastName,
                 orcid: publicationVersion.user.orcid,
-                affiliations: []
+                affiliations: [],
+                role: publicationVersion.user.role
             })
         );
     }

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -764,6 +764,7 @@ export interface DataCiteUser {
     lastName: string | null;
     orcid: string | null;
     affiliations: MappedOrcidAffiliation[];
+    role: Role;
 }
 export interface GeneratePDFPathParams {
     publicationId: string;


### PR DESCRIPTION
The purpose of this PR was to make a similar change to OC-939, but on the creator part of a DOI record, where the original change was only on the contributor part.

---

### Acceptance Criteria:

The nameType for organisational users on DOI records is "Organizational", remaining "Personal" for other users.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Screenshots:
![Screenshot 2024-10-29 102801](https://github.com/user-attachments/assets/e9b3bcc4-6fa6-486d-8e12-8c9dbca55cdb)


