### PR TITLE
OC-987: Fix CVE-2024-55565

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -11234,15 +11234,16 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.7",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+            "version": "3.3.8",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+            "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
             "funding": [
                 {
                     "type": "github",
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -23498,9 +23499,9 @@
             }
         },
         "nanoid": {
-            "version": "3.3.7",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
+            "version": "3.3.8",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+            "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w=="
         },
         "natural-compare": {
             "version": "1.4.0",


### PR DESCRIPTION
The purpose of this PR was to fix a medium severity improper input validation vulnerability in the nanoid package.

Octopus's UI uses this via a chain of dependencies: NextJS -> PostCSS -> nanoid.

---

### Acceptance Criteria:

Nanoid is installed at 3.3.8 or higher.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
![Screenshot 2025-01-02 132940](https://github.com/user-attachments/assets/a4825802-ea0e-4a1f-b9d3-165b43fae32f)

E2E
![Screenshot 2025-01-02 132858](https://github.com/user-attachments/assets/b3c1cc72-70fe-456e-8447-902050b66298)

