### PR TITLE
OC-923: Integrate PoC ECS infrastructure with octopus

### DIFF
--- a/api/src/components/publication/__tests__/createPublication.test.ts
+++ b/api/src/components/publication/__tests__/createPublication.test.ts
@@ -501,7 +501,9 @@ describe('Create live publication', () => {
 
         expect(createPublicationRequest.status).toEqual(201);
         expect(
-            createPublicationRequest.body.linkedTo.sort((a, b) => a.publicationToId.localeCompare(b.publicationToId))
+            createPublicationRequest.body.linkedTo.sort(
+                (a, b) => a.publicationToId.localeCompare(b.publicationToId) as string
+            )
         ).toMatchObject([
             { publicationToId: 'publication-problem-live', versionToId: 'publication-problem-live-v2', draft: false },
             {

--- a/infra/create-app/main.tf
+++ b/infra/create-app/main.tf
@@ -108,7 +108,6 @@ module "ecr" {
 }
 
 module "codepipeline" {
-  count        = local.environment == "prod" ? 1 : 0
   source       = "../modules/codepipeline"
   environment  = local.environment
   project_name = local.project_name

--- a/infra/create-app/main.tf
+++ b/infra/create-app/main.tf
@@ -87,3 +87,29 @@ module "cloudfront" {
     aws.us-east-1-provider = aws.us-east-1-provider
   }
 }
+
+module "ecs" {
+  source             = "../modules/ecs"
+  environment        = local.environment
+  private_subnet_ids = module.network.private_subnet_ids
+  project_name       = local.project_name
+  public_subnet_ids  = module.network.public_subnet_ids
+  vpc_id             = module.network.vpc_id
+}
+
+module "ecr" {
+  source                 = "../modules/ecr"
+  environment            = local.environment
+  private_route_table_id = module.network.private_route_table_id
+  private_subnet_ids     = module.network.private_subnet_ids
+  project_name           = local.project_name
+  task_security_group_id = module.ecs.task_security_group_id
+  vpc_id                 = module.network.vpc_id
+}
+
+module "codepipeline" {
+  count        = local.environment == "prod" ? 1 : 0
+  source       = "../modules/codepipeline"
+  environment  = local.environment
+  project_name = local.project_name
+}

--- a/infra/create-app/main.tf
+++ b/infra/create-app/main.tf
@@ -93,7 +93,6 @@ module "ecs" {
   environment        = local.environment
   private_subnet_ids = module.network.private_subnet_ids
   project_name       = local.project_name
-  public_subnet_ids  = module.network.public_subnet_ids
   vpc_id             = module.network.vpc_id
 }
 

--- a/infra/create-app/provider.tf
+++ b/infra/create-app/provider.tf
@@ -1,6 +1,17 @@
 provider "aws" {
   region  = "eu-west-1"
   profile = var.profile
+  # Jisc tagging policy - tags must be in PascalCase.
+  default_tags {
+    tags = {
+      Application = "Octopus"
+      Compliance  = "CE"
+      CostCentre  = "P10031"
+      Environment = title(terraform.workspace)
+      Owner       = "OctopusTeam"
+      Product     = "Octopus"
+    }
+  }
 }
 
 # Some resources need to be created in the "global" us-east-1 region.

--- a/infra/docker/poc/Dockerfile
+++ b/infra/docker/poc/Dockerfile
@@ -1,0 +1,2 @@
+FROM public.ecr.aws/docker/library/node:18-alpine
+CMD ["echo", "Hello again, World!"]

--- a/infra/modules/bastion/main.tf
+++ b/infra/modules/bastion/main.tf
@@ -15,19 +15,21 @@ resource "aws_security_group" "ec2_sg" {
   }
 }
 
+data "aws_iam_policy_document" "allow_ssm_role_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
 resource "aws_iam_role" "allow_ssm_role" {
   name               = "ssm-role-${var.environment}"
   description        = "Allow SSM access to EC2"
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": {
-    "Effect": "Allow",
-    "Principal": {"Service": "ec2.amazonaws.com"},
-    "Action": "sts:AssumeRole"
-  }
-}
-EOF
+  assume_role_policy = data.aws_iam_policy_document.allow_ssm_role_policy.json
 }
 
 resource "aws_iam_instance_profile" "allow_ssm_iam_profile" {

--- a/infra/modules/codepipeline/buildspec/deploy-docker-image.yml
+++ b/infra/modules/codepipeline/buildspec/deploy-docker-image.yml
@@ -1,0 +1,18 @@
+version: 0.1
+
+phases:
+  pre_build:
+    commands:
+      - echo Logging in to ECR...
+      - aws ecr get-login-password --region $DEFAULT_REGION | docker login --username AWS --password-stdin $ACCOUNT_ID.dkr.ecr.$DEFAULT_REGION.amazonaws.com
+  build:
+    commands:
+      - echo Building docker image...
+      - docker build -t $IMAGE_NAME ./infra/docker/poc
+      - docker tag $IMAGE_NAME:latest $ACCOUNT_ID.dkr.ecr.$DEFAULT_REGION.amazonaws.com/$PROJECT_NAME-$ENVIRONMENT:$IMAGE_NAME
+      - docker tag $IMAGE_NAME:latest $ACCOUNT_ID.dkr.ecr.$DEFAULT_REGION.amazonaws.com/$PROJECT_NAME-$ENVIRONMENT:$COMMIT_ID
+  post_build:
+    commands:
+      - echo Pushing docker image...
+      - docker push $ACCOUNT_ID.dkr.ecr.$DEFAULT_REGION.amazonaws.com/$PROJECT_NAME-$ENVIRONMENT:$IMAGE_NAME
+      - docker push $ACCOUNT_ID.dkr.ecr.$DEFAULT_REGION.amazonaws.com/$PROJECT_NAME-$ENVIRONMENT:$COMMIT_ID

--- a/infra/modules/codepipeline/buildspec/deploy-docker-image.yml
+++ b/infra/modules/codepipeline/buildspec/deploy-docker-image.yml
@@ -8,7 +8,7 @@ phases:
   build:
     commands:
       - echo Building docker image...
-      - docker build -t $IMAGE_NAME ./infra/docker/poc
+      - docker build --platform linux/arm64 --tag $IMAGE_NAME ./infra/docker/poc
       - docker tag $IMAGE_NAME:latest $ACCOUNT_ID.dkr.ecr.$DEFAULT_REGION.amazonaws.com/$PROJECT_NAME-$ENVIRONMENT:$IMAGE_NAME
       - docker tag $IMAGE_NAME:latest $ACCOUNT_ID.dkr.ecr.$DEFAULT_REGION.amazonaws.com/$PROJECT_NAME-$ENVIRONMENT:$COMMIT_ID
   post_build:

--- a/infra/modules/codepipeline/codebuild.tf
+++ b/infra/modules/codepipeline/codebuild.tf
@@ -1,0 +1,63 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+locals {
+  account_id  = data.aws_caller_identity.current.account_id
+  region_name = data.aws_region.current.name
+}
+
+resource "aws_codebuild_project" "deploy-docker-image" {
+  name          = "${var.project_name}-codebuild-deploy-docker-image-${var.environment}"
+  description   = "Build docker image"
+  build_timeout = "300"
+  service_role  = aws_iam_role.codepipeline_role.arn
+
+  artifacts {
+    type = "CODEPIPELINE"
+  }
+
+  environment {
+    compute_type    = "BUILD_GENERAL1_SMALL"
+    image           = "aws/codebuild/standard:5.0"
+    type            = "LINUX_CONTAINER"
+    privileged_mode = true
+
+    environment_variable {
+      name  = "ACCOUNT_ID"
+      value = local.account_id
+    }
+
+    environment_variable {
+      name  = "DEFAULT_REGION"
+      value = local.region_name
+    }
+
+    environment_variable {
+      name  = "IMAGE_NAME"
+      value = "latest"
+    }
+
+    environment_variable {
+      name  = "COMMIT_ID"
+      value = "#{SourceVariables.CommitId}"
+    }
+
+    environment_variable {
+      name  = "PROJECT_NAME"
+      value = var.project_name
+    }
+
+    environment_variable {
+      name  = "ENVIRONMENT"
+      value = var.environment
+    }
+  }
+
+  source_version = "main"
+
+  source {
+    type      = "CODEPIPELINE"
+    buildspec = "infra/modules/codepipeline/buildspec/deploy-docker-image.yml"
+  }
+}

--- a/infra/modules/codepipeline/codebuild.tf
+++ b/infra/modules/codepipeline/codebuild.tf
@@ -54,7 +54,7 @@ resource "aws_codebuild_project" "deploy-docker-image" {
     }
   }
 
-  source_version = "main"
+  source_version = var.environment
 
   source {
     type      = "CODEPIPELINE"

--- a/infra/modules/codepipeline/codepipeline.tf
+++ b/infra/modules/codepipeline/codepipeline.tf
@@ -1,0 +1,190 @@
+data "aws_ssm_parameter" "github_codestar_connection_arn" {
+  name = "${var.project_name}_github_codestar_connection_arn"
+}
+
+resource "aws_codepipeline" "docker-image-codepipeline" {
+  name          = "${var.project_name}-docker-image-pipeline-${var.environment}"
+  role_arn      = aws_iam_role.codepipeline_role.arn
+  pipeline_type = "V2"
+
+  artifact_store {
+    type     = "S3"
+    location = aws_s3_bucket.codepipeline_bucket.bucket
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "Source"
+      category         = "Source"
+      owner            = "AWS"
+      provider         = "CodeStarSourceConnection"
+      version          = "1"
+      output_artifacts = ["source_output"]
+      namespace        = "SourceVariables"
+
+      // options given here: https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference-CodestarConnectionSource.html#action-reference-CodestarConnectionSource-config
+      configuration = {
+        ConnectionArn        = data.aws_ssm_parameter.github_codestar_connection_arn.value
+        FullRepositoryId     = "JiscSD/octopus"
+        BranchName           = "main"
+        OutputArtifactFormat = "CODE_ZIP"
+      }
+    }
+  }
+
+  stage {
+    name = "Deploy-Image"
+
+    action {
+      name            = "Deploy-Image"
+      category        = "Build"
+      owner           = "AWS"
+      provider        = "CodeBuild"
+      input_artifacts = ["source_output"]
+      version         = "1"
+
+      configuration = {
+        ProjectName = aws_codebuild_project.deploy-docker-image.name
+        EnvironmentVariables = jsonencode([
+          {
+            name  = "COMMIT_ID",
+            type  = "PLAINTEXT"
+            value = "#{SourceVariables.CommitId}"
+          }
+        ])
+      }
+    }
+  }
+}
+
+resource "aws_iam_role" "codepipeline_role" {
+  name = "${var.project_name}-codepipeline-role-${var.environment}"
+  tags = {
+    Name = "${var.project_name}-codepipeline-role-${var.environment}"
+  }
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "Service": [
+                        "codepipeline.amazonaws.com",
+                        "codebuild.amazonaws.com"
+                ]
+            },
+            "Action": "sts:AssumeRole"
+        }
+    ]
+}
+EOF
+}
+
+// IAM codepipeline policy
+resource "aws_iam_role_policy" "codepipeline_policy" {
+  name = "${var.project_name}-codepipeline_policy-${var.environment}"
+  role = aws_iam_role.codepipeline_role.id
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:GetObjectVersion",
+                "s3:GetBucketVersioning",
+                "s3:PutObject",
+                "s3:PutObjectAcl",
+                "s3:GetBucketLocation",
+                "s3:DeleteObjectVersion",
+                "s3:DeleteObject"
+            ],
+            "Resource": [
+                "${aws_s3_bucket.codepipeline_bucket.arn}",
+                "${aws_s3_bucket.codepipeline_bucket.arn}/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "codestar-connections:UseConnection"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "codecommit:GitPull"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "codebuild:BatchGetBuilds",
+                "codebuild:StartBuild"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ecr:CreateRepository",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:CompleteLayerUpload",
+                "ecr:GetAuthorizationToken",
+                "ecr:InitiateLayerUpload",
+                "ecr:PutImage",
+                "ecr:UploadLayerPart",
+                "ecs:UpdateService",
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:PutSecretValue"
+            ],                
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "rds:DescribeDBSnapshots",
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "rds:CreateDBSnapshot",
+            "Resource": [
+                "*"
+            ]
+        },              
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:Describe*",
+                "ec2:DeleteNetworkInterface",
+                "ec2:CreateNetworkInterface",
+                "ec2:CreateNetworkInterfacePermission",
+                "iam:PassRole"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}

--- a/infra/modules/codepipeline/codepipeline.tf
+++ b/infra/modules/codepipeline/codepipeline.tf
@@ -28,7 +28,7 @@ resource "aws_codepipeline" "docker-image-codepipeline" {
       configuration = {
         ConnectionArn        = data.aws_ssm_parameter.github_codestar_connection_arn.value
         FullRepositoryId     = "JiscSD/octopus"
-        BranchName           = "main"
+        BranchName           = var.environment
         OutputArtifactFormat = "CODE_ZIP"
       }
     }

--- a/infra/modules/codepipeline/codepipeline.tf
+++ b/infra/modules/codepipeline/codepipeline.tf
@@ -59,29 +59,77 @@ resource "aws_codepipeline" "docker-image-codepipeline" {
   }
 }
 
+data "aws_iam_policy_document" "codepipeline_role_policy" {
+  statement {
+    effect = "Allow"
+    principals {
+      type = "Service"
+      identifiers = [
+        "codepipeline.amazonaws.com",
+        "codebuild.amazonaws.com"
+      ]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
 resource "aws_iam_role" "codepipeline_role" {
   name = "${var.project_name}-codepipeline-role-${var.environment}"
   tags = {
     Name = "${var.project_name}-codepipeline-role-${var.environment}"
   }
 
-  assume_role_policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Principal": {
-                "Service": [
-                        "codepipeline.amazonaws.com",
-                        "codebuild.amazonaws.com"
-                ]
-            },
-            "Action": "sts:AssumeRole"
-        }
-    ]
+  assume_role_policy = data.aws_iam_policy_document.codepipeline_role_policy.json
 }
