### PR TITLE
OC-979-fix: Deployment role needs permissions for serverless to manage lambda role

### DIFF
--- a/infra/modules/oidc/main.tf
+++ b/infra/modules/oidc/main.tf
@@ -60,6 +60,7 @@ data "aws_iam_policy_document" "deploy_backend_policy" {
       "iam:GetRole",
       "iam:GetInstanceProfile",
       "iam:PassRole",
+      "iam:PutRolePolicy",
       "kms:CreateGrant",
       "kms:Decrypt",
       "kms:DescribeKey",


### PR DESCRIPTION
The deployment of OC-979 to int failed with the following message:

```
ServerlessError2: An error occurred: IamRoleLambdaExecution - Resource handler returned message: "User: arn:aws:sts::[...]:assumed-role/github-actions-role-prod-octopus/github-actions-deploy-int is not authorized to perform: iam:PutRolePolicy on resource: role octopus-api-int-***-lambdaRole because no identity-based policy allows the iam:PutRolePolicy action
```

I'm not sure why it only surfaced now, but the deployment IAM role needs permission to let serverless manage the lambda role policy upon deployment.

I've applied this change already - subsequent deploys finish correctly.

---

### Acceptance Criteria:

CI deploys can manage the lambda role via serverless.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated
