### PR TITLE
OC-988: Date picker closes when different month is selected

### DIFF
--- a/e2e/tests/LoggedIn/search.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/search.e2e.spec.ts
@@ -45,8 +45,8 @@ test.describe('Search term is persisted in URL query string', () => {
 });
 
 const testDateInput = async (page: Page, dateFromInput: Locator, dateToInput: Locator): Promise<void> => {
-    await expect(dateFromInput).toHaveAttribute('value', PageModel.search.dateFrom);
-    await expect(dateToInput).toHaveAttribute('value', PageModel.search.dateTo);
+    await expect(dateFromInput).toHaveValue(PageModel.search.dateFrom);
+    await expect(dateToInput).toHaveValue(PageModel.search.dateTo);
 
     await page.waitForURL(
         `**/search/publications?dateTo=${PageModel.search.dateTo}&dateFrom=${PageModel.search.dateFrom}`
@@ -65,10 +65,8 @@ test.describe('dateTo and dateFrom fields are persisted in URL query string', ()
         const dateToInput = page.locator(PageModel.search.dateToInput);
 
         await dateFromInput.fill(PageModel.search.dateFrom);
-        // Wait for request because filling the dateFrom field will trigger it, and filling in the next field
-        // before it's ready will stop it being added to the URL.
-        await page.waitForResponse((response) => response.url().includes('/publication-versions'));
         await dateToInput.fill(PageModel.search.dateTo);
+        await page.getByRole('button', { name: 'Apply date filter' }).click();
 
         // expect dateFrom/dateTo input and URL to match selections
         await testDateInput(page, dateFromInput, dateToInput);

--- a/ui/src/pages/search/publications/index.tsx
+++ b/ui/src/pages/search/publications/index.tsx
@@ -2,6 +2,7 @@ import Head from 'next/head';
 import React from 'react';
 import useSWR from 'swr';
 import * as Router from 'next/router';
+import * as SolidIcons from '@heroicons/react/24/solid';
 
 import * as api from '@/api';
 import * as Components from '@/components';
@@ -164,6 +165,8 @@ const Publications: Types.NextPage<Props> = (props): React.ReactElement => {
     const [publicationTypes, setPublicationTypes] = React.useState(props.publicationTypes || '');
     const [dateFrom, setDateFrom] = React.useState(props.dateFrom ? props.dateFrom : '');
     const [dateTo, setDateTo] = React.useState(props.dateTo ? props.dateTo : '');
+    const dateFromRef = React.useRef<HTMLInputElement>(null);
+    const dateToRef = React.useRef<HTMLInputElement>(null);
     // param for pagination
     const [limit, setLimit] = React.useState(props.limit ? parseInt(props.limit, 10) : 10);
     const [offset, setOffset] = React.useState(props.offset ? parseInt(props.offset, 10) : 0);
@@ -205,28 +208,24 @@ const Publications: Types.NextPage<Props> = (props): React.ReactElement => {
         setQuery(searchTerm);
     };
 
-    const handleDateFormSubmit = async (e: React.ChangeEvent<HTMLInputElement>): Promise<void> => {
-        e.preventDefault();
-        const newDate = e.target.value;
-
-        const [dateFrom, dateTo, setDate] =
-            e.target.getAttribute('id') === 'date-from'
-                ? [newDate, router.query.dateTo, setDateFrom]
-                : [router.query.dateFrom, newDate, setDateTo];
-
+    const applyDateFilter = async (): Promise<void> => {
         await router.push(
             {
                 query: {
                     ...router.query,
-                    dateTo,
-                    dateFrom
+                    dateTo: dateToRef.current?.value || '',
+                    dateFrom: dateFromRef.current?.value || ''
                 }
             },
             undefined,
             { shallow: true }
         );
-
-        setDate(newDate);
+        if (dateFromRef.current?.value) {
+            setDateFrom(dateFromRef.current.value);
+        }
+        if (dateToRef.current?.value) {
+            setDateTo(dateToRef.current.value);
+        }
     };
 
     const collateAuthorTypes = async (e: React.ChangeEvent<HTMLInputElement>, value: string): Promise<void> => {
@@ -278,7 +277,9 @@ const Publications: Types.NextPage<Props> = (props): React.ReactElement => {
         setLimit(10);
         setPublicationTypes('');
         setDateFrom('');
+        dateFromRef.current && (dateFromRef.current.value = '');
         setDateTo('');
+        dateToRef.current && (dateToRef.current.value = '');
         setAuthorTypes('');
     };
 
@@ -365,7 +366,7 @@ const Publications: Types.NextPage<Props> = (props): React.ReactElement => {
                     </div>
                 </div>
             </fieldset>
-            <fieldset className="col-span-12 lg:col-span-3 xl:col-span-4 space-y-3">
+            <fieldset className="col-span-12 lg:col-span-3 xl:col-span-4 space-y-4">
                 <legend className="pb-2 font-montserrat text-xl font-semibold text-grey-800 transition-colors duration-500 dark:text-white-50">
                     Date Range
                 </legend>
@@ -380,8 +381,8 @@ const Publications: Types.NextPage<Props> = (props): React.ReactElement => {
                         placeholder="Date from..."
                         className="w-full rounded-md border border-grey-200 px-4 py-2 outline-none focus:ring-2 focus:ring-yellow-500 disabled:opacity-70"
                         disabled={isValidating}
-                        value={dateFrom}
-                        onChange={(e) => handleDateFormSubmit(e)}
+                        ref={dateFromRef}
+                        defaultValue={dateFrom}
                     />
                 </label>
                 <label htmlFor="date-to" className="relative block w-full">
@@ -395,10 +396,16 @@ const Publications: Types.NextPage<Props> = (props): React.ReactElement => {
                         placeholder="Date to..."
                         className="w-full rounded-md border border-grey-200 px-4 py-2 outline-none focus:ring-2 focus:ring-yellow-500 disabled:opacity-70"
                         disabled={isValidating}
-                        value={dateTo}
-                        onChange={(e) => handleDateFormSubmit(e)}
+                        ref={dateToRef}
+                        defaultValue={dateTo}
                     />
                 </label>
+                <Components.Button
+                    endIcon={<SolidIcons.CheckCircleIcon className="h-5 w-5 text-teal-500" />}
+                    onClick={applyDateFilter}
+                    variant="block"
+                    title="Apply date filter"
+                />
             </fieldset>
         </>
     );

--- a/ui/src/pages/search/publications/index.tsx
+++ b/ui/src/pages/search/publications/index.tsx
@@ -401,6 +401,7 @@ const Publications: Types.NextPage<Props> = (props): React.ReactElement => {
                     />
                 </label>
                 <Components.Button
+                    className="w-full justify-center"
                     endIcon={<SolidIcons.CheckCircleIcon className="h-5 w-5 text-teal-500" />}
                     onClick={applyDateFilter}
                     variant="block"


### PR DESCRIPTION
The purpose of this PR was to fix a bug where the date picker would close while the user is still interacting with it. This was because an action like changing month, without selecting a day, still triggers an onChange event on the input, which in turn updates the react state and pushes the date values to the querystring, reloading the page. The same applies with trying to type in a date.

The solution to this as agreed with the PO is to introduce a button to apply the selected date range filter, and only then update the react state and query string. This gives the user the time they need to select a date without the page changing and interrupting them.

---

### Acceptance Criteria:

The date picker does not close or lose focus while the user is changing it.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
![Screenshot 2025-01-27 142255](https://github.com/user-attachments/assets/a70ee74a-2d26-4654-9f5d-76ec82561fb6)

E2E
![Screenshot 2025-01-27 144940](https://github.com/user-attachments/assets/a950f9c0-a0a7-401a-b354-8bc479ca1ad4)

---

### Screenshots:
![Screenshot 2025-01-27 144913](https://github.com/user-attachments/assets/c8f654e1-59d3-4dce-ba17-0f40f26f9e15)
