### PR TITLE
OC-955: Suggested links navigation improvements

### DIFF
--- a/e2e/tests/LoggedOut/crosslinking.e2e.spec.ts
+++ b/e2e/tests/LoggedOut/crosslinking.e2e.spec.ts
@@ -47,9 +47,9 @@ test.describe('Crosslinking', () => {
         const page = await browser.newPage();
         await page.goto('/publications/publication-user-1-problem-1-live');
 
-        // Open show all modal.
+        // Open view all modal.
         const relatedPublicationsSidebar = page.locator('#desktop-related-publications-items');
-        await relatedPublicationsSidebar.getByRole('button', { name: 'Show all' }).click();
+        await relatedPublicationsSidebar.getByRole('button', { name: 'View all' }).click();
 
         // Check elements.
         await expect(page.getByRole('heading', { name: 'Related Publications' })).toBeVisible();

--- a/e2e/tests/PageModel.ts
+++ b/e2e/tests/PageModel.ts
@@ -269,7 +269,6 @@ export const PageModel = {
             suggestLinkButtonLoggedOut: '#desktop-related-publications >> a[title="Sign in to suggest a link"]',
             toggle: '#desktop-related-publications >> button[title="Related Publications"]'
         },
-        showAllModal: {},
         suggestModal: {
             clearSelectionButton: 'button[title="Clear selection"]',
             openButtonLoggedIn: '#desktop-related-publications >> button[title="Suggest a link"]',

--- a/ui/src/__tests__/components/Publication/RelatedPublications.test.tsx
+++ b/ui/src/__tests__/components/Publication/RelatedPublications.test.tsx
@@ -32,12 +32,18 @@ describe('No crosslinks', () => {
             />
         );
     });
+
     it('Neither category label is shown', () => {
         expect(screen.queryByText('Most relevant')).not.toBeInTheDocument();
         expect(screen.queryByText('Most recent')).not.toBeInTheDocument();
     });
+
     it('Sign in button is shown', () => {
         expect(screen.getByRole('link', { name: 'Sign in to suggest a link' })).toBeInTheDocument();
+    });
+
+    it('View all button is not shown', () => {
+        expect(screen.queryByRole('button', { name: 'View All' })).not.toBeInTheDocument();
     });
 });
 
@@ -109,6 +115,10 @@ describe('Recent and relevant crosslinks / general tests', () => {
         const link = screen.getByRole('link', { name: 'Related publications section in FAQ' });
         expect(link).toHaveTextContent('What is this?');
         expect(link).toHaveAttribute('href', '/faq#related_publications');
+    });
+
+    it('View all button is shown', () => {
+        expect(screen.getByRole('button', { name: 'View All' })).toBeInTheDocument();
     });
 });
 

--- a/ui/src/components/Publication/RelatedPublications/SuggestModal/index.tsx
+++ b/ui/src/components/Publication/RelatedPublications/SuggestModal/index.tsx
@@ -122,7 +122,7 @@ const RelatedPublicationsSuggestModal: React.FC<Props> = (props): React.ReactEle
             wide={true}
             loading={loading}
         >
-            <div className="min-h-192">
+            <div className="min-h-[55vh]">
                 <p className="text-left mb-8">
                     Suggest a related {Helpers.formatPublicationType(props.type)} to link it to the one you are viewing
                     currently.

