### PR TITLE
Change optional dependency stopping snyk from scanning

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -7,7 +7,10 @@ RUN apk add \
     curl \
     gnupg \
     lsb-release \
-    wget
+    wget \
+    openssl \
+    openssl-dev \
+    libc6-compat
 
 # Dockerize is needed to sync containers startup
 ENV DOCKERIZE_VERSION v0.6.1

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -72,7 +72,7 @@
                 "node": "20.x"
             },
             "optionalDependencies": {
-                "swc.linux-x64-musl.node": "1.7.36"
+                "@swc/core-linux-x64-musl": "1.9.3"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -11910,13 +11910,12 @@
             }
         },
         "node_modules/@swc/core-linux-x64-musl": {
-            "version": "1.7.39",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.7.39.tgz",
-            "integrity": "sha512-mg39pW5x/eqqpZDdtjZJxrUvQNSvJF4O8wCl37fbuFUqOtXs4TxsjZ0aolt876HXxxhsQl7rS+N4KioEMSgTZw==",
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.9.3.tgz",
+            "integrity": "sha512-ILsGMgfnOz1HwdDz+ZgEuomIwkP1PHT6maigZxaCIuC6OPEhKE8uYna22uU63XvYcLQvZYDzpR3ms47WQPuNEg==",
             "cpu": [
                 "x64"
             ],
-            "dev": true,
             "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
@@ -11972,6 +11971,23 @@
             "optional": true,
             "os": [
                 "win32"
+            ],
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@swc/core/node_modules/@swc/core-linux-x64-musl": {
+            "version": "1.7.39",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.7.39.tgz",
+            "integrity": "sha512-mg39pW5x/eqqpZDdtjZJxrUvQNSvJF4O8wCl37fbuFUqOtXs4TxsjZ0aolt876HXxxhsQl7rS+N4KioEMSgTZw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0 AND MIT",
+            "optional": true,
+            "os": [
+                "linux"
             ],
             "engines": {
                 "node": ">=10"

--- a/api/package.json
+++ b/api/package.json
@@ -101,7 +101,7 @@
         "typescript": "^5.2.2"
     },
     "optionalDependencies": {
-        "swc.linux-x64-musl.node": "1.7.36"
+        "@swc/core-linux-x64-musl": "1.9.3"
     },
     "overrides": {
         "fast-xml-parser": "^4.2.5",

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -1,7 +1,7 @@
 generator client {
     provider        = "prisma-client-js"
     previewFeatures = ["fullTextSearch"]
-    binaryTargets   = ["native", "rhel-openssl-3.0.x", "linux-arm64-openssl-3.0.x"]
+    binaryTargets   = ["native", "linux-musl", "rhel-openssl-3.0.x", "linux-arm64-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
The purpose of this PR was to get around an issue where the way an optional dependency was written was making snyk think that the package-lock file was out of sync.