-EOF
+
+data "aws_iam_policy_document" "codepipeline_policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+      "s3:GetBucketVersioning",
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+      "s3:GetBucketLocation",
+      "s3:DeleteObjectVersion",
+      "s3:DeleteObject"
+    ]
+    resources = [
+      "${aws_s3_bucket.codepipeline_bucket.arn}",
+      "${aws_s3_bucket.codepipeline_bucket.arn}/*"
+    ]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "codebuild:BatchGetBuilds",
+      "codebuild:StartBuild",
+      "codecommit:GitPull",
+      "codestar-connections:UseConnection",
+      "ec2:CreateNetworkInterface",
+      "ec2:CreateNetworkInterfacePermission",
+      "ec2:DeleteNetworkInterface",
+      "ec2:Describe*",
+      "ecr:CreateRepository",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:CompleteLayerUpload",
+      "ecr:GetAuthorizationToken",
+      "ecr:InitiateLayerUpload",
+      "ecr:PutImage",
+      "ecr:UploadLayerPart",
+      "ecs:UpdateService",
+      "iam:PassRole",
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "rds:CreateDBSnapshot",
+      "rds:DescribeDBSnapshots",
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:PutSecretValue"
+    ]
+    resources = ["*"]
+  }
 }
 
 // IAM codepipeline policy
