### PR TITLE
OC-925 fix 2: Differentiate scheduler name per environment

### DIFF
--- a/infra/modules/ecs/schedule.tf
+++ b/infra/modules/ecs/schedule.tf
@@ -52,7 +52,7 @@ resource "aws_iam_policy" "scheduler" {
 }
 
 resource "aws_scheduler_schedule" "ari_import_cron" {
-  name = "ari-import-schedule-int"
+  name = "ari-import-schedule-${var.environment}-${var.project_name}"
 
   flexible_time_window {
     mode = "OFF"


### PR DESCRIPTION
The purpose of this PR was to fix an issue that was preventing applying terraform to prod after merging OC-925. The name of the eventbridge scheduler didn't vary per environment so the prod one clashed with the int one.

This has been deployed to prod but just needs merging.
