### PR TITLE
OC-967: PDF generation won't work on ARM lambda functions

### DIFF
--- a/api/serverless-config-default.yml
+++ b/api/serverless-config-default.yml
@@ -46,6 +46,7 @@ functions:
                 cors: true
     getPDF:
         handler: dist/src/components/pdf/routes.getPublicationPDF
+        architecture: x86_64
         memorySize: 2048 # https://github.com/alixaxel/chrome-aws-lambda#:~:text=You%20should%20allocate%20at%20least%20512%20MB%20of%20RAM%20to%20your%20Lambda%2C%20however%201600%20MB%20(or%20more)%20is%20recommended
         events:
             - http:


### PR DESCRIPTION
The purpose of this PR was to fix an issue where PDFs are not generating. This is because the binary to launch chromium doesn't work on arm64 architectures ([github issue](https://github.com/Sparticuz/chromium/issues/186)), which we recently started using.

This PR changes the architecture of this function while leaving others on arm64.
