### PR TITLE
OC-946: Include "Background" heading on ARIs

### DIFF
--- a/api/.swcrc
+++ b/api/.swcrc
@@ -112,7 +112,7 @@
     },
     "minify": false,
     "exclude": [
-        "__tests__/", // Jest (and whatever other test runner we use) compiles these
+        "./**/__tests__/", // Jest (and whatever other test runner we use) compiles these
         "prisma"
     ]
 }

--- a/api/prisma/seeds/local/unitTesting/publications.ts
+++ b/api/prisma/seeds/local/unitTesting/publications.ts
@@ -798,7 +798,7 @@ const publicationSeeds: Prisma.PublicationCreateInput[] = [
                     // ARI Question title
                     '<p>ARI Publication 1</p>' +
                     // Background information
-                    '<p>Sample background information.</p>' +
+                    '<p><strong>Background</strong></p><p>Sample background information.</p>' +
                     // Contact details
                     '<p><strong>Contact details</strong></p><p>Sample contact details.</p>' +
                     // Related UKRI projects

--- a/api/src/components/integration/__tests__/ari.test.ts
+++ b/api/src/components/integration/__tests__/ari.test.ts
@@ -62,7 +62,7 @@ describe('ARI Mapping', () => {
                     // ARI Question title
                     '<p>ARI Publication 1</p>' +
                     // Background information
-                    '<p>Sample background information.</p>' +
+                    '<p><strong>Background</strong></p><p>Sample background information.</p>' +
                     // Contact details
                     '<p><strong>Contact details</strong></p><p>Sample contact details.</p>' +
                     // Related UKRI projects
@@ -84,7 +84,7 @@ describe('ARI Mapping', () => {
                 content:
                     "<p><strong>Question group</strong></p><p><em>This problem is a UK government area of research interest (ARI) that was originally posted at <a target='_blank' href='https://ari.org.uk/'>https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</em></p><p>ARI Publication 1</p>" +
                     // Background information
-                    '<p>Background information line 1.<br>Background information line 2.<br><br>Background information line 3.</p>' +
+                    '<p><strong>Background</strong></p><p>Background information line 1.<br>Background information line 2.<br><br>Background information line 3.</p>' +
                     // Contact details
                     '<p><strong>Contact details</strong></p><p>Contact details line 1.<br>Contact details line 2.<br><br>Contact details line 3.</p>' +
                     '<p><strong>Related UKRI Projects</strong></p><ul><li><a href="https://gtr.ukri.org/projects?ref=ES%2FS007105%2F1">Urban Big Data Centre</a></li><li><a href="https://gtr.ukri.org/projects?ref=ES%2FL011921%2F1">Urban Big Data</a></li></ul>'
@@ -274,7 +274,7 @@ describe('ARI handling', () => {
                     '<p><strong>New question group</strong></p>' +
                     "<p><em>This problem is a UK government area of research interest (ARI) that was originally posted at <a target='_blank' href='https://ari.org.uk/'>https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</em></p>" +
                     '<p>ARI Publication 1</p>' +
-                    '<p>New background information.</p>' +
+                    '<p><strong>Background</strong></p><p>New background information.</p>' +
                     '<p><strong>Contact details</strong></p><p>New contact details.</p>' +
                     '<p><strong>Related UKRI Projects</strong></p><ul><li><a href="https://jisc.ac.uk">Test</a></li></ul>'
             }
@@ -364,7 +364,7 @@ describe('ARI handling', () => {
                     '<p><strong>Question group</strong></p>' +
                     "<p><em>This problem is a UK government area of research interest (ARI) that was originally posted at <a target='_blank' href='https://ari.org.uk/'>https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</em></p>" +
                     '<p>ARI Publication 1</p>' +
-                    '<p>Sample background information.</p>' +
+                    '<p><strong>Background</strong></p><p>Sample background information.</p>' +
                     '<p><strong>Contact details</strong></p><p>Sample contact details.</p>' +
                     '<p><strong>Related UKRI Projects</strong></p><ul><li><a href="https://gtr.ukri.org/projects?ref=ES%2FS007105%2F1">Urban Big Data Centre</a></li><li><a href="https://gtr.ukri.org/projects?ref=ES%2FL011921%2F1">Urban Big Data</a></li></ul>',
                 keywords: ['field of research 1', 'field of research 2', 'tag 1', 'tag 2'],

--- a/api/src/components/integration/ariUtils.ts
+++ b/api/src/components/integration/ariUtils.ts
@@ -62,7 +62,9 @@ export const mapAriQuestionToPublicationVersion = async (
     const commonBoilerplateHTML =
         "<p><em>This problem is a UK government area of research interest (ARI) that was originally posted at <a target='_blank' href='https://ari.org.uk/'>https://ari.org.uk/</a> by a UK government organisation to indicate that they are keen to see research related to this area.</em></p>";
     const titleHTML = `<p>${question}</p>`;
-    const backgroundInformationHTML = backgroundInformation ? `<p>${parseAriTextField(backgroundInformation)}</p>` : '';
+    const backgroundInformationHTML = backgroundInformation
+        ? `<p><strong>Background</strong></p><p>${parseAriTextField(backgroundInformation)}</p>`
+        : '';
     const contactDetailsHTML = contactDetails
         ? `<p><strong>Contact details</strong></p><p>${parseAriTextField(contactDetails)}</p>`
         : '';


### PR DESCRIPTION
The purpose of this PR was to help users to infer that the background text on an ARI may be broader in scope than the specific ARI they are viewing by adding a heading to the background information section.

---

### Acceptance Criteria:

- ARIs have a “Background” heading included in bold text immediately above the background section.
- Complete a full re ingest of all whitelisted ARI departments on int (to do after code review)

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

API
(tests were run before the fix to .swcrc file to exclude test files from dist)
![Screenshot 2024-11-11 093259](https://github.com/user-attachments/assets/6b70fbee-7cfc-4a98-9987-a207a99cb1a5)

---

### Screenshots:
![Screenshot 2024-11-11 102128](https://github.com/user-attachments/assets/8ce72c76-9ac1-4c3d-a1d1-49f1037fc0c4)
