### PR TITLE
OC-773 fixes

### DIFF
--- a/e2e/tests/LoggedIn/crosslinking.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/crosslinking.e2e.spec.ts
@@ -34,7 +34,6 @@ test.describe('Crosslinking', () => {
         ]);
         await expect(page.getByText('Suggestion created')).toBeVisible();
         // Check that crosslink is present on new publication's page
-        await page.reload();
         await expect(
             page.locator('#desktop-related-publications-items').getByText(targetPublicationTitle)
         ).toBeVisible();

--- a/ui/src/__tests__/components/Publication/RelatedPublications.test.tsx
+++ b/ui/src/__tests__/components/Publication/RelatedPublications.test.tsx
@@ -11,6 +11,7 @@ jest.mock('next/router', () => ({
         };
     }
 }));
+const mockMutate = jest.fn();
 
 describe('No crosslinks', () => {
     beforeEach(() => {
@@ -27,6 +28,7 @@ describe('No crosslinks', () => {
                 }}
                 publicationId="test"
                 type="PROBLEM"
+                refreshCrosslinks={mockMutate}
             />
         );
     });
@@ -79,6 +81,7 @@ describe('Recent and relevant crosslinks / general tests', () => {
                 }}
                 publicationId="test"
                 type="PROBLEM"
+                refreshCrosslinks={mockMutate}
             />
         );
     });
@@ -133,6 +136,7 @@ describe('Only recent crosslinks', () => {
                 }}
                 publicationId="test"
                 type="PROBLEM"
+                refreshCrosslinks={mockMutate}
             />
         );
     });
@@ -175,6 +179,7 @@ describe('Only relevant crosslinks', () => {
                 }}
                 publicationId="test"
                 type="PROBLEM"
+                refreshCrosslinks={mockMutate}
             />
         );
     });

--- a/ui/src/components/Publication/RelatedPublications/SuggestModal/index.tsx
+++ b/ui/src/components/Publication/RelatedPublications/SuggestModal/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import useSWR from 'swr';
+import useSWR, { KeyedMutator } from 'swr';
 import * as axios from 'axios';
 import * as HeadlessUI from '@headlessui/react';
 import * as OutlineIcons from '@heroicons/react/24/outline';
@@ -17,6 +17,7 @@ type Props = {
     type: Types.PublicationType;
     open: boolean;
     onClose: () => void;
+    refreshCrosslinks: KeyedMutator<Interfaces.GetPublicationMixedCrosslinksResponse>;
 };
 
 const RelatedPublicationsSuggestModal: React.FC<Props> = (props): React.ReactElement => {
@@ -81,6 +82,7 @@ const RelatedPublicationsSuggestModal: React.FC<Props> = (props): React.ReactEle
                     },
                     user.token
                 );
+                props.refreshCrosslinks();
                 onClose();
                 setToast({
                     visible: true,

--- a/ui/src/components/Publication/RelatedPublications/index.tsx
+++ b/ui/src/components/Publication/RelatedPublications/index.tsx
@@ -1,3 +1,4 @@
+import { KeyedMutator } from 'swr';
 import * as NextRouter from 'next/router';
 import React, { useState } from 'react';
 import * as Components from '@/components';
@@ -12,6 +13,7 @@ type Props = {
     publicationId: string;
     crosslinks: Interfaces.GetPublicationMixedCrosslinksResponse;
     type: Types.PublicationType;
+    refreshCrosslinks: KeyedMutator<Interfaces.GetPublicationMixedCrosslinksResponse>;
 };
 
 const RelatedPublications: React.FC<Props> = (props) => {
@@ -101,7 +103,10 @@ const RelatedPublications: React.FC<Props> = (props) => {
                                 publicationId={props.publicationId}
                                 type={props.type}
                                 open={suggestModalVisibility}
-                                onClose={() => setSuggestModalVisibility(false)}
+                                onClose={() => {
+                                    setSuggestModalVisibility(false);
+                                }}
+                                refreshCrosslinks={props.refreshCrosslinks}
                             />
                         </>
                     ) : (

--- a/ui/src/pages/publications/[id]/versions/[versionId].tsx
+++ b/ui/src/pages/publications/[id]/versions/[versionId].tsx
@@ -106,11 +106,7 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
 
     let activeCrosslinkVote: Interfaces.CrosslinkVote | null = null;
     if (suggestedFromPublicationId && activeCrosslink) {
-        api.get(`${Config.endpoints.crosslinks}/${activeCrosslink.id}/vote`, token)
-            .then((res) => {
-                activeCrosslinkVote = res.data;
-            })
-            .catch((error) => console.log(error));
+        activeCrosslinkVote = (await api.get(`${Config.endpoints.crosslinks}/${activeCrosslink.id}/vote`, token)).data;
     }
 
     if (versionRequestError) {


### PR DESCRIPTION
The purpose of this PR was to make 2 fixes to OC-773 (voting on crosslinks):

- If a user had an existing vote it wasn't being shown correctly
    - It wasn't being set correctly in getServerSideProps
- After creating a crosslink, the list should be refetched so it is immediately shown under "Most recent" in the sidebar
    - Solved using SWR mutate

---

### Acceptance Criteria:

- Pre-existing crosslink votes are shown correctly in the voting area
- After creating a crosslink, it is shown under "Most recent" in the sidebar

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added (changed)
- [ ] Documentation updated