@@ -89,102 +137,5 @@ resource "aws_iam_role_policy" "codepipeline_policy" {
   name = "${var.project_name}-codepipeline_policy-${var.environment}"
   role = aws_iam_role.codepipeline_role.id
 
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:GetObjectVersion",
-                "s3:GetBucketVersioning",
-                "s3:PutObject",
-                "s3:PutObjectAcl",
-                "s3:GetBucketLocation",
-                "s3:DeleteObjectVersion",
-                "s3:DeleteObject"
-            ],
-            "Resource": [
-                "${aws_s3_bucket.codepipeline_bucket.arn}",
-                "${aws_s3_bucket.codepipeline_bucket.arn}/*"
-            ]
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "codestar-connections:UseConnection"
-            ],
-            "Resource": [
-                "*"
-            ]
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "codecommit:GitPull"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "codebuild:BatchGetBuilds",
-                "codebuild:StartBuild"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "logs:CreateLogGroup",
-                "logs:CreateLogStream",
-                "logs:PutLogEvents"
-            ],
-            "Resource": [
-                "*"
-            ]
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ecr:CreateRepository",
-                "ecr:BatchCheckLayerAvailability",
-                "ecr:CompleteLayerUpload",
-                "ecr:GetAuthorizationToken",
-                "ecr:InitiateLayerUpload",
-                "ecr:PutImage",
-                "ecr:UploadLayerPart",
-                "ecs:UpdateService",
-                "secretsmanager:GetSecretValue",
-                "secretsmanager:PutSecretValue"
-            ],                
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": "rds:DescribeDBSnapshots",
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": "rds:CreateDBSnapshot",
-            "Resource": [
-                "*"
-            ]
-        },              
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:Describe*",
-                "ec2:DeleteNetworkInterface",
-                "ec2:CreateNetworkInterface",
-                "ec2:CreateNetworkInterfacePermission",
-                "iam:PassRole"
-            ],
-            "Resource": "*"
-        }
-    ]
-}
-EOF
+  policy = data.aws_iam_policy_document.codepipeline_policy.json
 }

