### PR TITLE
OC-990: Align search bar on public profile pages

### DIFF
--- a/ui/src/components/Search/Interface/index.tsx
+++ b/ui/src/components/Search/Interface/index.tsx
@@ -39,7 +39,9 @@ const SearchInterface = React.forwardRef(
         return (
             <div className="mx-auto grid grid-cols-1 gap-x-6 lg:grid-cols-12 lg:gap-y-8 2xl:gap-x-10">
                 <div className="col-span-12 mb-8 grid w-full grid-cols-12 gap-x-6 gap-y-4 lg:mb-0 2xl:gap-x-10">
-                    <fieldset className="col-span-12 lg:col-span-5 xl:col-span-4 grid grid-cols-12 gap-x-6 2xl:gap-x-10">
+                    <fieldset
+                        className={`col-span-12 ${props.showSearchTypeSwitch ? 'grid grid-cols-12 gap-x-6 2xl:gap-x-10 lg:col-span-5 xl:col-span-4' : 'lg:col-span-3 xl:col-span-2'}`}
+                    >
                         <legend className="sr-only">Search options</legend>
 
                         {props.showSearchTypeSwitch && (
@@ -61,7 +63,10 @@ const SearchInterface = React.forwardRef(
                                 </select>
                             </label>
                         )}
-                        <label className="block col-span-4 xl:col-span-3" htmlFor="pageSize">
+                        <label
+                            className={`block ${props.showSearchTypeSwitch ? 'col-span-4 xl:col-span-3' : 'col-span-12'}`}
+                            htmlFor="pageSize"
+                        >
                             <span className="mb-1 block text-xxs font-bold uppercase tracking-widest text-grey-600 transition-colors duration-500 dark:text-grey-300">
                                 Showing
                             </span>
@@ -70,7 +75,7 @@ const SearchInterface = React.forwardRef(
                                 id="pageSize"
                                 onChange={(e) => props.setLimit(parseInt(e.target.value, 10))}
                                 value={props.limit}
-                                className="w-full rounded-md border border-grey-200 focus:ring-2 focus:ring-yellow-500"
+                                className={`w-full rounded-md border border-grey-200 focus:ring-2 focus:ring-yellow-500 ${!props.showSearchTypeSwitch && 'sm:w-1/4 lg:w-full'}`}
                                 disabled={props.isValidating}
                             >
                                 {props.pageSizes?.length ? (
@@ -94,7 +99,7 @@ const SearchInterface = React.forwardRef(
                     <form
                         name="query-form"
                         id="query-form"
-                        className="col-span-12 lg:col-span-7 xl:col-span-8"
+                        className={`col-span-12 ${props.showSearchTypeSwitch ? 'lg:col-span-7 xl:col-span-8' : 'lg:col-span-9 xl:col-span-10'}`}
                         onSubmit={props.handleSearchFormSubmit}
                     >
                         <label htmlFor="searchTerm" className="relative w-full">


### PR DESCRIPTION
The purpose of this PR was to make the search interface look neater when the search type select input is not displayed. Previously there was a gap between the page size select and the search bar which gave an interrupted feel.

---

### Acceptance Criteria:

On search interfaces where the search type dropdown is not displayed, the search box appears further left on the screen, and extends to the right to fill the empty space.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
![Screenshot 2025-01-07 131014](https://github.com/user-attachments/assets/3ba02d22-a056-4409-86f2-3b2792455a33)

E2E
![Screenshot 2025-01-07 125758](https://github.com/user-attachments/assets/de5103a1-54e1-4942-81fa-53a86d3e19f7)

---

### Screenshots:

Before
![Screenshot 2025-01-07 131233](https://github.com/user-attachments/assets/d5ac75af-c9cd-4381-91c9-3bb59d099c0d)

After
![Screenshot 2025-01-07 131213](https://github.com/user-attachments/assets/bc3c2992-87c6-4cf5-948c-d1b09bff8f74)
