### PR TITLE
OC-966 fix: Override AWS XSS body rule

### DIFF
--- a/infra/modules/cloudfront/main.tf
+++ b/infra/modules/cloudfront/main.tf
@@ -93,6 +93,14 @@ resource "aws_wafv2_web_acl" "api_web_acl" {
           }
           name = "SizeRestrictions_BODY"
         }
+        # Override default rule which rejects requests with a body failing an XSS evaluation.
+        # This blocks legitimate publication updates with style attributes in the content HTML.
+        rule_action_override {
+          action_to_use {
+            count {}
+          }
+          name = "CrossSiteScripting_BODY"
+        }
       }
     }
     visibility_config {


### PR DESCRIPTION
The purpose of this PR was to override an AWS WAF rule that blocks legitimate publication save requests. The HTML editor creates a table with a style attribute and the style attribute is blocked by the rule. Unfortunately there doesn't seem to be a more refined way than this to disable that, other than overriding the rule.

---

### Acceptance Criteria:

Publications with a table in their content can be saved.

---

### Checklist:

- [x] Local manual testing conducted (applied change to int environment and tested)
- [ ] Automated tests added
- [ ] Documentation updated