--- a/infra/modules/codepipeline/s3.tf
+++ b/infra/modules/codepipeline/s3.tf
@@ -1,0 +1,28 @@
+resource "aws_s3_bucket" "codepipeline_bucket" {
+  bucket = "${var.project_name}-codepipeline-bucket-${var.environment}"
+  tags = {
+    Name = "${var.project_name}-codepipeline-bucket-${var.environment}"
+  }
+}
+
+resource "aws_s3_bucket_ownership_controls" "codepipeline_bucket_ownership_controls" {
+  bucket = aws_s3_bucket.codepipeline_bucket.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_acl" "codepipeline_bucket_acl" {
+  depends_on = [aws_s3_bucket_ownership_controls.codepipeline_bucket_ownership_controls]
+
+  bucket = aws_s3_bucket.codepipeline_bucket.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_public_access_block" "codepipeline_bucket_access" {
+  bucket                  = aws_s3_bucket.codepipeline_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  restrict_public_buckets = true
+  ignore_public_acls      = true
+}

--- a/infra/modules/codepipeline/vars.tf
+++ b/infra/modules/codepipeline/vars.tf
@@ -1,0 +1,7 @@
+variable "project_name" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}

--- a/infra/modules/ecr/ecr.tf
+++ b/infra/modules/ecr/ecr.tf
@@ -1,0 +1,57 @@
+data "aws_region" "current" {}
+
+locals {
+  region_name = data.aws_region.current.name
+}
+
+resource "aws_ecr_repository" "ecr" {
+  name                 = "${var.project_name}-ecr-${var.environment}"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+// Below is all stuff to allow ECS tasks to pull images from this ECR.
+resource "aws_security_group" "vpc_endpoints" {
+  name_prefix = "${var.project_name}-vpc-endpoint-${var.environment}"
+  description = "Associated to ECR/s3 VPC Endpoints"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description     = "Allow ECS tasks to pull images from ECR via VPC endpoints"
+    protocol        = "tcp"
+    from_port       = 443
+    to_port         = 443
+    security_groups = [var.task_security_group_id]
+  }
+}
+
+resource "aws_vpc_endpoint" "ecr_endpoint" {
+  vpc_id              = var.vpc_id
+  service_name        = "com.amazonaws.${local.region_name}.ecr.dkr"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+
+  security_group_ids = [aws_security_group.vpc_endpoints.id]
+  subnet_ids         = var.private_subnet_ids
+}
+
+resource "aws_vpc_endpoint" "ecr_api_endpoint" {
+  vpc_id              = var.vpc_id
+  service_name        = "com.amazonaws.${local.region_name}.ecr.api"
+  vpc_endpoint_type   = "Interface"
+  private_dns_enabled = true
+
+  security_group_ids = [aws_security_group.vpc_endpoints.id]
+  subnet_ids         = var.private_subnet_ids
+}
+
+resource "aws_vpc_endpoint" "ecr_s3_endpoint" {
+  vpc_id            = var.vpc_id
+  service_name      = "com.amazonaws.${local.region_name}.s3"
+  vpc_endpoint_type = "Gateway"
+
+  route_table_ids = [var.private_route_table_id]
+}

