### PR TITLE
OC-986: Add Matomo tags for organisational account publications

### DIFF
--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -2,7 +2,7 @@
 const isLocal = process.env.NODE_ENV === 'development';
 const CSPDirectives = [
     "default-src 'none';",
-    `script-src 'self' https://live.matomo.jisc.ac.uk ${isLocal ? "'unsafe-eval'" : ''};`,
+    `script-src 'self' https://live.matomo.jisc.ac.uk 'sha256-i6f/49srVFuOjNVfFr0wuerEVL1EPOoBwnrjWDUm1UA=' ${isLocal ? "'unsafe-eval'" : ''};`,
     "style-src 'self' 'unsafe-inline';",
     `connect-src 'self' https://*.api.octopus.ac http://127.0.0.1:4003 https://api.octopus.ac https://api.ror.org https://cdn.contentful.com https://live.matomo.jisc.ac.uk;`,
     `img-src https: data: ${isLocal ? 'http:' : ''};`,

--- a/ui/src/pages/_app.tsx
+++ b/ui/src/pages/_app.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import Head from 'next/head';
 import { PagesProgressBar as NextProgressBar } from 'next-nprogress-bar';
+import Script from 'next/script';
 
 import * as SWR from 'swr';
 import * as Framer from 'framer-motion';
@@ -45,6 +46,16 @@ const App = ({ Component, pageProps }: Types.AppProps<CustomProps>) => {
                     content="Free, fast and fair: the global primary research record where researchers publish their work in full detail."
                 />
             </Head>
+            <Script>
+                {`
+                var _mtm = window._mtm = window._mtm || [];
+                _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});
+                (function() {
+                    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                    g.async=true; g.src='https://live.matomo.jisc.ac.uk/js/container_WL3HjWKp.js'; s.parentNode.insertBefore(g,s);
+                })();
+                `}
+            </Script>
 
             <NextProgressBar
                 color="#348cb1"

--- a/ui/src/pages/_app.tsx
+++ b/ui/src/pages/_app.tsx
@@ -46,7 +46,7 @@ const App = ({ Component, pageProps }: Types.AppProps<CustomProps>) => {
                     content="Free, fast and fair: the global primary research record where researchers publish their work in full detail."
                 />
             </Head>
-            <Script>
+            <Script id="matomo-tag-manager-init">
                 {`
                 var _mtm = window._mtm = window._mtm || [];
                 _mtm.push({'mtm.startTime': (new Date().getTime()), 'event': 'mtm.Start'});

--- a/ui/src/pages/publications/[id]/versions/[versionId].tsx
+++ b/ui/src/pages/publications/[id]/versions/[versionId].tsx
@@ -671,7 +671,14 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                         : undefined
                 }
             >
-                <section className="col-span-12 lg:col-span-8 xl:col-span-9">
+                <section
+                    id={
+                        publicationVersion.user.role === 'ORGANISATION'
+                            ? `organisation-${publicationVersion.user.id}-publication`
+                            : undefined
+                    }
+                    className="col-span-12 lg:col-span-8 xl:col-span-9"
+                >
                     {alerts}
                     {showApprovalsTracker && (
                         <>


### PR DESCRIPTION
The purpose of this PR was to facilitate tracking publication views by organisational author. For example, to distinguish when an ARI publication is viewed that was authored by a particular government department.

In matomo a trigger can be set up to detect that an element with a particular ID is visible, so I have set an ID on the publication page's main section element containing the organisational user ID.

---

### Acceptance Criteria:

- Matomo tracking code is present on all publication pages
- A way of triggering a publication-view event is set up that can differentiate which organisational account owns the publication

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
![Screenshot 2025-01-21 120902](https://github.com/user-attachments/assets/0e15ea35-6ddd-43c3-955a-77361d998ad1)

E2E
![Screenshot 2025-01-21 121347](https://github.com/user-attachments/assets/7fe08a50-034c-4055-bb4c-b695860eedc8)
