### PR TITLE
OC-925-fix: Provide name with container override

### DIFF
--- a/api/src/components/integration/service.ts
+++ b/api/src/components/integration/service.ts
@@ -173,7 +173,12 @@ export const triggerAriIngest = async (dryRun?: boolean): Promise<string> => {
         // If not local, trigger task to run in ECS.
         await ecs.runFargateTask({
             clusterArn: Helpers.checkEnvVariable('ECS_CLUSTER_ARN'),
-            ...(dryRun && { commandOverride: ['npm', 'run', 'ariImport', '--', 'dryRun=true', 'reportFormat=email'] }),
+            ...(dryRun && {
+                containerOverride: {
+                    command: ['npm', 'run', 'ariImport', '--', 'dryRun=true', 'reportFormat=email'],
+                    name: 'ari-import'
+                }
+            }),
             securityGroups: [Helpers.checkEnvVariable('ECS_TASK_SECURITY_GROUP_ID')],
             subnetIds: Helpers.checkEnvVariable('PRIVATE_SUBNET_IDS').split(','),
             taskDefinitionId: Helpers.checkEnvVariable('ECS_TASK_DEFINITION_ID')

--- a/api/src/lib/ecs.ts
+++ b/api/src/lib/ecs.ts
@@ -4,7 +4,10 @@ const client = new ECSClient();
 
 export const runFargateTask = async (config: {
     clusterArn: string;
-    commandOverride?: string[];
+    containerOverride?: {
+        command: string[];
+        name: string;
+    };
     securityGroups: string[];
     subnetIds: string[];
     taskDefinitionId: string;
@@ -18,11 +21,12 @@ export const runFargateTask = async (config: {
                 subnets: config.subnetIds
             }
         },
-        ...(config.commandOverride && {
+        ...(config.containerOverride && {
             overrides: {
                 containerOverrides: [
                     {
-                        command: config.commandOverride
+                        command: config.containerOverride.command,
+                        name: config.containerOverride.name
                     }
                 ]
             }


### PR DESCRIPTION
The purpose of this PR was to fix an issue in the OC-925 branch that only surfaced on deployed code.

The code that triggers the ECS task was providing an invalid container override. The name property is needed as well as the command property.
