### PR TITLE
OC-834: Set disableCookies flag on matomo

### DIFF
--- a/ui/src/hooks/useMatomoNext.ts
+++ b/ui/src/hooks/useMatomoNext.ts
@@ -9,8 +9,8 @@ const useMatomoNext = () => {
 
         if (stage === 'prod' && matomoUrl && matomoSiteId) {
             // Cookieless Tracking
-            push(['disableCookies', 'trackPageView', 'enableLinkTracking']);
-            init({ url: matomoUrl, siteId: matomoSiteId });
+            push(['trackPageView', 'enableLinkTracking']);
+            init({ url: matomoUrl, siteId: matomoSiteId, disableCookies: true });
         }
     }, []);
 };


### PR DESCRIPTION
The purpose of this PR was to set the `disableCookies` property on the object passed to the [@socialgouv/matomo-next](https://www.npmjs.com/package/@socialgouv/matomo-next) `init()` function. The way we had previously been doing it seems to be having the same effect, but just isn't the way the library's README recommends to do it.

---

### Acceptance Criteria:

Matomo is initialised with the `disableCookies` flag set to true.
