### PR TITLE
OC-974-fix: Fix error with spaces in search query

### DIFF
--- a/api/src/components/user/service.ts
+++ b/api/src/components/user/service.ts
@@ -258,7 +258,7 @@ export const getPublications = async (
                       some: {
                           isLatestLiveVersion: true,
                           title: {
-                              search: params.query + ':*'
+                              search: Helpers.sanitizeSearchQuery(params.query)
                           }
                       }
                   }


### PR DESCRIPTION
The purpose of this PR was to fix an error that happens when a query is submitted to the user publications endpoint with a space in it.

If such a query term is passed in to prisma's full text search, it causes a postgresql syntax error. I forgot to use the helper that converts spaces (which is used by similar endpoints for full text search).

---

### Acceptance Criteria:

Query terms containing white space can be used with the get user publications endpoint without an error.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

API
![Screenshot 2024-12-19 102647](https://github.com/user-attachments/assets/732fc4cd-a80d-423e-900e-8923a8f99d93)

---

### Screenshots:
![Screenshot 2024-12-19 102625](https://github.com/user-attachments/assets/e76858b0-7e23-4060-a4fd-33c7c5464d02)
