### PR TITLE
OC-949: Additional UI indication of user votes

### DIFF
--- a/ui/src/components/Publication/RelatedPublications/VotingArea/index.tsx
+++ b/ui/src/components/Publication/RelatedPublications/VotingArea/index.tsx
@@ -92,22 +92,22 @@ const VotingArea: React.FC<Props> = (props): React.ReactElement => {
                 <button
                     onClick={() => handleVote(true)}
                     title="Upvote"
-                    className={`bg-white-50 flex items-center rounded disabled:select-none disabled:opacity-50 disabled:hover:cursor-not-allowed ${userHasUpvoted ? 'text-green-700 font-medium' : 'text-grey-600'}`}
+                    className={`bg-white-50 flex items-center rounded disabled:select-none disabled:opacity-50 disabled:hover:cursor-not-allowed ${userHasUpvoted ? 'text-green-700 font-medium shadow-md shadow-green-400' : 'text-grey-600'}`}
                     disabled={!user}
                 >
                     <span className="p-2">
-                        <OutlineIcons.ChevronUpIcon className="w-4 stroke-2" />
+                        <OutlineIcons.HandThumbUpIcon className="w-4 stroke-2" />
                     </span>
                     <span className="p-2 border-l border-grey-200 min-w-8">{upvotes}</span>
                 </button>
                 <button
                     onClick={() => handleVote(false)}
                     title="Downvote"
-                    className={`bg-white-50 flex items-center rounded disabled:select-none disabled:opacity-50 disabled:hover:cursor-not-allowed ${userHasDownVoted ? 'text-red-800 font-medium' : 'text-grey-600'}`}
+                    className={`bg-white-50 flex items-center rounded disabled:select-none disabled:opacity-50 disabled:hover:cursor-not-allowed ${userHasDownVoted ? 'text-red-800 font-medium shadow-md shadow-red-500' : 'text-grey-600'}`}
                     disabled={!user}
                 >
                     <span className="p-2">
-                        <OutlineIcons.ChevronDownIcon className="w-4 stroke-2" />
+                        <OutlineIcons.HandThumbDownIcon className="w-4 stroke-2" />
                     </span>
                     <span className="p-2 border-l border-grey-200 min-w-8">{downvotes}</span>
                 </button>


### PR DESCRIPTION
The purpose of this PR was to help users to be able to clearly tell whether or not they have voted on a crosslink already, and how they have voted.

---

### Acceptance Criteria:
- Voting options are displayed as “Thumbs up” and “Thumbs down” style icons instead of as carets
- Voting in favour of a suggested link causes the positive vote box to be highlighted with a green outline
- Voting against a suggested link causes the negative vote box to be highlighted with a red outline
- This outline does not conflict with the focus outline

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

Change not covered in tests

---

### Screenshots:
![Screenshot 2024-11-07 140440](https://github.com/user-attachments/assets/6f7f094b-0d7a-4a3f-b6c6-ffd64abdcc9e)
![Screenshot 2024-11-07 140446](https://github.com/user-attachments/assets/9fa075d9-9463-4517-8223-2eb67c465605)