--- a/ui/src/components/Publication/RelatedPublications/index.tsx
+++ b/ui/src/components/Publication/RelatedPublications/index.tsx
@@ -80,7 +80,7 @@ const RelatedPublications: React.FC<Props> = (props) => {
                     {showShowAllButton && (
                         <>
                             <Components.Button
-                                title="Show All"
+                                title="View All"
                                 className="border-2 bg-teal-600 px-2.5 text-white-50 shadow-sm focus:ring-offset-2 children:border-0 children:text-white-50 justify-center w-full md:w-1/2 lg:w-full"
                                 onClick={openViewAllModal}
                             />

--- a/ui/src/components/Publication/RelatedPublications/index.tsx
+++ b/ui/src/components/Publication/RelatedPublications/index.tsx
@@ -24,7 +24,7 @@ const RelatedPublications: React.FC<Props> = (props) => {
     const [viewAllModalVisibility, setViewAllModalVisibility] = useState(false);
     const [suggestModalVisibility, setSuggestModalVisibility] = useState(false);
     const [viewAllModalKey, setViewAllModalKey] = useState(0);
-    const showShowAllButton = totalCrosslinks > 5;
+    const showViewAllButton = totalCrosslinks > 0;
 
     const openViewAllModal = () => {
         setViewAllModalVisibility(true);
@@ -77,7 +77,7 @@ const RelatedPublications: React.FC<Props> = (props) => {
                     </section>
                 )}
                 <div className="flex flex-col md:flex-row lg:flex-col gap-4 justify-between ">
-                    {showShowAllButton && (
+                    {showViewAllButton && (
                         <>
                             <Components.Button
                                 title="View All"

--- a/ui/src/pages/publications/[id]/versions/[versionId].tsx
+++ b/ui/src/pages/publications/[id]/versions/[versionId].tsx
@@ -105,8 +105,16 @@ export const getServerSideProps: Types.GetServerSideProps = async (context) => {
         await Promise.all(promises);
 
     let activeCrosslinkVote: Interfaces.CrosslinkVote | null = null;
-    if (suggestedFromPublicationId && activeCrosslink) {
-        activeCrosslinkVote = (await api.get(`${Config.endpoints.crosslinks}/${activeCrosslink.id}/vote`, token)).data;
+    if (suggestedFromPublicationId && activeCrosslink && token) {
+        try {
+            activeCrosslinkVote = (await api.get(`${Config.endpoints.crosslinks}/${activeCrosslink.id}/vote`, token))
+                .data;
+        } catch (error) {
+            // Users who haven't voted will get a 404 back from this request, which is expected.
+            if (axios.isAxiosError(error) && error.response?.status !== 404) {
+                console.error('Error fetching crosslink vote:', error);
+            }
+        }
     }
 
     if (versionRequestError) {

--- a/ui/src/pages/publications/[id]/versions/[versionId].tsx
+++ b/ui/src/pages/publications/[id]/versions/[versionId].tsx
@@ -1076,7 +1076,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                     </Components.ContentSection>
                 </section>
                 <aside className="relative hidden lg:col-span-4 lg:block xl:col-span-3">
-                    <div className="sticky top-12 space-y-8">
+                    <div className="space-y-8">
                         {showVersionsAccordion && (
                             <Components.VersionsAccordion
                                 id="desktop-versions-accordion"


### PR DESCRIPTION
The purpose of this PR was to help users to quickly view all content & functions of the suggested links feature with minimal extra navigation.

---

### Acceptance Criteria:

- The “Suggest a link” modal” is short enough to fit within the browser window on 1080p screen at 100% display scaling
- The versions, info and suggested links areas are all locked to the page rather than scrolling
- The “Show all” button is renamed to “View all”
- The “View all” button in the related publications area is visible if at least 1 link has been added

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
![Screenshot 2024-11-04 100613](https://github.com/user-attachments/assets/36f38d8e-d099-465a-9532-b8a9c6ae2d64)

E2E - IDE crashed when nearly all of them were done and I ran the rest after restarting, but the plugin lost track of the last run when it crashed... please take my word for it, they all passed!

---

### Screenshots:

AC 1 (smaller viewport height):
![Screenshot 2024-11-04 111936](https://github.com/user-attachments/assets/208e064e-d891-4871-a387-4946c0109c95)

All other ACs - renamed button, button visible with 1 crosslink, sidebar not sticky to view when scrolled down
![Screenshot 2024-11-04 111855](https://github.com/user-attachments/assets/acb7b980-9f60-4e2b-b848-e4b9d50697e7)

