### PR TITLE
OC-817 fix: path param name and area showing behaviour

### DIFF
--- a/api/serverless-config-default.yml
+++ b/api/serverless-config-default.yml
@@ -283,7 +283,7 @@ functions:
         handler: dist/src/components/flag/routes.getUserFlags
         events:
             - http:
-                path: ${self:custom.versions.v1}/users/{userId}/flags
+                path: ${self:custom.versions.v1}/users/{id}/flags
                 method: GET
                 cors: true
     # Images

--- a/api/src/components/flag/controller.ts
+++ b/api/src/components/flag/controller.ts
@@ -39,7 +39,7 @@ export const getUserFlags = async (
     event: I.APIRequest<undefined, I.GetUserFlagsQueryParams, I.GetUserFlagsPathParams>
 ): Promise<I.JSONResponse> => {
     try {
-        const flags = await flagService.getByUserID(event.pathParameters.userId, event.queryStringParameters);
+        const flags = await flagService.getByUserID(event.pathParameters.id, event.queryStringParameters);
 
         return response.json(200, flags);
     } catch (err) {

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -384,7 +384,7 @@ export interface GetFlagPathParams {
 }
 
 export interface GetUserFlagsPathParams {
-    userId: string;
+    id: string;
 }
 
 export interface GetUserFlagsQueryParams {

--- a/ui/src/pages/authors/[id]/index.tsx
+++ b/ui/src/pages/authors/[id]/index.tsx
@@ -315,29 +315,27 @@ const Author: Types.NextPage<Props> = (props): React.ReactElement => {
                     ></Components.SearchInterface>
                 </section>
 
-                {getFlagsResponse && flags.length ? (
-                    <section className="container mx-auto px-8">
-                        <h2 className="mb-4 font-montserrat text-xl font-semibold text-grey-800 transition-colors duration-500 dark:text-white-50 lg:mb-8">
-                            Red flags raised by this user
-                        </h2>
-                        <Components.Checkbox
-                            checked={includeResolvedFlags}
-                            className="mb-4 lg:mb-8"
-                            id="include-resolved-flags"
-                            label="Include resolved flags"
-                            name="include-resolved-flags"
-                            onChange={(e) => setIncludeResolvedFlags(e.target.checked)}
-                        />
-                        <Components.PaginatedResults
-                            isValidating={getFlagsIsValidating}
-                            limit={10}
-                            offset={flagsOffset}
-                            results={flagResults}
-                            setOffset={setFlagsOffset}
-                            total={getFlagsResponse.metadata.total}
-                        />
-                    </section>
-                ) : null}
+                <section className="container mx-auto px-8">
+                    <h2 className="mb-4 font-montserrat text-xl font-semibold text-grey-800 transition-colors duration-500 dark:text-white-50 lg:mb-8">
+                        Red flags raised by this user
+                    </h2>
+                    <Components.Checkbox
+                        checked={includeResolvedFlags}
+                        className="mb-4 lg:mb-8"
+                        id="include-resolved-flags"
+                        label="Include resolved flags"
+                        name="include-resolved-flags"
+                        onChange={(e) => setIncludeResolvedFlags(e.target.checked)}
+                    />
+                    <Components.PaginatedResults
+                        isValidating={getFlagsIsValidating}
+                        limit={10}
+                        offset={flagsOffset}
+                        results={flagResults}
+                        setOffset={setFlagsOffset}
+                        total={getFlagsResponse?.metadata.total || 0}
+                    />
+                </section>
             </Layouts.Standard>
         </>
     );


### PR DESCRIPTION
The purpose of this PR was to fix 2 issues with the OC-817 work:
- the name of the pathParam specified in serverless.yml caused an error because it didn't match the same param after `/users/` in other endpoint paths.
- the "red flags raised by this user" area needs to show even if there are no results initially, because the user may only have raised flags that are now resolved (excluded by default), which could then be shown using the button if the area was displayed.