### PR TITLE
OC-958: Move publish options to sit above title

### DIFF
--- a/e2e/tests/PageModel.ts
+++ b/e2e/tests/PageModel.ts
@@ -98,7 +98,7 @@ export const PageModel = {
         verifyEmailForMoreButton: 'text=Verify your email for more actions',
         addBookmark: '[title="Bookmark this publication"]',
         removeBookmark: '[title="Remove bookmark"]',
-        writeReview: 'button[aria-label="Write a review"]',
+        writeReview: 'a[aria-label="Write a review"]',
         flagConcern: 'button[aria-label="Flag a concern with this publication"]',
         redFlagComment: '#red-flag-comment',
         redFlagSubmit: '[aria-label="Submit"]',

--- a/e2e/tests/helpers/livePublication.ts
+++ b/e2e/tests/helpers/livePublication.ts
@@ -1,4 +1,4 @@
-import { expect, Page } from '@playwright/test';
+import { BrowserContext, expect, Page } from '@playwright/test';
 import { PageModel } from '../PageModel';
 
 export const checkLivePublicationLayout = async (page: Page, id: string, loggedIn?: boolean) => {
@@ -20,8 +20,10 @@ export const checkLivePublicationLayout = async (page: Page, id: string, loggedI
     );
 
     if (loggedIn) {
-        // Confirm review link
-        await page.locator(PageModel.livePublication.writeReview).locator('visible=true').click();
-        await expect(page).toHaveURL(`/create?for=${id}&type=PEER_REVIEW`);
+        // Expect review link
+        await expect(page.locator(PageModel.livePublication.writeReview).locator('visible=true')).toHaveAttribute(
+            'href',
+            `/create?for=${id}&type=PEER_REVIEW`
+        );
     }
 };

--- a/ui/src/components/AccordionSection/index.tsx
+++ b/ui/src/components/AccordionSection/index.tsx
@@ -27,7 +27,8 @@ const AccordionSection: React.FC<Props> = (props) => {
                 <Components.Button
                     id={toggleId}
                     title={props.title}
-                    className={`w-full justify-between bg-grey-50 px-6 py-1 font-inter transition-all duration-300 children:border-0 dark:bg-grey-700 ${
+                    variant="block"
+                    className={`w-full justify-between bg-grey-50 px-6 py-1 font-inter transition-all duration-300 dark:bg-grey-700 ${
                         expanded ? 'rounded-none rounded-t' : ''
                     }`}
                     endIcon={

--- a/ui/src/components/Button/index.tsx
+++ b/ui/src/components/Button/index.tsx
@@ -3,60 +3,62 @@ import React from 'react';
 import * as Components from '@/components';
 
 type CommonProps = {
-    id?: string;
-    title: string;
-    endIcon?: React.ReactElement;
-    startIcon?: React.ReactElement;
-    onClick?: (e: React.MouseEvent) => void;
-    disabled?: boolean;
-    className?: string;
-    childClassName?: string;
-    textSize?: string;
-    padding?: string;
-    children?: React.ReactNode;
     accordionConfig?: {
         contentElementId: string;
         expanded: Boolean;
     };
+    childClassName?: string;
+    children?: React.ReactNode;
+    className?: string;
+    disabled?: boolean;
+    endIcon?: React.ReactElement;
+    id?: string;
+    onClick?: (e: React.MouseEvent) => void;
+    padding?: string;
+    startIcon?: React.ReactElement;
+    textSize?: string;
+    title: string;
+    variant?: 'underlined' | 'block' | 'block-alt';
 };
 
 type ConditionalProps = { href: string; openNew?: boolean } | { href?: never; openNew?: never };
 
 type Props = CommonProps & ConditionalProps;
 
+const blockClasses =
+    'border-2 px-2.5 text-white-50 shadow-sm focus:ring-offset-2 children:border-0 children:text-white-50 ';
+
 const Button: React.FC<Props> = (props): React.ReactElement | null => {
     const parentStyles = React.useMemo(() => {
-        return `
-            group
-            inline-flex
-            items-center
-            outline-0
-            focus:ring-2
-            focus:ring-yellow-400
-            disabled:select-none
-            disabled:opacity-50
-            disabled:hover:cursor-not-allowed
-            ${props.className ?? ''}
-            `;
-    }, [props.className]);
+        let classes =
+            'disabled:select-none disabled:opacity-50 disabled:hover:cursor-not-allowed inline-flex items-center w-fit ';
+        switch (props.variant) {
+            case 'block':
+                classes += blockClasses + 'bg-teal-600 ';
+                break;
+            case 'block-alt':
+                classes += blockClasses + 'bg-green-600 ';
+                break;
+            default:
+                classes += 'outline-0 focus:ring-2 focus:ring-yellow-400 ';
+        }
+        classes += props.className ?? '';
+        return classes;
+    }, [props.className, props.variant]);
 
     const childStyles = React.useMemo(() => {
-        return `
-            ${props.startIcon ? 'ml-3' : ''}
-            ${props.endIcon ? 'mr-3' : ''}
-            ${props.padding ? props.padding : 'py-2'}
-            font-montserrat
-            text-${props.textSize ? props.textSize : 'sm'}
-            font-semibold
-            text-grey-800
-            dark:text-white-50
-            transition-colors
-            duration-500
-            border-b-2
-            border-b-teal-500
-            dark:border-b-teal-400
-            ${props.childClassName ?? ''}
-            `;
+        return (
+            // Shared classes
+            'font-montserrat font-semibold' +
+            // Underline only
+            (props.variant !== 'block'
+                ? ' border-b-2 border-b-teal-500 dark:border-b-teal-400 text-grey-800 dark:text-white-50 transition-colors duration-500'
+                : '') +
+            (props.startIcon ? ' ml-3' : '') +
+            (props.endIcon ? ' mr-3' : '') +
+            (props.padding ? ' ' + props.padding : ' py-2') +
+            ` text-${props.textSize ? props.textSize : 'sm'} ${props.childClassName ?? ''}`
+        );
     }, [props.endIcon, props.padding, props.startIcon, props.textSize]);
 
     return props.href ? (

--- a/ui/src/components/Nav/index.tsx
+++ b/ui/src/components/Nav/index.tsx
@@ -45,13 +45,17 @@ const Nav: React.FC = (): React.ReactElement => {
         setOpen(false);
     }, []);
 
-    const handleLogOut = useCallback(async () => {
-        await router.push({
-            pathname: `${Config.urls.home.path}`
-        });
-        Helpers.clearJWT();
-        setUser(null);
-    }, [router, setUser]);
+    const handleLogOut = useCallback(
+        (event: React.MouseEvent<HTMLAnchorElement>) => {
+            event.preventDefault();
+            Helpers.clearJWT();
+            setUser(null);
+            router.push({
+                pathname: `${Config.urls.home.path}`
+            });
+        },
+        [router, setUser]
+    );
 
     const items = useMemo(() => {
         const menuItems: Interfaces.NavMenuItem[] = [
@@ -122,7 +126,7 @@ const Nav: React.FC = (): React.ReactElement => {
                     {
                         label: 'Log out',
                         value: '#log-out',
-                        onClick: () => handleLogOut()
+                        onClick: handleLogOut
                     }
                 ]
             });

--- a/ui/src/components/Publication/PublicationPage/CoAuthoringActions/index.tsx
+++ b/ui/src/components/Publication/PublicationPage/CoAuthoringActions/index.tsx
@@ -18,7 +18,7 @@ type Props = {
     onEditAffiliations: () => void;
 };
 
-const ActionBar: React.FC<Props> = (props) => {
+const CoAuthoringActions: React.FC<Props> = (props) => {
     const { user } = Stores.useAuthStore();
 
     const author = React.useMemo(
@@ -167,7 +167,8 @@ const ActionBar: React.FC<Props> = (props) => {
 
                 {props.isCorrespondingAuthor ? (
                     <Components.Button
-                        className="inline-flex max-w-fit items-center border-2 bg-teal-600 px-2.5 text-white-50 shadow-sm outline-0 focus:overflow-hidden focus:ring-offset-2 disabled:select-none disabled:opacity-50 disabled:hover:cursor-not-allowed children:border-0 children:text-white-50"
+                        className="max-w-fit"
+                        variant="block"
                         disabled={!props.isReadyForPublish || props.isPublishing}
                         endIcon={<OutlineIcons.CloudArrowUpIcon className="w-5 shrink-0 text-white-50" />}
                         title="Publish"
@@ -177,7 +178,8 @@ const ActionBar: React.FC<Props> = (props) => {
                     </Components.Button>
                 ) : isApproved ? (
                     <Components.Button
-                        className="inline-flex max-w-fit items-center border-2 bg-red-600 px-2.5 text-white-50 shadow-sm outline-0 focus:overflow-hidden focus:ring-offset-2 disabled:select-none disabled:opacity-50 disabled:hover:cursor-not-allowed children:border-0 children:text-white-50"
+                        className="max-w-fit"
+                        variant="block"
                         endIcon={<OutlineIcons.XMarkIcon className="w-5 shrink-0 text-white-50" />}
                         title="Cancel your approval"
                         onClick={props.onCancelApproval}
@@ -186,7 +188,8 @@ const ActionBar: React.FC<Props> = (props) => {
                     </Components.Button>
                 ) : (
                     <Components.Button
-                        className="inline-flex max-w-fit items-center border-2 bg-teal-600 px-2.5 text-white-50 shadow-sm outline-0 focus:overflow-hidden focus:ring-offset-2 disabled:select-none disabled:opacity-50 disabled:hover:cursor-not-allowed children:border-0 children:text-white-50"
+                        className="max-w-fit"
+                        variant="block"
                         disabled={!(author?.isIndependent || author?.affiliations.length)}
                         endIcon={<OutlineIcons.CheckIcon className="w-5 shrink-0 text-white-50" />}
                         title="Approve this publication"
@@ -200,4 +203,4 @@ const ActionBar: React.FC<Props> = (props) => {
     );
 };
 
-export default ActionBar;
+export default CoAuthoringActions;

--- a/ui/src/components/Publication/PublicationPage/HeaderActions/index.tsx
+++ b/ui/src/components/Publication/PublicationPage/HeaderActions/index.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import * as Components from '@/components';
+import * as Config from '@/config';
+import * as Helpers from '@/helpers';
+import * as Stores from '@/stores';
+import * as Types from '@/types';
+
+type Props = {
+    authorIds: string[];
+    publicationId: string;
+    publicationType: Types.PublicationType;
+};
+
+const HeaderActions: React.FC<Props> = (props) => {
+    const { user } = Stores.useAuthStore();
+
+    return user ? (
+        <div className="col-span-8 mb-10 pb-10 flex flex-col md:flex-row gap-4 md:gap-8 border-b border-grey-200">
+            {Helpers.linkedPublicationTypes[props.publicationType as keyof typeof Helpers.linkedPublicationTypes].map(
+                (childPublicationType) => {
+                    return (
+                        <Components.Button
+                            variant="block"
+                            title={`Write a linked ${Helpers.formatPublicationType(childPublicationType as Types.PublicationType)}`}
+                            key={childPublicationType}
+                            href={`${Config.urls.createPublication.path}?for=${props.publicationId}&type=${childPublicationType}`}
+                            openNew={true}
+                        />
+                    );
+                }
+            )}
+            {!props.authorIds.includes(user.id) && (
+                <Components.Button
+                    title="Write a review"
+                    variant="block"
+                    href={`${Config.urls.createPublication.path}?for=${props.publicationId}&type=PEER_REVIEW`}
+                    openNew={true}
+                />
+            )}
+        </div>
+    ) : null;
+};
+
+export default HeaderActions;

--- a/ui/src/components/Publication/PublicationPage/HeaderActions/index.tsx
+++ b/ui/src/components/Publication/PublicationPage/HeaderActions/index.tsx
@@ -14,7 +14,11 @@ type Props = {
 const HeaderActions: React.FC<Props> = (props) => {
     const { user } = Stores.useAuthStore();
 
-    return user ? (
+    if (!user) {
+        return null;
+    }
+
+    return (
         <div className="col-span-8 mb-10 pb-10 flex flex-col md:flex-row gap-4 md:gap-8 border-b border-grey-200">
             {Helpers.linkedPublicationTypes[props.publicationType as keyof typeof Helpers.linkedPublicationTypes].map(
                 (childPublicationType) => {
@@ -38,7 +42,7 @@ const HeaderActions: React.FC<Props> = (props) => {
                 />
             )}
         </div>
-    ) : null;
+    );
 };
 
 export default HeaderActions;

--- a/ui/src/components/Publication/RelatedPublications/index.tsx
+++ b/ui/src/components/Publication/RelatedPublications/index.tsx
@@ -81,7 +81,8 @@ const RelatedPublications: React.FC<Props> = (props) => {
                         <>
                             <Components.Button
                                 title="View All"
-                                className="border-2 bg-teal-600 px-2.5 text-white-50 shadow-sm focus:ring-offset-2 children:border-0 children:text-white-50 justify-center w-full md:w-1/2 lg:w-full"
+                                variant="block"
+                                className="justify-center w-full md:w-1/2 lg:w-full"
                                 onClick={openViewAllModal}
                             />
                             <Components.RelatedPublicationsViewAllModal
@@ -96,7 +97,8 @@ const RelatedPublications: React.FC<Props> = (props) => {
                         <>
                             <Components.Button
                                 title="Suggest a link"
-                                className="border-2 bg-teal-600 px-2.5 text-white-50 shadow-sm focus:ring-offset-2 children:border-0 children:text-white-50 justify-center w-full md:w-1/2 lg:w-full"
+                                variant="block"
+                                className="justify-center w-full md:w-1/2 lg:w-full"
                                 onClick={() => setSuggestModalVisibility((prevState) => !prevState)}
                             />
                             <Components.RelatedPublicationsSuggestModal
@@ -112,7 +114,8 @@ const RelatedPublications: React.FC<Props> = (props) => {
                     ) : (
                         <Components.Button
                             title="Sign in to suggest a link"
-                            className="border-2 bg-teal-600 px-2.5 text-white-50 shadow-sm focus:ring-offset-2 children:border-0 children:text-white-50 justify-center w-full md:w-1/2 lg:w-full"
+                            variant="block"
+                            className="justify-center w-full md:w-1/2 lg:w-full"
                             href={`${Config.urls.orcidLogin.path}&state=${encodeURIComponent(router.asPath)}`}
                         />
                     )}

--- a/ui/src/components/Publication/SidebarCard/Actions/index.tsx
+++ b/ui/src/components/Publication/SidebarCard/Actions/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Image from 'next/image';
 import * as SWR from 'swr';
-import * as Router from 'next/router';
 import * as OutlineIcons from '@heroicons/react/24/outline';
 import * as Interfaces from '@/interfaces';
 import * as Components from '@/components';
@@ -19,7 +18,6 @@ type ActionProps = {
 };
 
 const Actions: React.FC<ActionProps> = (props): React.ReactElement => {
-    const router = Router.useRouter();
     const SWRConfig = SWR.useSWRConfig();
     // Store
     const user = Stores.useAuthStore((state) => state.user);
@@ -35,6 +33,10 @@ const Actions: React.FC<ActionProps> = (props): React.ReactElement => {
     // Misc state
     const [error, setError] = React.useState<string | undefined>();
     const [submitting, setSubmitting] = React.useState(false);
+
+    const authorIds = props.publicationVersion.coAuthors.flatMap((coAuthor) =>
+        coAuthor.linkedUser ? [coAuthor.linkedUser] : []
+    );
 
     const saveRedFlag = async () => {
         setError(undefined);
@@ -208,53 +210,12 @@ const Actions: React.FC<ActionProps> = (props): React.ReactElement => {
                                 Make your name visible on your ORCiD profile for more actions
                             </Components.Link>
                         ) : user && user.email ? (
-                            <>
-                                {/* if the publication is a peer review, no options shall be given to write a linked publication */}
-                                {props.publicationVersion.publication.type !== 'PEER_REVIEW' && (
-                                    <>
-                                        {Helpers.linkedPublicationTypes[
-                                            props.publicationVersion.publication
-                                                .type as keyof typeof Helpers.linkedPublicationTypes
-                                        ].map((item: any) => {
-                                            return (
-                                                <Components.PublicationSidebarCardActionsButton
-                                                    label={`Write a linked ${Helpers.formatPublicationType(item)}`}
-                                                    key={item}
-                                                    onClick={() => {
-                                                        router.push({
-                                                            pathname: `${Config.urls.createPublication.path}`,
-                                                            query: {
-                                                                for: props.publicationVersion.versionOf,
-                                                                type: item
-                                                            }
-                                                        });
-                                                    }}
-                                                />
-                                            );
-                                        })}
-                                        {props.publicationVersion.user.id !== user.id && (
-                                            <>
-                                                <Components.PublicationSidebarCardActionsButton
-                                                    label="Write a review"
-                                                    onClick={() => {
-                                                        router.push({
-                                                            pathname: `${Config.urls.createPublication.path}`,
-                                                            query: {
-                                                                for: props.publicationVersion.versionOf,
-                                                                type: 'PEER_REVIEW'
-                                                            }
-                                                        });
-                                                    }}
-                                                />
-                                                <Components.PublicationSidebarCardActionsButton
-                                                    label="Flag a concern with this publication"
-                                                    onClick={() => setShowRedFlagModal(true)}
-                                                />
-                                            </>
-                                        )}
-                                    </>
-                                )}
-                            </>
+                            !authorIds.includes(user.id) && (
+                                <Components.PublicationSidebarCardActionsButton
+                                    label="Flag a concern with this publication"
+                                    onClick={() => setShowRedFlagModal(true)}
+                                />
+                            )
                         ) : (
                             <>
                                 <Components.Link

--- a/ui/src/components/Publication/SimpleResult/index.tsx
+++ b/ui/src/components/Publication/SimpleResult/index.tsx
@@ -52,6 +52,7 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
                 disabled={loadingControlRequest}
                 title="Take over editing"
                 variant="block-alt"
+                className="mt-5"
                 onClick={handleControlRequest}
                 endIcon={<OutlineIcons.PencilSquareIcon className="h-4" />}
             />
@@ -64,6 +65,7 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
             endIcon={<OutlineIcons.EyeIcon className="h-4" />}
             title="View Draft"
             variant="block-alt"
+            className="mt-5"
         />
     );
 
@@ -147,6 +149,7 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
                                         href={`/author-link?email=${props.user.email}&publicationId=${props.publication.id}&versionId=${draftVersion.id}&approve=true`}
                                         title="Confirm Involvement"
                                         variant="block-alt"
+                                        className="mt-5"
                                     />
                                 </>
                             )
@@ -158,6 +161,7 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
                                 endIcon={<OutlineIcons.PencilSquareIcon className="h-4" />}
                                 title="Edit Draft"
                                 variant="block-alt"
+                                className="mt-5"
                             />
                         )}
                     </div>
@@ -179,6 +183,7 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
                                 disabled={loadingNewVersion}
                                 title="Create Draft Version"
                                 variant="block-alt"
+                                className="mt-5"
                                 onClick={handleCreateNewVersion}
                                 endIcon={<OutlineIcons.PencilSquareIcon className="h-4" />}
                             />
@@ -211,6 +216,7 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
                                 endIcon={<OutlineIcons.ArrowTopRightOnSquareIcon className="h-4" />}
                                 title="View"
                                 variant="block"
+                                className="mt-5"
                             />
                             <Components.EngagementCounts flagCount={flagCount} peerReviewCount={peerReviewCount} />
                         </div>

--- a/ui/src/components/Publication/SimpleResult/index.tsx
+++ b/ui/src/components/Publication/SimpleResult/index.tsx
@@ -51,9 +51,9 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
             <Components.Button
                 disabled={loadingControlRequest}
                 title="Take over editing"
+                variant="block-alt"
                 onClick={handleControlRequest}
                 endIcon={<OutlineIcons.PencilSquareIcon className="h-4" />}
-                className="mt-5 w-fit bg-green-600 px-3 text-white-50 children:border-none children:text-white-50"
             />
         </>
     );
@@ -63,7 +63,7 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
             href={`/publications/${props.publication.id}`}
             endIcon={<OutlineIcons.EyeIcon className="h-4" />}
             title="View Draft"
-            className="mt-5 w-fit bg-green-600 px-3 text-white-50 children:border-none children:text-white-50"
+            variant="block-alt"
         />
     );
 
@@ -146,7 +146,7 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
                                     <Components.Button
                                         href={`/author-link?email=${props.user.email}&publicationId=${props.publication.id}&versionId=${draftVersion.id}&approve=true`}
                                         title="Confirm Involvement"
-                                        className="mt-5 w-fit bg-green-600 px-3 text-white-50 children:border-none children:text-white-50"
+                                        variant="block-alt"
                                     />
                                 </>
                             )
@@ -157,7 +157,7 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
                                 href={`/publications/${props.publication.id}/edit?step=0`}
                                 endIcon={<OutlineIcons.PencilSquareIcon className="h-4" />}
                                 title="Edit Draft"
-                                className="mt-5 w-fit bg-green-600 px-3 text-white-50 children:border-none children:text-white-50"
+                                variant="block-alt"
                             />
                         )}
                     </div>
@@ -178,9 +178,9 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
                             <Components.Button
                                 disabled={loadingNewVersion}
                                 title="Create Draft Version"
+                                variant="block-alt"
                                 onClick={handleCreateNewVersion}
                                 endIcon={<OutlineIcons.PencilSquareIcon className="h-4" />}
-                                className="mt-5 bg-green-600 px-3 text-white-50 children:border-none children:text-white-50"
                             />
                         </>
                     )
@@ -210,7 +210,7 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
                                 href={`/publications/${props.publication.id}`}
                                 endIcon={<OutlineIcons.ArrowTopRightOnSquareIcon className="h-4" />}
                                 title="View"
-                                className="bg-teal-500 px-3 text-white-50 children:border-none children:text-white-50"
+                                variant="block"
                             />
                             <Components.EngagementCounts flagCount={flagCount} peerReviewCount={peerReviewCount} />
                         </div>

--- a/ui/src/components/index.tsx
+++ b/ui/src/components/index.tsx
@@ -1,5 +1,4 @@
 export { default as AccordionSection } from './AccordionSection';
-export { default as ActionBar } from './Publication/ActionBar';
 export { default as ActionCard } from './ActionCard';
 export { default as AdditionalInformationCard } from './AdditionalInformationCard';
 export { default as AdditionalInformationForm } from './Publication/Creation/AdditionalInformation/Form';
@@ -72,6 +71,7 @@ export { default as PublicationCreationMainText } from './Publication/Creation/M
 export { default as PublicationCreationResearchProcess } from './Publication/Creation/ResearchProcess';
 export { default as PublicationCreationStepTitle } from './Publication/Creation/StepTitle';
 export { default as PublicationLink } from './Publication/Link';
+export { default as PublicationPageCoAuthoringActions } from './Publication/PublicationPage/CoAuthoringActions';
 export { default as PublicationSearchResult } from './Publication/SearchResult';
 export { default as PublicationSidebar } from './Publication/Sidebar';
 export { default as PublicationSidebarCardActions } from './Publication/SidebarCard/Actions';

--- a/ui/src/components/index.tsx
+++ b/ui/src/components/index.tsx
@@ -72,6 +72,7 @@ export { default as PublicationCreationResearchProcess } from './Publication/Cre
 export { default as PublicationCreationStepTitle } from './Publication/Creation/StepTitle';
 export { default as PublicationLink } from './Publication/Link';
 export { default as PublicationPageCoAuthoringActions } from './Publication/PublicationPage/CoAuthoringActions';
+export { default as PublicationPageHeaderActions } from './Publication/PublicationPage/HeaderActions';
 export { default as PublicationSearchResult } from './Publication/SearchResult';
 export { default as PublicationSidebar } from './Publication/Sidebar';
 export { default as PublicationSidebarCardActions } from './Publication/SidebarCard/Actions';

--- a/ui/src/config/endpoints.ts
+++ b/ui/src/config/endpoints.ts
@@ -1,19 +1,30 @@
-import * as api from '@/api';
+export let baseURL: string;
 
-const endpoints = {
-    authorization: `${api.baseURL}/authorization`,
-    bookmarks: `${api.baseURL}/bookmarks`,
-    crosslinks: `${api.baseURL}/crosslinks`,
-    decodeUserToken: `${api.baseURL}/decode-user-token`,
-    flags: `${api.baseURL}/flags`,
-    links: `${api.baseURL}/links`,
-    publications: `${api.baseURL}/publications`,
-    publicationVersions: `${api.baseURL}/publication-versions`,
-    revokeOrcidAccess: `${api.baseURL}/revoke-orcid-access`,
-    topics: `${api.baseURL}/topics`,
-    users: `${api.baseURL}/users`,
-    verification: `${api.baseURL}/verification`,
-    verifyOrcidAccess: `${api.baseURL}/verify-orcid-access`
+switch (process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF) {
+    case 'local':
+        baseURL = 'http://127.0.0.1:4003/local/v1'; // https://github.com/node-fetch/node-fetch/issues/1624
+        break;
+    case 'main':
+        baseURL = 'https://octopus.ac/v1';
+        break;
+    default:
+        baseURL = `https://${process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF}.octopus.ac/v1`;
+        break;
+}
+
+export default {
+    authorization: `${baseURL}/authorization`,
+    base: baseURL,
+    bookmarks: `${baseURL}/bookmarks`,
+    crosslinks: `${baseURL}/crosslinks`,
+    decodeUserToken: `${baseURL}/decode-user-token`,
+    flags: `${baseURL}/flags`,
+    links: `${baseURL}/links`,
+    publications: `${baseURL}/publications`,
+    publicationVersions: `${baseURL}/publication-versions`,
+    revokeOrcidAccess: `${baseURL}/revoke-orcid-access`,
+    topics: `${baseURL}/topics`,
+    users: `${baseURL}/users`,
+    verification: `${baseURL}/verification`,
+    verifyOrcidAccess: `${baseURL}/verify-orcid-access`
 };
-
-export default endpoints;

--- a/ui/src/config/errors.ts
+++ b/ui/src/config/errors.ts
@@ -1,6 +1,0 @@
-export class SearchThrowError extends Error {
-    constructor(message: string) {
-        super(message);
-        Object.setPrototypeOf(this, SearchThrowError.prototype);
-    }
-}

--- a/ui/src/config/index.ts
+++ b/ui/src/config/index.ts
@@ -3,4 +3,3 @@ export { default as keys } from './keys';
 export { default as screens } from './screens';
 export { default as endpoints } from './endpoints';
 export * as values from './values';
-export * as CustomErros from './errors';

--- a/ui/src/layouts/BuildPublication.tsx
+++ b/ui/src/layouts/BuildPublication.tsx
@@ -707,7 +707,7 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
                                     onClick={handlePreview}
                                     disabled={!isReadyToPreview}
                                     endIcon={<OutlineIcons.EyeIcon className="text-white-500 h-5 w-5" />}
-                                    className="border-2 bg-teal-600 px-2.5 text-white-50 shadow-sm focus:ring-offset-2 children:border-0 children:text-white-50"
+                                    variant="block"
                                 >
                                     Preview
                                 </Components.Button>
@@ -717,7 +717,7 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
                                         onClick={() => setRequestApprovalModalVisibility(true)}
                                         disabled={!isReadyToRequestApproval}
                                         endIcon={<OutlineIcons.CloudArrowUpIcon className="h-5 w-5 text-white-50" />}
-                                        className="border-2 bg-teal-600 px-2.5 text-white-50 shadow-sm focus:ring-offset-2 children:border-0 children:text-white-50"
+                                        variant="block"
                                     />
                                 ) : (
                                     <Components.Button
@@ -725,13 +725,13 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
                                         onClick={() => setPublishModalVisibility(true)}
                                         disabled={!isReadyToPublish}
                                         endIcon={<OutlineIcons.CloudArrowUpIcon className="h-5 w-5 text-white-50" />}
-                                        className="border-2 bg-teal-600 px-2.5 text-white-50 shadow-sm focus:ring-offset-2 children:border-0 children:text-white-50"
+                                        variant="block"
                                     />
                                 )}
                                 <Components.Button
                                     title="Save"
                                     onClick={() => setSaveModalVisibility(true)}