--- a/infra/modules/ecr/ecr.tf
+++ b/infra/modules/ecr/ecr.tf
@@ -5,7 +5,7 @@ locals {
 }
 
 resource "aws_ecr_repository" "ecr" {
-  name                 = "${var.project_name}-ecr-${var.environment}"
+  name                 = "${var.project_name}-${var.environment}"
   image_tag_mutability = "MUTABLE"
 
   image_scanning_configuration {

--- a/infra/modules/ecr/vars.tf
+++ b/infra/modules/ecr/vars.tf
@@ -1,0 +1,23 @@
+variable "environment" {
+  type = string
+}
+
+variable "private_route_table_id" {
+  type = string
+}
+
+variable "private_subnet_ids" {
+  type = list(string)
+}
+
+variable "project_name" {
+  type = string
+}
+
+variable "task_security_group_id" {
+  type = string
+}
+
+variable "vpc_id" {
+  type = string
+}

--- a/infra/modules/ecs/ecs.tf
+++ b/infra/modules/ecs/ecs.tf
@@ -1,0 +1,50 @@
+resource "aws_service_discovery_private_dns_namespace" "namespace" {
+  name        = "${var.project_name}-namespace-${var.environment}"
+  description = "Namespace for ${var.project_name} ECS service"
+  vpc         = var.vpc_id
+
+  tags = {
+    Name = "${var.project_name}-namespace-${var.environment}"
+  }
+}
+
+resource "aws_service_discovery_service" "discovery-service" {
+  name = "${var.project_name}-ds-${var.environment}"
+
+  dns_config {
+    namespace_id   = aws_service_discovery_private_dns_namespace.namespace.id
+    routing_policy = "MULTIVALUE"
+
+    dns_records {
+      ttl  = 60
+      type = "A"
+    }
+  }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
+
+  tags = {
+    Name = "${var.project_name}-ds-${var.environment}"
+  }
+}
+
+resource "aws_ecs_cluster" "ecs" {
+  name = "${var.project_name}-ecs-${var.environment}"
+
+  configuration {
+    execute_command_configuration {
+      logging = "DEFAULT"
+    }
+  }
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+
+  service_connect_defaults {
+    namespace = aws_service_discovery_private_dns_namespace.namespace.arn
+  }
+}

--- a/infra/modules/ecs/iam.tf
+++ b/infra/modules/ecs/iam.tf
@@ -1,0 +1,72 @@
+resource "aws_iam_role" "ecs-task-exec-role" {
+  name                = "${var.project_name}-ecs-task-exec-role-${var.environment}"
+  managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"]
+
+  assume_role_policy = jsonencode({
+    "Version" : "2008-10-17",
+    "Statement" : [
+      {
+        "Sid" : "",
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "ecs-tasks.amazonaws.com"
+        },
+        "Action" : "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "task-exec-policy" {
+  name = "${var.project_name}-task-exec-policy-${var.environment}"
+  role = aws_iam_role.ecs-task-exec-role.id
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : [
+          "logs:CreateLogGroup"
+        ],
+        "Resource" : "*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role" "ecs-task-role" {
+  name = "${var.project_name}-ecs-task-role-${var.environment}"
+  assume_role_policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Service" : "ecs-tasks.amazonaws.com"
+        },
+        "Action" : "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "task-policy" {
+  name = "${var.project_name}-task-policy-${var.environment}"
+  role = aws_iam_role.ecs-task-role.id
+  policy = jsonencode(
+    {
+      Statement = [
+        {
+          Action = [
+            "ssmmessages:CreateControlChannel",
+            "ssmmessages:CreateDataChannel",
+            "ssmmessages:OpenControlChannel",
+            "ssmmessages:OpenDataChannel",
+          ]
+          Effect   = "Allow"
+          Resource = "*"
+        },
+      ]
+      Version = "2012-10-17"
+  })
+}

--- a/infra/modules/ecs/outputs.tf
+++ b/infra/modules/ecs/outputs.tf
@@ -1,0 +1,3 @@
+output "task_security_group_id" {
+  value = aws_security_group.hello-world-task-sg.id
+}

--- a/infra/modules/ecs/services.tf
+++ b/infra/modules/ecs/services.tf
@@ -1,0 +1,37 @@
+resource "aws_security_group" "hello-world-task-sg" {
+  name                   = "${var.project_name}-hello-world-task-sg-${var.environment}"
+  description            = "Security group for hello world ecs service"
+  vpc_id                 = var.vpc_id
+  revoke_rules_on_delete = true
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = -1
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project_name}-hello-world-task-sg-${var.environment}"
+  }
+}
+
+resource "aws_ecs_service" "hello-world" {
+  name                   = "${var.project_name}-hello-world-${var.environment}"
+  cluster                = aws_ecs_cluster.ecs.id
+  task_definition        = "${aws_ecs_task_definition.hello-world.id}:${aws_ecs_task_definition.hello-world.revision}"
+  enable_execute_command = true
+  launch_type            = "FARGATE"
+  desired_count          = 1
+
+  network_configuration {
+    assign_public_ip = true
+    subnets          = var.public_subnet_ids
+    security_groups  = [aws_security_group.hello-world-task-sg.id]
+  }
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+}

--- a/infra/modules/ecs/services.tf
+++ b/infra/modules/ecs/services.tf
@@ -26,7 +26,7 @@ resource "aws_ecs_service" "hello-world" {
 
   network_configuration {
     assign_public_ip = true
-    subnets          = var.public_subnet_ids
+    subnets          = var.private_subnet_ids
     security_groups  = [aws_security_group.hello-world-task-sg.id]
   }
 

--- a/infra/modules/ecs/tasks.tf
+++ b/infra/modules/ecs/tasks.tf
@@ -1,0 +1,47 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+locals {
+  account_id  = data.aws_caller_identity.current.account_id
+  region_name = data.aws_region.current.name
+}
+
+resource "aws_ecs_task_definition" "hello-world" {
+  family                   = "${var.project_name}-hello-world-${var.environment}"
+  requires_compatibilities = ["FARGATE"]
+
+  cpu    = 256
+  memory = 512
+
+  network_mode = "awsvpc"
+
+  execution_role_arn = aws_iam_role.ecs-task-exec-role.arn
+  task_role_arn      = aws_iam_role.ecs-task-role.arn
+
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = "X86_64"
+  }
+
+  container_definitions = jsonencode([
+    {
+      "name" : "hello-world",
+      "image" : "${local.account_id}.dkr.ecr.${local.region_name}.amazonaws.com/${var.project_name}-${var.environment}:latest",
+      "entryPoints" : [
+        "sh", "-c"
+      ],
+      "essential" : true,
+      "logConfiguration" : {
+        "logDriver" : "awslogs",
+        "options" : {
+          "awslogs-create-group" : "true",
+          "awslogs-group" : "${var.project_name}-hello-world-ecs-task-${var.environment}",
+          "awslogs-region" : "${local.region_name}",
+          "awslogs-stream-prefix" : "ecs"
+        },
+        "secretOptions" : []
+      }
+    }
+  ])
+}

--- a/infra/modules/ecs/tasks.tf
+++ b/infra/modules/ecs/tasks.tf
@@ -21,7 +21,7 @@ resource "aws_ecs_task_definition" "hello-world" {
 
   runtime_platform {
     operating_system_family = "LINUX"
-    cpu_architecture        = "X86_64"
+    cpu_architecture        = "ARM64"
   }
 
   container_definitions = jsonencode([

--- a/infra/modules/ecs/vars.tf
+++ b/infra/modules/ecs/vars.tf
@@ -1,0 +1,19 @@
+variable "environment" {
+  type = string
+}
+
+variable "private_subnet_ids" {
+  type = list(string)
+}
+
+variable "project_name" {
+  type = string
+}
+
+variable "public_subnet_ids" {
+  type = list(string)
+}
+
+variable "vpc_id" {
+  type = string
+}

--- a/infra/modules/ecs/vars.tf
+++ b/infra/modules/ecs/vars.tf
@@ -10,10 +10,6 @@ variable "project_name" {
   type = string
 }
 
-variable "public_subnet_ids" {
-  type = list(string)
-}
-
 variable "vpc_id" {
   type = string
 }

--- a/infra/modules/network/outputs.tf
+++ b/infra/modules/network/outputs.tf
@@ -1,5 +1,13 @@
-output "vpc_id" {
-  value = aws_vpc.main.id
+output "private_route_table_id" {
+  value = aws_route_table.private.id
+}
+
+output "private_subnet_ids" {
+  value = [
+    aws_subnet.private_az1.id,
+    aws_subnet.private_az2.id,
+    aws_subnet.private_az3.id,
+  ]
 }
 
 output "public_subnet_ids" {
@@ -10,10 +18,6 @@ output "public_subnet_ids" {
   ]
 }
 
-output "private_subnet_ids" {
-  value = [
-    aws_subnet.private_az1.id,
-    aws_subnet.private_az2.id,
-    aws_subnet.private_az3.id,
-  ]
+output "vpc_id" {
+  value = aws_vpc.main.id
 }

--- a/infra/modules/oidc/main.tf
+++ b/infra/modules/oidc/main.tf
@@ -40,50 +40,47 @@ resource "aws_iam_role" "github_actions_role" {
 
 }
 
-resource "aws_iam_policy" "deploy_backend" {
+data "aws_iam_policy_document" "deploy_backend_policy" {
   count = local.only_in_production
-  name  = "deploy-backend-${var.environment}-${var.project_name}"
-  policy = jsonencode(
-    {
-      "Version" : "2012-10-17",
-      "Statement" : [
-        {
-          "Effect" : "Allow",
-          "Action" : [
-            "apigateway:*",
-            "cloudformation:*",
-            "cloudwatch:*",
-            "ec2:DescribeSecurityGroups",
-            "ec2:DescribeSubnets",
-            "ec2:DescribeVpcs",
-            "ec2:RunInstances",
-            "events:ListTargetsByRule",
-            "events:DescribeRule",
-            "iam:ListRolePolicies",
-            "iam:ListAttachedRolePolicies",
-            "iam:GetRolePolicy",
-            "iam:GetRole",
-            "iam:GetInstanceProfile",
-            "iam:PassRole",
-            "kms:CreateGrant",
-            "kms:Decrypt",
-            "kms:DescribeKey",
-            "kms:Encrypt",
-            "lambda:*",
-            "logs:*",
-            "s3:*",
-            "ssm:DescribeInstanceInformation",
-            "ssm:GetParameter",
-            "ssm:PutParameter",
-            "ssm:StartSession",
-            "sts:GetCallerIdentity"
-          ],
-          "Resource" : [
-            "*"
-          ]
-        }
-      ]
-  })
+  statement {
+    effect = "Allow"
+    actions = [
+      "apigateway:*",
+      "cloudformation:*",
+      "cloudwatch:*",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeVpcs",
+      "ec2:RunInstances",
+      "events:ListTargetsByRule",
+      "events:DescribeRule",
+      "iam:ListRolePolicies",
+      "iam:ListAttachedRolePolicies",
+      "iam:GetRolePolicy",
+      "iam:GetRole",
+      "iam:GetInstanceProfile",
+      "iam:PassRole",
+      "kms:CreateGrant",
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:Encrypt",
+      "lambda:*",
+      "logs:*",
+      "s3:*",
+      "ssm:DescribeInstanceInformation",
+      "ssm:GetParameter",
+      "ssm:PutParameter",
+      "ssm:StartSession",
+      "sts:GetCallerIdentity"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "deploy_backend" {
+  count  = local.only_in_production
+  name   = "deploy-backend-${var.environment}-${var.project_name}"
+  policy = data.aws_iam_policy_document.deploy_backend_policy[local.only_in_production - 1].json
 }
 
 resource "aws_iam_role_policy_attachment" "trust_github_oidc" {


### PR DESCRIPTION
The purpose of this PR was to work a proof of concept ECS setup I made separately into octopus's codebase. The terraform code creates:
- An ECR for docker containers
- A codepipeline which builds a docker container when the source branch (int/prod) is pushed to
- An ECS service which runs a task using the latest of these docker containers
The proof of concept just logs a simple message.

There is one per environment because the idea is that this infrastructure will be used to run scripts against each environment like the ARI import script.

---

### Acceptance Criteria:

The proof of concept ECS setup can be deployed and run within octopus's environment.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Screenshots:

Service running on int
![Screenshot 2024-11-27 102211](https://github.com/user-attachments/assets/7c80422b-8f2f-4ce0-b824-ea4fdaa437f6)

Service running on prod
![Screenshot 2024-11-27 104143](https://github.com/user-attachments/assets/38bc4487-90ea-4a64-adcc-ee6478e049b8)

