### PR TITLE
OC-983: Peer reviews do not load whilst logged in

### DIFF
--- a/ui/src/components/Publication/PublicationPage/HeaderActions/index.tsx
+++ b/ui/src/components/Publication/PublicationPage/HeaderActions/index.tsx
@@ -14,25 +14,23 @@ type Props = {
 const HeaderActions: React.FC<Props> = (props) => {
     const { user } = Stores.useAuthStore();
 
-    if (!user) {
+    if (!user || props.publicationType === 'PEER_REVIEW') {
         return null;
     }
 
     return (
         <div className="col-span-8 mb-10 pb-10 flex flex-col md:flex-row gap-4 md:gap-8 border-b border-grey-200">
-            {Helpers.linkedPublicationTypes[props.publicationType as keyof typeof Helpers.linkedPublicationTypes].map(
-                (childPublicationType) => {
-                    return (
-                        <Components.Button
-                            variant="block"
-                            title={`Write a linked ${Helpers.formatPublicationType(childPublicationType as Types.PublicationType)}`}
-                            key={childPublicationType}
-                            href={`${Config.urls.createPublication.path}?for=${props.publicationId}&type=${childPublicationType}`}
-                            openNew={true}
-                        />
-                    );
-                }
-            )}
+            {Helpers.linkedPublicationTypes[props.publicationType].map((childPublicationType) => {
+                return (
+                    <Components.Button
+                        variant="block"
+                        title={`Write a linked ${Helpers.formatPublicationType(childPublicationType as Types.PublicationType)}`}
+                        key={childPublicationType}
+                        href={`${Config.urls.createPublication.path}?for=${props.publicationId}&type=${childPublicationType}`}
+                        openNew={true}
+                    />
+                );
+            })}
             {!props.authorIds.includes(user.id) && (
                 <Components.Button
                     title="Write a review"


### PR DESCRIPTION
The purpose of this PR was to fix a bug causing an error to crash the page when viewing a peer review whilst logged in.

The previous code was unintentionally hacking around typescript, which was actually protecting it from this bug. PEER_REVIEW is not in the Helpers.linkedPublicationTypes object, unlike the other types, causing this error.

It's fine to hide the area entirely as we have no need to "call to action" users in this way on peer reviews.

---

### Acceptance Criteria:

Peer reviews are viewable error-free while logged in.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Screenshots:
![Screenshot 2024-12-10 095526](https://github.com/user-attachments/assets/c19ed62d-56a7-47a9-a505-f88883b2c545)