-                                    className="border-0 bg-green-600 px-2.5 text-white-50 shadow-sm focus:ring-offset-2 children:border-0 children:text-white-50"
+                                    variant="block-alt"
                                     endIcon={<ReactIconsFA.FaRegSave className="h-5 w-5 text-white-50" />}
                                 />
                                 <Components.Button
@@ -831,7 +831,7 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
                             <Components.Button
                                 title="Save"
                                 onClick={() => setSaveModalVisibility(true)}
-                                className="border-0 bg-green-600 px-2.5 text-white-50 shadow-sm focus:ring-offset-2 children:border-0 children:text-white-50"
+                                variant="block-alt"
                                 endIcon={<ReactIconsFA.FaRegSave className="h-5 w-5 text-white-50" />}
                             />
                             <Components.Button
@@ -854,14 +854,14 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
                                         }
                                         disabled={!isReadyToPreview}
                                         endIcon={<OutlineIcons.EyeIcon className="text-white-500 h-5 w-5" />}
-                                        className="border-2 bg-teal-600 px-2.5 text-white-50 shadow-sm focus:ring-offset-2 children:border-0 children:text-white-50"
+                                        variant="block"
                                         onClick={handlePreview}
                                     >
                                         Preview
                                     </Components.Button>
                                     {hasUnconfirmedCoAuthors ? (
                                         <Components.Button
-                                            className="border-2 bg-teal-600 px-2.5 text-white-50 shadow-sm focus:ring-offset-2 children:border-0 children:text-white-50"
+                                            variant="block"
                                             disabled={!isReadyToRequestApproval}
                                             endIcon={
                                                 <OutlineIcons.CloudArrowUpIcon className="h-5 w-5 text-white-50" />
@@ -871,7 +871,7 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
                                         />
                                     ) : (
                                         <Components.Button
-                                            className="border-2 bg-teal-600 px-2.5 text-white-50 shadow-sm focus:ring-offset-2 children:border-0 children:text-white-50"
+                                            variant="block"
                                             disabled={!isReadyToPublish}
                                             endIcon={
                                                 <OutlineIcons.CloudArrowUpIcon className="h-5 w-5 text-white-50" />

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -4,22 +4,8 @@ import * as Interfaces from '@/interfaces';
 import * as Config from '@/config';
 import * as Types from '@/types';
 
-export let baseURL: string;
-
-switch (process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF) {
-    case 'local':
-        baseURL = 'http://127.0.0.1:4003/local/v1'; // https://github.com/node-fetch/node-fetch/issues/1624
-        break;
-    case 'main':
-        baseURL = 'https://api.octopus.ac/v1';
-        break;
-    default:
-        baseURL = `https://${process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_REF}.api.octopus.ac/v1`;
-        break;
-}
-
 const api = axios.create({
-    baseURL
+    baseURL: Config.endpoints.base
 });
 
 export const get = async (url: string, token?: string): Promise<AxiosResponse> => {

--- a/ui/src/pages/about.tsx
+++ b/ui/src/pages/about.tsx
@@ -218,7 +218,7 @@ const About: NextPage = (): React.ReactElement => (
                             content="Review our FAQs to find out more about how the platform works."
                             icon={<OutlineIcons.QuestionMarkCircleIcon className="h-8 w-8 text-teal-500" />}
                             link={Config.urls.faq.path}
-                            linkText="See FAQ's"
+                            linkText="See FAQs"
                         />
                     </div>
                 </>

--- a/ui/src/pages/browse.tsx
+++ b/ui/src/pages/browse.tsx
@@ -74,7 +74,6 @@ const Browse: Types.NextPage<Props> = (props): React.ReactElement => {
                                     endIcon={
                                         <OutlineIcons.ArrowRightIcon className="h-4 w-4 text-teal-500 transition-colors duration-500 dark:text-white-50" />
                                     }
-                                    className="w-fit"
                                 />
                                 <Components.Button
                                     href={`${Config.urls.search.path}/authors`}
@@ -82,7 +81,6 @@ const Browse: Types.NextPage<Props> = (props): React.ReactElement => {
                                     endIcon={
                                         <OutlineIcons.UserIcon className="h-4 w-4 text-teal-500 transition-colors duration-500 dark:text-white-50" />
                                     }
-                                    className="w-fit"
                                 />
                             </div>
                             <h2 className="mb-6 block font-montserrat text-xl font-bold leading-none text-grey-800 transition-colors duration-500 dark:text-white-50">

--- a/ui/src/pages/publications/[id]/versions/[versionId].tsx
+++ b/ui/src/pages/publications/[id]/versions/[versionId].tsx
@@ -674,39 +674,37 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                 <section className="col-span-12 lg:col-span-8 xl:col-span-9">
                     {alerts}
                     {showApprovalsTracker && (
-                        <Components.ActionBar
-                            publicationVersion={publicationVersion}
-                            isCorrespondingAuthor={isCorrespondingAuthor}
-                            isReadyForPublish={isReadyForPublish}
-                            isPublishing={isPublishing}
-                            onUnlockPublication={handleUnlock}
-                            onApprove={handleApproval}
-                            onCancelApproval={handleCancelApproval}
-                            onPublish={handlePublish}
-                            onEditAffiliations={handleOpenAffiliationsModal}
-                        />
-                    )}
-
-                    {showApprovalsTracker && (
-                        <div className="pb-16">
-                            <Components.ApprovalsTracker
+                        <>
+                            <Components.PublicationPageCoAuthoringActions
                                 publicationVersion={publicationVersion}
+                                isCorrespondingAuthor={isCorrespondingAuthor}
+                                isReadyForPublish={isReadyForPublish}
                                 isPublishing={isPublishing}
+                                onUnlockPublication={handleUnlock}
+                                onApprove={handleApproval}
+                                onCancelApproval={handleCancelApproval}
                                 onPublish={handlePublish}
-                                onError={setServerError}
                                 onEditAffiliations={handleOpenAffiliationsModal}
-                                refreshPublicationVersionData={mutatePublicationVersion}
                             />
-                        </div>
-                    )}
-
-                    {showApprovalsTracker && author && (
-                        <Components.EditAffiliationsModal
-                            author={author}
-                            autoUpdate={isCorrespondingAuthor || !author.confirmedCoAuthor}
-                            open={isEditingAffiliations}
-                            onClose={handleCloseAffiliationsModal}
-                        />
+                            <div className="pb-16">
+                                <Components.ApprovalsTracker
+                                    publicationVersion={publicationVersion}
+                                    isPublishing={isPublishing}
+                                    onPublish={handlePublish}
+                                    onError={setServerError}
+                                    onEditAffiliations={handleOpenAffiliationsModal}
+                                    refreshPublicationVersionData={mutatePublicationVersion}
+                                />
+                            </div>
+                            {author && (
+                                <Components.EditAffiliationsModal
+                                    author={author}
+                                    autoUpdate={isCorrespondingAuthor || !author.confirmedCoAuthor}
+                                    open={isEditingAffiliations}
+                                    onClose={handleCloseAffiliationsModal}
+                                />
+                            )}
+                        </>
                     )}
 
                     {!!uniqueRedFlagCategoryList.length && (

--- a/ui/src/pages/publications/[id]/versions/[versionId].tsx
+++ b/ui/src/pages/publications/[id]/versions/[versionId].tsx
@@ -735,6 +735,15 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                     )}
                     <header>
                         <div className="grid w-full grid-cols-8">
+                            {publicationVersion.isLatestLiveVersion && (
+                                <Components.PublicationPageHeaderActions
+                                    authorIds={authors.flatMap((coAuthor) =>
+                                        coAuthor.linkedUser ? [coAuthor.linkedUser] : []
+                                    )}
+                                    publicationId={publication.id}
+                                    publicationType={publication.type}
+                                />
+                            )}
                             <h1 className="col-span-7 mb-4 block font-montserrat text-2xl font-bold leading-tight text-grey-800 transition-colors duration-500 dark:text-white-50 md:text-3xl xl:text-3xl xl:leading-normal">
                                 {publicationVersion.title}
                             </h1>


### PR DESCRIPTION
The purpose of this PR was to encourage users to publish by moving the options to contribute to a more clearly visible place that reflects their role as a primary function of the system.

While working on this, also made some more changes:
- Move baseURL to endpoints config from api config to avoid circular dependency error.
- Remove unused errors config.
- Attempt to standardise button classes a bit by introducing a variant prop.
- Fix a bug where clicking logout would cause a "Cancel rendering route" nextJS error because it attempts to follow the link and do a router.push() at the same time.

---

### Acceptance Criteria:

- The following options are no longer present in the side bar actions area: 
    - “Write a linked <publication type>”
    - “Write a linked review”
    - “Write a linked research problem” 
- Below the publication title, whilst logged in, blue buttons (styled the same as the related publication area buttons) are present. These buttons are aligned in a row if the browser window width allows it, in the following order:
    - “Write a linked <Publication Type>”
    - “Write a linked Research Problem>” 
    - “Write a Peer Review”

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
![Screenshot 2024-11-12 143414](https://github.com/user-attachments/assets/97ced702-8b51-46fb-ad76-39967e6b6c90)

E2E
![Screenshot 2024-11-12 142457](https://github.com/user-attachments/assets/b928ade0-d908-4015-90ff-f0b20389e387)

---

### Screenshots:

Previous
![Screenshot 2024-11-12 143723](https://github.com/user-attachments/assets/57cc4656-a245-4d14-b473-868524fd1723)

New
![Screenshot 2024-11-12 143645](https://github.com/user-attachments/assets/1eb0b92d-f7f5-494f-aa13-9b6dc3605372)

