### PR TITLE
OC-948: Reduce "View All" modal height

### DIFF
--- a/e2e/tests/LoggedOut/crosslinking.e2e.spec.ts
+++ b/e2e/tests/LoggedOut/crosslinking.e2e.spec.ts
@@ -61,9 +61,9 @@ test.describe('Crosslinking', () => {
         await expect(orderByRecency).toBeChecked();
         const orderByRelevance = page.getByRole('radio', { name: 'Most relevant' });
         await expect(orderByRelevance).not.toBeChecked();
-        // 5 results per page.
-        await expect(page.getByRole('link', { name: 'Visit publication' })).toHaveCount(5);
-        await expect(page.getByText(/Showing 1 - 5 of \d+/)).toBeVisible();
+        // 4 results per page.
+        await expect(page.getByRole('link', { name: 'Visit publication' })).toHaveCount(4);
+        await expect(page.getByText(/Showing 1 - 4 of \d+/)).toBeVisible();
         // Expect 6 total results (i.e. more than 1 page).
         const prevButton = page.getByRole('button', { name: 'Previous' });
         const nextButton = page.getByRole('button', { name: 'Next' });
@@ -72,11 +72,11 @@ test.describe('Crosslinking', () => {
         // Use pagination.
         await nextButton.click();
         await page.waitForResponse((response) => response.url().includes('/crosslinks') && response.ok());
-        await expect(page.getByRole('link', { name: 'Visit publication' })).toHaveCount(1);
+        await expect(page.getByRole('link', { name: 'Visit publication' })).toHaveCount(2);
         await expect(prevButton).toBeEnabled();
         await expect(nextButton).toBeDisabled();
         await prevButton.click();
-        await expect(page.getByRole('link', { name: 'Visit publication' })).toHaveCount(5);
+        await expect(page.getByRole('link', { name: 'Visit publication' })).toHaveCount(4);
         // Change order.
         await expect(page.getByRole('link', { name: 'Visit publication' }).first()).toHaveAttribute(
             'href',
@@ -100,6 +100,6 @@ test.describe('Crosslinking', () => {
         );
         await page.getByLabel('Search for suggested links').clear();
         await page.waitForResponse((response) => response.url().includes('/crosslinks') && response.ok());
-        await expect(page.getByRole('link', { name: 'Visit publication' })).toHaveCount(5);
+        await expect(page.getByRole('link', { name: 'Visit publication' })).toHaveCount(4);
     });
 });

--- a/ui/src/components/Publication/RelatedPublications/ViewAllModal/index.tsx
+++ b/ui/src/components/Publication/RelatedPublications/ViewAllModal/index.tsx
@@ -27,7 +27,7 @@ const RelatedPublicationsViewAllModal: React.FC<Props> = (props): React.ReactEle
     const [ownLinks, setOwnLinks] = useState(false);
     const [offset, setOffset] = useState(0);
     const [genericError, setGenericError] = useState('');
-    const limit = 5;
+    const limit = 4;
     const swrKey = `${Config.endpoints.publications}/${props.publicationId}/crosslinks?order=${sortOrder}&search=${searchTerm}&own=${ownLinks}&offset=${offset}&limit=${limit}`;
     const {
         data: getCrosslinksResponse,
@@ -136,7 +136,7 @@ const RelatedPublicationsViewAllModal: React.FC<Props> = (props): React.ReactEle
             <div aria-live="polite" className="sr-only">
                 {!resultCount && !isValidating && 'No results found'}
             </div>
-            <div className="min-h-160">
+            <div className="min-h-128">
                 {!resultCount && !isValidating && (
                     <Components.Alert
                         severity="INFO"


### PR DESCRIPTION
The purpose of this PR was to reduce the height of the view all crosslinks modal to reduce the chance that users have to scroll down to see the confirm/close buttons.

---

### Acceptance Criteria:

- The “View all” modal” only contains 4 results, and is short enough to fit within the browser window on 1080p screen at 100% display scaling

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
![Screenshot 2024-11-06 095835](https://github.com/user-attachments/assets/2b710b83-ba20-47de-badc-0cc23fe67839)

E2E (relevant tests)
![Screenshot 2024-11-06 095439](https://github.com/user-attachments/assets/f6a01906-0958-4547-88b9-34984a075eb7)

---

### Screenshots:

Close button is visible on a 900px high viewport
![Screenshot 2024-11-06 095930](https://github.com/user-attachments/assets/fdfd8e2b-e82c-4789-a57c-54705c94c3b2)
