### PR TITLE
OC-981: Clear author type filter using clear filters option

### DIFF
--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -468,7 +468,7 @@ test.describe('Publication flow', () => {
 
         // Save and expect topic to be shown as a linked item
         await page.locator(PageModel.publish.createThisPublicationButton).click();
-        const response = await page.waitForResponse(
+        await page.waitForResponse(
             (response) => response.url().includes('/publications') && response.request().method() === 'POST'
         );
         await (await page.waitForSelector("aside button:has-text('Linked items')")).click();

--- a/ui/src/pages/search/publications/index.tsx
+++ b/ui/src/pages/search/publications/index.tsx
@@ -322,6 +322,7 @@ const Publications: Types.NextPage<Props> = (props): React.ReactElement => {
         setPublicationTypes('');
         setDateFrom('');
         setDateTo('');
+        setAuthorTypes('');
     };
 
     React.useEffect((): void => {


### PR DESCRIPTION
The purpose of this PR was to fix an oversight introduced with the new Author Types search filter. The Clear Filters button does not clear this new filter.

---

### Acceptance Criteria:

- The “Clear filters” option removes any selection in the “Author types” filter.

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
![Screenshot 2024-12-05 132732](https://github.com/user-attachments/assets/7ccd9912-fd29-4515-9f92-9f29e5ec3c6e)

E2E
![Screenshot 2024-12-05 132534](https://github.com/user-attachments/assets/8356c23e-f517-4f7c-860e-361d93c9cbef)
