### PR TITLE
OC-962: Minor copy & link updates

### DIFF
--- a/ui/src/pages/author-guide.tsx
+++ b/ui/src/pages/author-guide.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { NextPage } from 'next';
 import Head from 'next/head';
-import * as Framer from 'framer-motion';
 
 import * as Components from '@/components';
 import * as Layouts from '@/layouts';
@@ -20,7 +19,7 @@ const authorGuideSections: AuthorGuideSection[] = [
         content: (
             <>
                 <p className="mb-2">
-                    Octopus publications are different to traditional journal articles or papers. There are eight
+                    Octopus publications are different from traditional journal articles or papers. There are eight
                     smaller publication types aligned with the research process. A little like a &apos;patent
                     office&apos;, you can register all your work, including theories, data, and analyses. However, when
                     you start the publication process you’ll need to approach it as though you’re submitting to a

--- a/ui/src/pages/get-involved.tsx
+++ b/ui/src/pages/get-involved.tsx
@@ -160,7 +160,7 @@ const GetInvolved: NextPage = (): React.ReactElement => (
                                 <>
                                     For regular updates you can join our{' '}
                                     <Components.Link
-                                        href="https://www.jiscmail.ac.uk/cgi-bin/wa-jisc.exe?A0=OCTOPUSCOMMUNITY"
+                                        href="https://www.jisc.ac.uk/forms/sign-up-for-octopusac-news-and-updates"
                                         openNew={true}
                                         className="rounded text-teal-600 outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400 dark:text-teal-300"
                                     >
@@ -168,11 +168,19 @@ const GetInvolved: NextPage = (): React.ReactElement => (
                                     </Components.Link>
                                     , or follow us on{' '}
                                     <Components.Link
-                                        href="https://twitter.com/science_octopus"
+                                        href="https://twitter.com/octopus_ac"
                                         openNew={true}
                                         className="rounded text-teal-600 outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400 dark:text-teal-300"
                                     >
                                         Twitter
+                                    </Components.Link>{' '}
+                                    or{' '}
+                                    <Components.Link
+                                        href="https://bsky.app/profile/octopus-ac.bsky.social"
+                                        openNew={true}
+                                        className="rounded text-teal-600 outline-0 transition-colors duration-500 focus:ring-2 focus:ring-yellow-400 dark:text-teal-300"
+                                    >
+                                        Bluesky
                                     </Components.Link>
                                     .
                                 </>


### PR DESCRIPTION
The purpose of this PR was to make a few updates to static text and links on the site.

---

### Acceptance Criteria:

- The “Mailing list” link at the bottom of the get involved page now points to https://www.jisc.ac.uk/forms/sign-up-for-octopusac-news-and-updates
- The final sentence of the get involved page ending “…follow us on twitter” now also includes the text “or Bluesky” where “Bluesky” is a link to [Octopus.ac (@octopus-ac.bsky.social)](https://bsky.app/profile/octopus-ac.bsky.social) 
- On the author guide, please change the first sentence from “Octopus publications are different to traditional journal articles or papers.” to “Octopus publications are different from traditional journal articles or papers.” (from instead of to).

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
![Screenshot 2024-11-27 113656](https://github.com/user-attachments/assets/ab126ec1-9c7a-4b29-860c-08be6d0951e3)

E2E
![Screenshot 2024-11-27 140015](https://github.com/user-attachments/assets/1612445b-f58e-40c8-ba5a-ce21f2c82904)

