### PR TITLE
OC-964: Add HMRC and HMT to ARI ingest

### DIFF
--- a/api/prisma/seeds/local/dev/organisationalAccounts.ts
+++ b/api/prisma/seeds/local/dev/organisationalAccounts.ts
@@ -178,6 +178,20 @@ const userSeeds: Prisma.UserCreateManyInput[] = [
         defaultTopicId: 'cly46903l007x7ryzgan8igh3', // Regulation of industry
         ror: 'https://ror.org/019ya6433',
         url: 'https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy'
+    },
+    {
+        id: 'cm3fzp3x80001i9po2idoiksv',
+        role: 'ORGANISATION',
+        firstName: 'HM Treasury (UK)',
+        email: 'ari.comment@go-science.gov.uk',
+        defaultTopicId: 'clkv6ulvw01dyl2rsjhplwtqo' // Expenditures. Government spending
+    },
+    {
+        id: 'cm3fzp3x80003i9po45lfun1h',
+        role: 'ORGANISATION',
+        firstName: 'HMRC (UK)',
+        email: 'ari.comment@go-science.gov.uk',
+        defaultTopicId: 'clkv6ulvm01dul2rs0q6u2yor' // Revenue. Taxation. Internal revenue
     }
 ];
 export default userSeeds;

--- a/api/prisma/seeds/local/dev/userMappings.ts
+++ b/api/prisma/seeds/local/dev/userMappings.ts
@@ -110,6 +110,16 @@ const userMappings: Prisma.UserMappingCreateManyInput[] = [
         userId: 'clyheq7kt0015eg48i58jtf3a',
         value: 'Department for Business, Energy & Industrial Strategy',
         source: 'ARI'
+    },
+    {
+        userId: 'cm3fzp3x80001i9po2idoiksv',
+        value: 'HMT',
+        source: 'ARI'
+    },
+    {
+        userId: 'cm3fzp3x80003i9po45lfun1h',
+        value: 'HMRC',
+        source: 'ARI'
     }
 ];
 


### PR DESCRIPTION
The purpose of this PR was to add config for 2 new government departments that have started to publish ARIs so that we can handle them when we import ARIs.

No issues or unrecognised topics when running a full import locally.

---

### Acceptance Criteria:

- An organisational account exists for “HM Treasury (UK)”, mapped to the ARI DB organisation “HMT”, with a default topic of “Expenditures. Government spending” ([Expenditures. Government spending - Octopus | Built for Researchers](https://www.octopus.ac/topics/cllqi3mxp00p2m48wyugqhh2c) // [Expenditures. Government spending - Octopus | Built for Researchers](https://int.octopus.ac/topics/clkv6ulvw01dyl2rsjhplwtqo) )
- An organisational account exists for “HMRC (UK)”, mapped to the ARI DB organisation “HMRC”, with a default topic of “Revenue. Taxation. Internal Revenue” ([Revenue. Taxation. Internal revenue - Octopus | Built for Researche...](https://www.octopus.ac/topics/cllqi3mxc00p0m48wep50mhdb)  // [Revenue. Taxation. Internal revenue - Octopus | Built for Researche...](https://int.octopus.ac/topics/clkv6ulvm01dul2rs0q6u2yor) )
- The initial ingest script now returns a report of any unrecognised topics
- Attempt an ingest with both of these accounts on the whitelist and provide a list of all unrecognised topics

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated


