### PR TITLE
OC-1004 (part 1): Add cookie policy

### DIFF
--- a/e2e/tests/LoggedOut/staticPages.e2e.spec.ts
+++ b/e2e/tests/LoggedOut/staticPages.e2e.spec.ts
@@ -93,5 +93,10 @@ test.describe('Static pages, logged out', () => {
         await page.locator(PageModel.footer.links[7]).click();
         await expect(page).toHaveURL(`/accessibility`);
         await page.goBack();
+
+        // Check cookie policy
+        await page.locator(PageModel.footer.links[8]).click();
+        await expect(page).toHaveURL(`/cookie-policy`);
+        await page.goBack();
     });
 });

--- a/e2e/tests/PageModel.ts
+++ b/e2e/tests/PageModel.ts
@@ -19,7 +19,8 @@ export const PageModel = {
             'footer > div > div > a[href="/get-involved"]',
             'footer > div > div > a[href="/user-terms"]',
             'footer > div > div > a[href="/privacy"]',
-            'footer > div > div > a[href="/accessibility"]'
+            'footer > div > div > a[href="/accessibility"]',
+            'footer > div > div > a[href="/cookie-policy"]'
         ]
     },
     homepage: {

--- a/ui/src/components/Footer/index.tsx
+++ b/ui/src/components/Footer/index.tsx
@@ -13,6 +13,9 @@ type Props = {
     waves: boolean;
 };
 
+const linkClasses = 'mb-1 block max-w-fit p-1';
+const linkInnerClasses = 'font-montserrat font-semibold text-white-50 dark:text-teal-200';
+
 const Footer: React.FC<Props> = (props: Props): React.ReactElement => (
     <>
         {props.waves && (
@@ -49,7 +52,7 @@ const Footer: React.FC<Props> = (props: Props): React.ReactElement => (
                 </div>
                 {/* contact us section */}
                 <div className="col-span-1 mb-6 md:col-span-4">
-                    <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">
+                    <h3 className={linkInnerClasses}>
                         Contact us: <Components.Link href="mailto:help@jisc.ac.uk">help@jisc.ac.uk</Components.Link>
                     </h3>
                 </div>
@@ -58,59 +61,34 @@ const Footer: React.FC<Props> = (props: Props): React.ReactElement => (
                     process.env.NEXT_PUBLIC_MAINTENANCE_MODE !== 'true' && (
                         <>
                             <div className="col-span-1 mb-14 md:col-span-2 lg:col-span-1">
-                                <Components.Link
-                                    href={Config.urls.browsePublications.path}
-                                    className="mb-1 block max-w-fit p-1"
-                                >
-                                    <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">
-                                        Browse
-                                    </h3>
+                                <Components.Link href={Config.urls.browsePublications.path} className={linkClasses}>
+                                    <h3 className={linkInnerClasses}>Browse</h3>
                                 </Components.Link>
-                                <Components.Link
-                                    href={Config.urls.createPublication.path}
-                                    className="mb-1 block max-w-fit p-1"
-                                >
-                                    <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">
-                                        Publish
-                                    </h3>
+                                <Components.Link href={Config.urls.createPublication.path} className={linkClasses}>
+                                    <h3 className={linkInnerClasses}>Publish</h3>
                                 </Components.Link>
-                                <Components.Link href={Config.urls.about.path} className="mb-1 block max-w-fit p-1">
-                                    <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">
-                                        About
-                                    </h3>
+                                <Components.Link href={Config.urls.about.path} className={linkClasses}>
+                                    <h3 className={linkInnerClasses}>About</h3>
                                 </Components.Link>
-                                <Components.Link href={Config.urls.faq.path} className="mb-1 block max-w-fit p-1">
-                                    <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">
-                                        FAQs
-                                    </h3>
+                                <Components.Link href={Config.urls.faq.path} className={linkClasses}>
+                                    <h3 className={linkInnerClasses}>FAQs</h3>
                                 </Components.Link>
-                                <Components.Link
-                                    href={Config.urls.getInvolved.path}
-                                    className="mb-1 block max-w-fit p-1"
-                                >
-                                    <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">
-                                        Get involved
-                                    </h3>
+                                <Components.Link href={Config.urls.getInvolved.path} className={linkClasses}>
+                                    <h3 className={linkInnerClasses}>Get involved</h3>
                                 </Components.Link>
                             </div>
                             <div className="col-span-1 mb-4 md:col-span-2 lg:col-span-3">
-                                <Components.Link href={Config.urls.terms.path} className="mb-1 block max-w-fit p-1">
-                                    <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">
-                                        Terms
-                                    </h3>
+                                <Components.Link href={Config.urls.terms.path} className={linkClasses}>
+                                    <h3 className={linkInnerClasses}>Terms</h3>
                                 </Components.Link>
-                                <Components.Link href={Config.urls.privacy.path} className="mb-1 block max-w-fit p-1">
-                                    <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">
-                                        Privacy
-                                    </h3>
+                                <Components.Link href={Config.urls.privacy.path} className={linkClasses}>
+                                    <h3 className={linkInnerClasses}>Privacy</h3>
                                 </Components.Link>
-                                <Components.Link
-                                    href={Config.urls.accessibility.path}
-                                    className="mb-1 block max-w-fit p-1 "
-                                >
-                                    <h3 className="font-montserrat font-semibold text-white-50 dark:text-teal-200">
-                                        Accessibility
-                                    </h3>
+                                <Components.Link href={Config.urls.accessibility.path} className={linkClasses}>
+                                    <h3 className={linkInnerClasses}>Accessibility</h3>
+                                </Components.Link>
+                                <Components.Link href={Config.urls.cookiePolicy.path} className={linkClasses}>
+                                    <h3 className={linkInnerClasses}>Cookie Policy</h3>
                                 </Components.Link>
                             </div>
                         </>

--- a/ui/src/components/FunderForm/index.tsx
+++ b/ui/src/components/FunderForm/index.tsx
@@ -46,24 +46,24 @@ const TableRow: React.FC<RowProps> = (props): React.ReactElement => {
     return (
         <>
             <tr key={props.item.id} className="h-12 align-middle">
-                <td className="space-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
+                <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
                     {props.item.name}
                 </td>
-                <td className="space-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
+                <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
                     <Components.Link href={props.item.link} openNew>
                         {props.item.link}
                     </Components.Link>
                 </td>
-                <td className="space-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
+                <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
                     {props.item.city + (props.item.country && ', ' + props.item.country)}
                 </td>
-                <td className="space-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
+                <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
                     {props.item.ror}
                 </td>
-                <td className="space-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
+                <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
                     {props.item.grantId}
                 </td>
-                <td className="space-nowrap h-full items-center justify-center py-4 text-center">
+                <td className="whitespace-nowrap h-full items-center justify-center py-4 text-center">
                     {isLoading ? (
                         <Components.IconButton
                             className="p-2"

--- a/ui/src/components/Publication/Creation/AdditionalInformation/Table.tsx
+++ b/ui/src/components/Publication/Creation/AdditionalInformation/Table.tsx
@@ -39,18 +39,18 @@ const TableRow: React.FC<RowProps> = (props): React.ReactElement => {
 
     return (
         <tr key={props.item.id} className="h-12 align-middle">
-            <td className="space-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
+            <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
                 {props.item.title}
             </td>
-            <td className="space-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
+            <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
                 <Components.Link href={props.item.url} openNew>
                     {props.item.url}
                 </Components.Link>
             </td>
-            <td className="space-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
+            <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
                 {props.item.description}
             </td>
-            <td className="space-nowrap h-full items-center justify-center py-4 text-center">
+            <td className="whitespace-nowrap h-full items-center justify-center py-4 text-center">
                 {isLoading ? (
                     <Components.IconButton
                         className="p-2"

--- a/ui/src/components/Publication/Creation/CoAuthorEntry/index.tsx
+++ b/ui/src/components/Publication/Creation/CoAuthorEntry/index.tsx
@@ -22,7 +22,7 @@ const CoAuthorEntry: React.FC<Props> = (props): React.ReactElement => {
 
     return (
         <tr {...props.entryProps}>
-            <td className="space-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
+            <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
                 <span
                     {...props.dragHandleProps}
                     className="rounded-sm outline-2 outline-offset-2 outline-yellow-400"
@@ -31,7 +31,7 @@ const CoAuthorEntry: React.FC<Props> = (props): React.ReactElement => {
                     <OutlineIcons.Bars3Icon className="h-5 w-5 text-teal-700 transition-colors duration-500 dark:text-white-50" />
                 </span>
             </td>
-            <td className="space-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
+            <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
                 <div className="space-y-2">
                     {props.isMainAuthor ? (
                         <span className="leading-10">N/A</span>
@@ -50,7 +50,7 @@ const CoAuthorEntry: React.FC<Props> = (props): React.ReactElement => {
                     )}
                 </div>
             </td>
-            <td className="space-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
+            <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
                 <div className="space-y-2">
                     {props.isMainAuthor ? (
                         'N/A'
@@ -69,14 +69,14 @@ const CoAuthorEntry: React.FC<Props> = (props): React.ReactElement => {
                     )}
                 </div>
             </td>
-            <td className="space-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
+            <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
                 <div className="space-y-2">
                     <p className="text-grey-800 transition-colors duration-500 dark:text-white-50">
                         {props.coAuthor.email}
                     </p>
                 </div>
             </td>
-            <td className="space-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
+            <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
                 <div className="space-y-2">
                     {props.coAuthor.user ? (
                         <Components.Link
@@ -96,7 +96,7 @@ const CoAuthorEntry: React.FC<Props> = (props): React.ReactElement => {
                     )}
                 </div>
             </td>
-            <td className="space-nowrap px-8 py-4 text-center text-sm font-medium text-grey-900 transition-colors duration-500 dark:text-white-50">
+            <td className="whitespace-nowrap px-8 py-4 text-center text-sm font-medium text-grey-900 transition-colors duration-500 dark:text-white-50">
                 {!props.isMainAuthor && (
                     <Components.IconButton
                         className="p-2"

--- a/ui/src/components/Publication/Creation/LinkedItems/LinkedPublicationRow.tsx
+++ b/ui/src/components/Publication/Creation/LinkedItems/LinkedPublicationRow.tsx
@@ -19,7 +19,7 @@ const LinkedPublicationRow: React.FC<Props> = (props): React.ReactElement => {
 
     return (
         <tr key={props.linkedPublication.id}>
-            <td className="space-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
+            <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
                 <div className="space-y-2">
                     <span className="font-montserrat text-sm font-medium text-teal-600 transition-colors duration-500 dark:text-teal-100">
                         {Helpers.formatPublicationType(props.linkedPublication.type)}
@@ -43,7 +43,7 @@ const LinkedPublicationRow: React.FC<Props> = (props): React.ReactElement => {
                     </div>
                 </div>
             </td>
-            <td className="space-nowrap px-8 py-4 text-center text-sm font-medium text-grey-900 transition-colors duration-500 dark:text-white-50">
+            <td className="whitespace-nowrap px-8 py-4 text-center text-sm font-medium text-grey-900 transition-colors duration-500 dark:text-white-50">
                 {props.linkedPublication.draft ? (
                     loading ? (
                         <Components.IconButton

--- a/ui/src/components/Publication/Creation/LinkedItems/LinkedTopicRow.tsx
+++ b/ui/src/components/Publication/Creation/LinkedItems/LinkedTopicRow.tsx
@@ -19,10 +19,10 @@ const LinkedTopicRow: React.FC<Props> = (props): React.ReactElement => {
 
     return (
         <tr key={props.topic.id}>
-            <td className="space-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
+            <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
                 <p className="text-grey-800 transition-colors duration-500 dark:text-white-50">{props.topic.title}</p>
             </td>
-            <td className="space-nowrap px-8 py-4 text-center text-sm font-medium text-grey-900 transition-colors duration-500 dark:text-white-50">
+            <td className="whitespace-nowrap px-8 py-4 text-center text-sm font-medium text-grey-900 transition-colors duration-500 dark:text-white-50">
                 {props.topic.draft ? (
                     loading ? (
                         <Components.IconButton

--- a/ui/src/components/Users/HistoryTable/index.tsx
+++ b/ui/src/components/Users/HistoryTable/index.tsx
@@ -31,7 +31,7 @@ const HistoryTable: React.FC<Props> = (props) => (
                         <tbody className="divide-y divide-grey-100 bg-white-50 transition-colors duration-500 dark:divide-teal-300 dark:bg-grey-600">
                             {props.records.map((record, index) => (
                                 <tr key={index}>
-                                    <td className="space-nowrap py-4 pl-4 pr-3 text-sm font-medium text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
+                                    <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
                                         {record.organisation}
                                     </td>
                                     <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-grey-500 transition-colors duration-500 dark:text-grey-100">

--- a/ui/src/components/Users/WorksTable/index.tsx
+++ b/ui/src/components/Users/WorksTable/index.tsx
@@ -31,7 +31,7 @@ const WorksTable: React.FC<Props> = (props) => (
                         <tbody className="divide-y divide-grey-100 bg-white-50 transition-colors duration-500 dark:divide-teal-300 dark:bg-grey-600">
                             {props.records.map((record, index) => (
                                 <tr key={index}>
-                                    <td className="space-nowrap py-4 pl-4 pr-3 text-sm font-medium text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
+                                    <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
                                         {record.url ? (
                                             <a href={record.url} className="underline">
                                                 {record.title}

--- a/ui/src/config/urls.ts
+++ b/ui/src/config/urls.ts
@@ -292,6 +292,14 @@ const urls = {
         documentTitle: `Research Culture Report - ${base.title}`,
         keywords: ['research', 'culture', 'report'],
         canonical: `${base.host}/research-culture-report`
+    },
+    cookiePolicy: {
+        path: '/cookie-policy',
+        title: 'Cookie Policy',
+        description: 'Octopus cookie policy',
+        documentTitle: `Cookie Policy - ${base.title}`,
+        keywords: ['cookies', 'policy', 'cookie policy'],
+        canonical: `${base.host}/cookie-policy`
     }
 };
 

--- a/ui/src/layouts/Information.tsx
+++ b/ui/src/layouts/Information.tsx
@@ -11,7 +11,11 @@ const Information: React.FC<Props> = (props): React.ReactElement => (
     <>
         <Components.JumpToContent />
         <Components.Header fixed={props.fixedHeader} />
-        <main className="container mx-auto px-8 pt-8 lg:gap-4 lg:pt-16">{props.children}</main>
+        <main className="container mx-auto px-8 pt-8 lg:gap-4 lg:pt-16">
+            <section className="mx-auto mb-10 grid grid-cols-1 gap-4 text-grey-900 transition-colors duration-500 dark:text-white-50 lg:w-8/12">
+                {props.children}
+            </section>
+        </main>
         <Components.Footer waves={true} />
     </>
 );

--- a/ui/src/pages/accessibility.tsx
+++ b/ui/src/pages/accessibility.tsx
@@ -18,242 +18,239 @@ const Accessibility: Types.NextPage = (): React.ReactElement => {
             </Head>
 
             <Layouts.Information>
-                <section className="mx-auto mb-10 grid grid-cols-1 gap-4 text-grey-900 transition-colors duration-500 dark:text-white-50 lg:w-8/12">
-                    <Components.PageTitle text="Accessibility statement for Octopus.ac" />
-                    <p>
-                        This statement applies to content published on{' '}
-                        <Components.Link
-                            className="mb-6 w-fit rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
-                            href={Config.urls.home.path}
-                        >
-                            https://www.octopus.ac
-                        </Components.Link>
-                    </p>
-                    <p>
-                        This website has been developed by Jisc. It is designed to be used by as many people as
-                        possible. The text should be clear and simple to understand. You should be able to:
-                    </p>
-                    <ul className="ml-6 list-disc">
-                        <li>Change colours, contrast levels and fonts.</li>
-                        <li>Zoom in up to 400% without problems.</li>
-                        <li>Navigate most of the website using just a keyboard.</li>
-                        <li>Navigate most of the website using speech recognition software.</li>
-                        <li>
-                            Use most of the website using a screen reader (including the most recent versions of JAWS,
-                            NVDA and VoiceOver).
-                        </li>
-                    </ul>
-                    <p>
-                        <Components.Link
-                            className="rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
-                            openNew
-                            href="https://mcmw.abilitynet.org.uk/"
-                        >
-                            AbilityNet
-                        </Components.Link>{' '}
-                        has advice on making your device easier to use if you have a disability.
-                    </p>
-                    <h2 className="mt-10 text-xl font-semibold">How accessible this website is</h2>
-                    <p>We know some parts of this website are not fully accessible:</p>
-                    <ul className="ml-6 list-disc">
-                        <li>
-                            The publication page&apos;s navigation tool does not provide context on how different
-                            publications are related to each-other.
-                        </li>
-                        <li>Skip links are not functional on most pages.</li>
-                        <li>
-                            Informational links typically do not have markups to explain their purpose when focusing
-                            them with a screen reader.
-                        </li>
-                    </ul>
-                    <h2 className="mt-10 text-xl font-semibold">Feedback and contact information</h2>
-                    <p>
-                        If you find any problems that aren&apos;t listed on this page or think we&apos;re not meeting
-                        the requirements of the accessibility regulations, please contact{' '}
-                        <Components.Link
-                            className="mb-4 w-fit rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
-                            openNew
-                            href="mailto:help@jisc.ac.uk"
-                        >
-                            help@jisc.ac.uk.
-                        </Components.Link>
-                    </p>
-                    <p>
-                        If you need information on this website in a different format like accessible PDF, large print,
-                        easy read, audio recording or braille please contact{' '}
-                        <Components.Link
-                            className="mb-4 w-fit rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
-                            openNew
-                            href="mailto:help@jisc.ac.uk"
-                        >
-                            help@jisc.ac.uk.
-                        </Components.Link>
-                    </p>
-                    <p>We&apos;ll consider your request and get back to you in 7 days.</p>
-                    <h2 className="mt-10 text-xl font-semibold">Enforcement procedure</h2>
-                    <p>
-                        The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector
-                        Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the
-                        &apos;accessibility regulations&apos;). If you&apos;re not happy with how we respond to your
-                        complaint,{' '}
-                        <Components.Link
-                            className="mb-4 w-fit rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
-                            openNew
-                            href="https://www.equalityadvisoryservice.com/"
-                        >
-                            contact the Equality Advisory and Support Service (EASS)
-                        </Components.Link>
-                        .
-                    </p>
-                    <h2 className="mt-10 text-xl font-semibold">
-                        Technical information about this website&apos;s accessibility
-                    </h2>
-                    <p>
-                        Jisc is committed to making its website accessible, in accordance with the Public Sector Bodies
-                        (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
-                    </p>
-                    <h3 className="mt-8 text-lg font-semibold">Compliance status</h3>
-                    <p>
-                        This website is partially compliant with the{' '}
-                        <Components.Link
-                            className="mb-4 w-fit rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
-                            openNew
-                            href="https://www.w3.org/TR/WCAG21/"
-                        >
-                            Web Content Accessibility Guidelines version 2.1
-                        </Components.Link>{' '}
-                        AA standard due to the non-compliances and exemptions listed below.
-                    </p>
-                    <h2 className="mt-10 text-xl font-semibold">Non-accessible content</h2>
-                    <p>The content listed below is non-accessible for the following reasons.</p>
-                    <h3 className="mt-8 text-lg font-semibold">Non-compliance with the accessibility regulations</h3>
-                    <h4 className="mt-6 font-semibold">1.1.1 Non-text Content (Level A)</h4>
-                    <p>Certain icons on the draft edit page do not have a label or other text-based alternative.</p>
-                    <h4 className="mt-6 font-semibold">
-                        1.3.1 Info and Relationships (Level A), 2.4.6 Headings and Labels (Level AA), 3.3.2 Labels or
-                        Instructions (Level A), 4.1.2 Name, Role, Value (Level A)
-                    </h4>
-                    <p>
-                        The information structure of certain elements such as affiliations or linked publications are
-                        not effectively conveyed to screen readers.
-                    </p>
-                    <p>
-                        Changes in the structure of the affiliations table based upon user input are not marked up to
-                        announce the change.
-                    </p>
-                    <p>
-                        Many fields on the draft edit page are not marked up with a label, although placeholder text is
-                        present to explain their purpose in most cases.
-                    </p>
-                    <p>Certain fields are not marked up with their semantic purpose.</p>
-                    <p>Several lists on publication pages do not convey details about the list&apos;s structure.</p>
-                    <p>
-                        The &quot;Main Text&quot; and &quot;References&quot; fields on the draft edit page do not convey
-                        their purpose to screen readers. Some modals, such as the “Red flag publication” modal do not
-                        announce their name to screen readers.
-                    </p>
-                    <h4 className="mt-6 font-semibold">1.3.3 Sensory Characteristics (Level A)</h4>
-                    <p>The completion of sections on the draft edit page is only indicated via icon colour & shape.</p>
-                    <h4 className="mt-6 font-semibold">2.4.1 Bypass Blocks (Level A)</h4>
-                    <p>
-                        Skip links to access main content do not function correctly, and additional skip links should be
-                        added to avoid unnecessary navigation to reach interactive elements of the publication page.
-                    </p>
-                    <h4 className="mt-6 font-semibold">2.4.4 Link Purpose (In Context) (Level A)</h4>
-                    <p>
-                        Many links on informational pages and on the draft edit page do not provide sufficient
-                        information about their purpose, requiring the user to gather context from the surrounding page.
-                    </p>
-                    <h4 className="mt-6 font-semibold">1.3.5 Identify Input Purpose (Level AA)</h4>
-                    <p>Fields to enter organisation name do not have their semantic purpose correctly recorded.</p>
-                    <h4 className="mt-6 font-semibold">1.4.3 Contrast (Minimum) (Level AA)</h4>
-                    <p>
-                        Red asterisks used to denote mandatory fields are presented on the &quot;Flag a concern&quot;
-                        model as small text without sufficient contrast (3.78:1).
-                    </p>
-                    <p>
-                        DOI text publications listed on the account page on light mode is small and has insufficient
-                        contrast (3.79:1).
-                    </p>
-                    <p>Publication type text on the account page has insufficient contrast on dark mode (3.05:1).</p>
-                    <h4 className="mt-6 font-semibold">3.1.2 Language of Parts (Level AA)</h4>
-                    <p>Publication text is not marked up as being in the language it was written in.</p>
-                    <h4 className="mt-6 font-semibold">3.2.4 Consistent Identification (Level AA)</h4>
-                    <p>
-                        Publication title is described differently by assistive technology on the &quot;publish&quot;
-                        page compared with the draft edit page.
-                    </p>
-                    <h4 className="mt-6 font-semibold">3.3.3 Error Suggestion (Level AA)</h4>
-                    <p>
-                        Error banners that advise a correction, such as the one that appears when a user enters an
-                        invalid URL for a funder, or an invalid email for a co-author are displayed to the user advising
-                        of the issue but are not announced to screen readers.
-                    </p>
-                    <h4 className="mt-6 font-semibold">4.1.3 Status Messages (Level AA)</h4>
-                    <p>
-                        Error banners do not have a role=alert markup. This includes both programmatic errors, such as
-                        403, &quot;Publication is already locked&quot;, and so on, as well as user input errors, such as
-                        an invalid URL for a funder, or an invalid email for a co-author.
-                    </p>
-                    <h3 className="mt-8 text-lg font-semibold">Disproportionate Burden</h3>
-                    <h4 className="mt-6 font-semibold">User uploaded content</h4>
-                    <p>
-                        Whilst authors are provided with tools that allow them to create accessible publications, we do
-                        not have any direct oversight of the content they upload, nor power to modify it. User uploaded
-                        content on any publication page (at a URL beginning with https://www.octopus.ac/publications/)
-                        may not conform with accessibility guidelines.
-                    </p>
-                    <p>
-                        Possible examples of non-accessible content include images without explanatory alt-text (1.1.1
-                        Non-text content), relationships and information conveyed by shape, position and other
-                        characteristics that cannot be conveyed to assistive technology (1.3.1 Info and relationships),
-                        and links that do not provide context about their purpose (2.4.4 Link Purpose).
-                    </p>
-                    <p>
-                        It is not within our power to compel users to upload accessible content, and we do not have any
-                        form of manual intervention in the publishing process. As such, we believe that the time,
-                        resources, and complexity of auditing each draft before publication to suggest modifications
-                        represents a disproportionate burden within the meaning of the accessibility regulations. We
-                        will endeavour to provide features and guidance to authors to encourage them to upload
-                        accessible publications.
-                    </p>
-                    <h2 className="mt-10 text-xl font-semibold">What we&apos;re doing to improve accessibility</h2>
-                    <p>
-                        Whenever new features are released, they go through our internal quality assurance checks and
-                        must meet WCAG 2.1 A & AA guidelines. We&apos;re also committed to working on the issues above
-                        and aim to have all known issues resolved by mid-2025.
-                    </p>
-                    <p>
-                        Improvements are being made both as a part of routine development, and as dedicated exercises.
-                        Accessibility is considered as a priority for all features developed for the platform.
-                    </p>
-                    <h2 className="mt-10 text-xl font-semibold">Preparation of this accessibility statement</h2>
-                    <p>This statement was prepared on 3 Nov 2023. It was last reviewed on 25 Jun 2024.</p>
-                    <p>This website was last tested on 25 Jun 2024.</p>
-                    <p>
-                        The test was carried out by Jisc staff, using semi-automated testing tools such as Site Improve,
-                        Chrome Lighthouse and WAVE Evaluation tool. Manual accessibility testing was conducted on Chrome
-                        & Edge using NVDA screen reader, and TPGI&apos;s colour contrast analyser on Windows 11.
-                    </p>
-                    <article className="mt-10 flex flex-col gap-1">
-                        <p>Content modified from:</p>
-                        <Components.Link
-                            className="mb-4 w-fit rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
-                            openNew
-                            href="https://www.gov.uk/help/accessibility-statement"
-                        >
-                            <span>GOV.UK accessibility statement</span>
-                        </Components.Link>
-                        <p>Used through the:</p>
-                        <Components.Link
-                            className="mb-4 w-fit rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
-                            openNew
-                            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-                        >
-                            <span> Open Government Licence v3.0</span>
-                        </Components.Link>
-                    </article>
-                </section>
+                <Components.PageTitle text="Accessibility statement for Octopus.ac" />
+                <p>
+                    This statement applies to content published on{' '}
+                    <Components.Link
+                        className="mb-6 w-fit rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
+                        href={Config.urls.home.path}
+                    >
+                        https://www.octopus.ac
+                    </Components.Link>
+                </p>
+                <p>
+                    This website has been developed by Jisc. It is designed to be used by as many people as possible.
+                    The text should be clear and simple to understand. You should be able to:
+                </p>
+                <ul className="ml-6 list-disc">
+                    <li>Change colours, contrast levels and fonts.</li>
+                    <li>Zoom in up to 400% without problems.</li>
+                    <li>Navigate most of the website using just a keyboard.</li>
+                    <li>Navigate most of the website using speech recognition software.</li>
+                    <li>
+                        Use most of the website using a screen reader (including the most recent versions of JAWS, NVDA
+                        and VoiceOver).
+                    </li>
+                </ul>
+                <p>
+                    <Components.Link
+                        className="rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
+                        openNew
+                        href="https://mcmw.abilitynet.org.uk/"
+                    >
+                        AbilityNet
+                    </Components.Link>{' '}
+                    has advice on making your device easier to use if you have a disability.
+                </p>
+                <h2 className="mt-10 text-xl font-semibold">How accessible this website is</h2>
+                <p>We know some parts of this website are not fully accessible:</p>
+                <ul className="ml-6 list-disc">
+                    <li>
+                        The publication page&apos;s navigation tool does not provide context on how different
+                        publications are related to each-other.
+                    </li>
+                    <li>Skip links are not functional on most pages.</li>
+                    <li>
+                        Informational links typically do not have markups to explain their purpose when focusing them
+                        with a screen reader.
+                    </li>
+                </ul>
+                <h2 className="mt-10 text-xl font-semibold">Feedback and contact information</h2>
+                <p>
+                    If you find any problems that aren&apos;t listed on this page or think we&apos;re not meeting the
+                    requirements of the accessibility regulations, please contact{' '}
+                    <Components.Link
+                        className="mb-4 w-fit rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
+                        openNew
+                        href="mailto:help@jisc.ac.uk"
+                    >
+                        help@jisc.ac.uk.
+                    </Components.Link>
+                </p>
+                <p>
+                    If you need information on this website in a different format like accessible PDF, large print, easy
+                    read, audio recording or braille please contact{' '}
+                    <Components.Link
+                        className="mb-4 w-fit rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
+                        openNew
+                        href="mailto:help@jisc.ac.uk"
+                    >
+                        help@jisc.ac.uk.
+                    </Components.Link>
+                </p>
+                <p>We&apos;ll consider your request and get back to you in 7 days.</p>
+                <h2 className="mt-10 text-xl font-semibold">Enforcement procedure</h2>
+                <p>
+                    The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector
+                    Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the
+                    &apos;accessibility regulations&apos;). If you&apos;re not happy with how we respond to your
+                    complaint,{' '}
+                    <Components.Link
+                        className="mb-4 w-fit rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
+                        openNew
+                        href="https://www.equalityadvisoryservice.com/"
+                    >
+                        contact the Equality Advisory and Support Service (EASS)
+                    </Components.Link>
+                    .
+                </p>
+                <h2 className="mt-10 text-xl font-semibold">
+                    Technical information about this website&apos;s accessibility
+                </h2>
+                <p>
+                    Jisc is committed to making its website accessible, in accordance with the Public Sector Bodies
+                    (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+                </p>
+                <h3 className="mt-8 text-lg font-semibold">Compliance status</h3>
+                <p>
+                    This website is partially compliant with the{' '}
+                    <Components.Link
+                        className="mb-4 w-fit rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
+                        openNew
+                        href="https://www.w3.org/TR/WCAG21/"
+                    >
+                        Web Content Accessibility Guidelines version 2.1
+                    </Components.Link>{' '}
+                    AA standard due to the non-compliances and exemptions listed below.
+                </p>
+                <h2 className="mt-10 text-xl font-semibold">Non-accessible content</h2>
+                <p>The content listed below is non-accessible for the following reasons.</p>
+                <h3 className="mt-8 text-lg font-semibold">Non-compliance with the accessibility regulations</h3>
+                <h4 className="mt-6 font-semibold">1.1.1 Non-text Content (Level A)</h4>
+                <p>Certain icons on the draft edit page do not have a label or other text-based alternative.</p>
+                <h4 className="mt-6 font-semibold">
+                    1.3.1 Info and Relationships (Level A), 2.4.6 Headings and Labels (Level AA), 3.3.2 Labels or
+                    Instructions (Level A), 4.1.2 Name, Role, Value (Level A)
+                </h4>
+                <p>
+                    The information structure of certain elements such as affiliations or linked publications are not
+                    effectively conveyed to screen readers.
+                </p>
+                <p>
+                    Changes in the structure of the affiliations table based upon user input are not marked up to
+                    announce the change.
+                </p>
+                <p>
+                    Many fields on the draft edit page are not marked up with a label, although placeholder text is
+                    present to explain their purpose in most cases.
+                </p>
+                <p>Certain fields are not marked up with their semantic purpose.</p>
+                <p>Several lists on publication pages do not convey details about the list&apos;s structure.</p>
+                <p>
+                    The &quot;Main Text&quot; and &quot;References&quot; fields on the draft edit page do not convey
+                    their purpose to screen readers. Some modals, such as the “Red flag publication” modal do not
+                    announce their name to screen readers.
+                </p>
+                <h4 className="mt-6 font-semibold">1.3.3 Sensory Characteristics (Level A)</h4>
+                <p>The completion of sections on the draft edit page is only indicated via icon colour & shape.</p>
+                <h4 className="mt-6 font-semibold">2.4.1 Bypass Blocks (Level A)</h4>
+                <p>
+                    Skip links to access main content do not function correctly, and additional skip links should be
+                    added to avoid unnecessary navigation to reach interactive elements of the publication page.
+                </p>
+                <h4 className="mt-6 font-semibold">2.4.4 Link Purpose (In Context) (Level A)</h4>
+                <p>
+                    Many links on informational pages and on the draft edit page do not provide sufficient information
+                    about their purpose, requiring the user to gather context from the surrounding page.
+                </p>
+                <h4 className="mt-6 font-semibold">1.3.5 Identify Input Purpose (Level AA)</h4>
+                <p>Fields to enter organisation name do not have their semantic purpose correctly recorded.</p>
+                <h4 className="mt-6 font-semibold">1.4.3 Contrast (Minimum) (Level AA)</h4>
+                <p>
+                    Red asterisks used to denote mandatory fields are presented on the &quot;Flag a concern&quot; model
+                    as small text without sufficient contrast (3.78:1).
+                </p>
+                <p>
+                    DOI text publications listed on the account page on light mode is small and has insufficient
+                    contrast (3.79:1).
+                </p>
+                <p>Publication type text on the account page has insufficient contrast on dark mode (3.05:1).</p>
+                <h4 className="mt-6 font-semibold">3.1.2 Language of Parts (Level AA)</h4>
+                <p>Publication text is not marked up as being in the language it was written in.</p>
+                <h4 className="mt-6 font-semibold">3.2.4 Consistent Identification (Level AA)</h4>
+                <p>
+                    Publication title is described differently by assistive technology on the &quot;publish&quot; page
+                    compared with the draft edit page.
+                </p>
+                <h4 className="mt-6 font-semibold">3.3.3 Error Suggestion (Level AA)</h4>
+                <p>
+                    Error banners that advise a correction, such as the one that appears when a user enters an invalid
+                    URL for a funder, or an invalid email for a co-author are displayed to the user advising of the
+                    issue but are not announced to screen readers.
+                </p>
+                <h4 className="mt-6 font-semibold">4.1.3 Status Messages (Level AA)</h4>
+                <p>
+                    Error banners do not have a role=alert markup. This includes both programmatic errors, such as 403,
+                    &quot;Publication is already locked&quot;, and so on, as well as user input errors, such as an
+                    invalid URL for a funder, or an invalid email for a co-author.
+                </p>
+                <h3 className="mt-8 text-lg font-semibold">Disproportionate Burden</h3>
+                <h4 className="mt-6 font-semibold">User uploaded content</h4>
+                <p>
+                    Whilst authors are provided with tools that allow them to create accessible publications, we do not
+                    have any direct oversight of the content they upload, nor power to modify it. User uploaded content
+                    on any publication page (at a URL beginning with https://www.octopus.ac/publications/) may not
+                    conform with accessibility guidelines.
+                </p>
+                <p>
+                    Possible examples of non-accessible content include images without explanatory alt-text (1.1.1
+                    Non-text content), relationships and information conveyed by shape, position and other
+                    characteristics that cannot be conveyed to assistive technology (1.3.1 Info and relationships), and
+                    links that do not provide context about their purpose (2.4.4 Link Purpose).
+                </p>
+                <p>
+                    It is not within our power to compel users to upload accessible content, and we do not have any form
+                    of manual intervention in the publishing process. As such, we believe that the time, resources, and
+                    complexity of auditing each draft before publication to suggest modifications represents a
+                    disproportionate burden within the meaning of the accessibility regulations. We will endeavour to
+                    provide features and guidance to authors to encourage them to upload accessible publications.
+                </p>
+                <h2 className="mt-10 text-xl font-semibold">What we&apos;re doing to improve accessibility</h2>
+                <p>
+                    Whenever new features are released, they go through our internal quality assurance checks and must
+                    meet WCAG 2.1 A & AA guidelines. We&apos;re also committed to working on the issues above and aim to
+                    have all known issues resolved by mid-2025.
+                </p>
+                <p>
+                    Improvements are being made both as a part of routine development, and as dedicated exercises.
+                    Accessibility is considered as a priority for all features developed for the platform.
+                </p>
+                <h2 className="mt-10 text-xl font-semibold">Preparation of this accessibility statement</h2>
+                <p>This statement was prepared on 3 Nov 2023. It was last reviewed on 25 Jun 2024.</p>
+                <p>This website was last tested on 25 Jun 2024.</p>
+                <p>
+                    The test was carried out by Jisc staff, using semi-automated testing tools such as Site Improve,
+                    Chrome Lighthouse and WAVE Evaluation tool. Manual accessibility testing was conducted on Chrome &
+                    Edge using NVDA screen reader, and TPGI&apos;s colour contrast analyser on Windows 11.
+                </p>
+                <article className="mt-10 flex flex-col gap-1">
+                    <p>Content modified from:</p>
+                    <Components.Link
+                        className="mb-4 w-fit rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
+                        openNew
+                        href="https://www.gov.uk/help/accessibility-statement"
+                    >
+                        <span>GOV.UK accessibility statement</span>
+                    </Components.Link>
+                    <p>Used through the:</p>
+                    <Components.Link
+                        className="mb-4 w-fit rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
+                        openNew
+                        href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                    >
+                        <span> Open Government Licence v3.0</span>
+                    </Components.Link>
+                </article>
             </Layouts.Information>
         </>
     );

--- a/ui/src/pages/cookie-policy.tsx
+++ b/ui/src/pages/cookie-policy.tsx
@@ -1,0 +1,94 @@
+import Head from 'next/head';
+
+import * as Components from '@/components';
+import * as Layouts from '@/layouts';
+import * as Config from '@/config';
+import * as Types from '@/types';
+
+const CookiePolicy: Types.NextPage = (): React.ReactElement => {
+    const headerClasses = 'mb-1 mt-10 text-xl font-medium';
+    const paragraphClasses = 'mb-4';
+    const baseHeadingCellClasses =
+        'whitespace-pre py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-grey-900 transition-colors duration-500 dark:text-grey-50 sm:pl-6';
+    const defaultHeadingCellClasses = baseHeadingCellClasses + 'pr-2';
+    const rightHeadingCellClasses = baseHeadingCellClasses + 'pr-4 sm:pr-6';
+    const baseCellClasses = 'py-4 pl-4 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6';
+    const rightCellClasses = baseCellClasses + 'pr-4 sm:pr-6';
+    const defaultCellClasses = baseCellClasses + 'pr-2';
+    return (
+        <>
+            <Head>
+                <title>{Config.urls.cookiePolicy.title}</title>
+                <meta name="description" content={Config.urls.cookiePolicy.description} />
+                <meta name="og:title" content={Config.urls.cookiePolicy.title} />
+                <meta name="og:description" content={Config.urls.cookiePolicy.description} />
+                <meta name="keywords" content={Config.urls.cookiePolicy.keywords.join(', ')} />
+                <link rel="canonical" href={Config.urls.cookiePolicy.canonical} />
+            </Head>
+            <Layouts.Information>
+                <Components.PageTitle text={Config.urls.cookiePolicy.title} />
+                <h2 className={headerClasses}>About cookies</h2>
+                <p className={paragraphClasses}>
+                    To help improve this site we place small files, known as cookies, onto your computer. All of the
+                    cookies we use are essential for the site to work properly.
+                </p>
+                <h2 className={headerClasses}>How we use cookies</h2>
+                <p className={paragraphClasses}>We use cookies only for essential purposes on this website.</p>
+                <h2 className={headerClasses}>Essential cookies</h2>
+                <p className={paragraphClasses}>
+                    The system that runs our website sets cookies to allow it to run smoothly.
+                </p>
+                <div className="mb-6 overflow-hidden shadow ring-1 ring-black ring-opacity-5 dark:ring-transparent rounded-lg">
+                    <table className="min-w-full divide-y divide-grey-100 dark:divide-teal-300">
+                        <thead className="bg-grey-50 transition-colors duration-500 dark:bg-grey-700">
+                            <tr>
+                                <th className={defaultHeadingCellClasses}>Name</th>
+                                <th className={defaultHeadingCellClasses}>Purpose</th>
+                                <th className={rightHeadingCellClasses}>Expires</th>
+                            </tr>
+                        </thead>
+                        <tbody className="divide-y divide-grey-100 bg-white-50 transition-colors duration-500 dark:divide-teal-300 dark:bg-grey-600">
+                            <tr>
+                                <td className={defaultCellClasses}>production-octopus-token</td>
+                                <td className={defaultCellClasses}>Used to store your login token</td>
+                                <td className={rightCellClasses}>8 hours</td>
+                            </tr>
+                            <tr>
+                                <td className={defaultCellClasses}>AWSALB</td>
+                                <td className={defaultCellClasses}>
+                                    Used to make sure the website can cope with unexpected traffic
+                                </td>
+                                <td className={rightCellClasses}>7 days</td>
+                            </tr>
+                            <tr>
+                                <td className={defaultCellClasses}>AWSALBCORS</td>
+                                <td className={defaultCellClasses}>
+                                    Used to make sure the website can cope with unexpected traffic
+                                </td>
+                                <td className={rightCellClasses}>7 days</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <p className={paragraphClasses}>
+                    NB: Cookie guidance wording adapted from{' '}
+                    <Components.Link href="http://www.gov.uk/help/cookies" openNew className="underline">
+                        cookies on gov.uk
+                    </Components.Link>
+                    , shared under the{' '}
+                    <Components.Link
+                        href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                        openNew
+                        className="underline"
+                    >
+                        Open Government Licence
+                    </Components.Link>
+                    .
+                </p>
+                <p className={paragraphClasses + ' font-bold'}>Last updated: 11 Feb 2025.</p>
+            </Layouts.Information>
+        </>
+    );
+};
+
+export default CookiePolicy;

--- a/ui/src/pages/privacy.tsx
+++ b/ui/src/pages/privacy.tsx
@@ -18,80 +18,76 @@ const Privacy: Types.NextPage = (): React.ReactElement => {
             </Head>
 
             <Layouts.Information>
-                <section className="mx-auto mb-10 grid grid-cols-1 gap-4 text-grey-900 transition-colors duration-500 dark:text-white-50 lg:w-8/12">
-                    <Components.PageTitle text="Privacy" />
-                    <p className="mb-4">
-                        The following information is needed for us to register your user account in Octopus. We’ll use
-                        it, as described in our standard privacy notice (at{' '}
-                        <Components.Link
-                            openNew
-                            className="rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
-                            href="https://www.jisc.ac.uk/website/privacy-notice"
-                        >
-                            <span>https://www.jisc.ac.uk/website/privacy-notice</span>
-                        </Components.Link>
-                        ), to provide the service you’ve requested, as well as to identify problems or ways to make the
-                        service better.
-                    </p>
-                    <p className="mb-4">
-                        We&apos;ll keep the information until we are told that you no longer wish to hold an account. If
-                        you wish to delete your Octopus user account, you can email{' '}
-                        <Components.Link
-                            openNew
-                            className="rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
-                            href="mailto:help@jisc.ac.uk"
-                        >
-                            <span>help@jisc.ac.uk </span>
-                        </Components.Link>
-                        and we will remove your individual account and personal information. However, please note that
-                        unless otherwise agreed we would not as standard delete any publications affiliated with this
-                        account.
-                    </p>
-                    <h2 className="mb-1 mt-10 text-xl font-medium">User accounts</h2>
-                    <p className="mb-4">
-                        The following information is needed for us to set up your Octopus account and communicate with
-                        you as an Octopus user:
-                    </p>
-                    <ul className="mb-4 ml-6 list-disc">
-                        <li>Name (via ORCID®)</li>
-                        <li>Affiliation (via ORCID)</li> <li>Current email address</li>
-                    </ul>
-                    <p className="mb-4">
-                        Octopus accounts must be linked to an{' '}
-                        <Components.Link
-                            openNew
-                            className="rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
-                            href="https://orcid.org/"
-                        >
-                            <span>ORCID account.</span>
-                        </Components.Link>{' '}
-                        When you create an account on this service you are granting Octopus:
-                    </p>
-                    <ul className="mb-4 ml-6 list-disc">
-                        <li>
-                            Access to your public ORCID information, such as name, affiliation(s), and publications.
-                        </li>
-                        <li>Permission to display this public information on your Octopus user account </li>
-                        <li>
-                            Permission to update your ORCID public information to display any publications created on
-                            Octopus
-                        </li>
-                    </ul>
-                    <p className="mb-4">
-                        As well as data from ORCID, all user activity (such as submitted content, red flags, and related
-                        publications), is stored by Jisc and will be displayed on your public user profile.
-                    </p>
-                    <p className="mb-4">
-                        Further data protection particulars are detailed in the{' '}
-                        <Components.Link
-                            openNew
-                            className="rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
-                            href={Config.urls.userTerms.path}
-                        >
-                            platform T&Cs
-                        </Components.Link>
-                    </p>
-                </section>
+                <Components.PageTitle text="Privacy" />
+                <p className="mb-4">
+                    The following information is needed for us to register your user account in Octopus. We’ll use it,
+                    as described in our standard privacy notice (at{' '}
+                    <Components.Link
+                        openNew
+                        className="rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
+                        href="https://www.jisc.ac.uk/website/privacy-notice"
+                    >
+                        <span>https://www.jisc.ac.uk/website/privacy-notice</span>
+                    </Components.Link>
+                    ), to provide the service you’ve requested, as well as to identify problems or ways to make the
+                    service better.
+                </p>
+                <p className="mb-4">
+                    We&apos;ll keep the information until we are told that you no longer wish to hold an account. If you
+                    wish to delete your Octopus user account, you can email{' '}
+                    <Components.Link
+                        openNew
+                        className="rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
+                        href="mailto:help@jisc.ac.uk"
+                    >
+                        <span>help@jisc.ac.uk </span>
+                    </Components.Link>
+                    and we will remove your individual account and personal information. However, please note that
+                    unless otherwise agreed we would not as standard delete any publications affiliated with this
+                    account.
+                </p>
+                <h2 className="mb-1 mt-10 text-xl font-medium">User accounts</h2>
+                <p className="mb-4">
+                    The following information is needed for us to set up your Octopus account and communicate with you
+                    as an Octopus user:
+                </p>
+                <ul className="mb-4 ml-6 list-disc">
+                    <li>Name (via ORCID®)</li>
+                    <li>Affiliation (via ORCID)</li> <li>Current email address</li>
+                </ul>
+                <p className="mb-4">
+                    Octopus accounts must be linked to an{' '}
+                    <Components.Link
+                        openNew
+                        className="rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
+                        href="https://orcid.org/"
+                    >
+                        <span>ORCID account.</span>
+                    </Components.Link>{' '}
+                    When you create an account on this service you are granting Octopus:
+                </p>
+                <ul className="mb-4 ml-6 list-disc">
+                    <li>Access to your public ORCID information, such as name, affiliation(s), and publications.</li>
+                    <li>Permission to display this public information on your Octopus user account </li>
+                    <li>
+                        Permission to update your ORCID public information to display any publications created on
+                        Octopus
+                    </li>
+                </ul>
+                <p className="mb-4">
+                    As well as data from ORCID, all user activity (such as submitted content, red flags, and related
+                    publications), is stored by Jisc and will be displayed on your public user profile.
+                </p>
+                <p className="mb-4">
+                    Further data protection particulars are detailed in the{' '}
+                    <Components.Link
+                        openNew
+                        className="rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
+                        href={Config.urls.userTerms.path}
+                    >
+                        platform T&Cs
+                    </Components.Link>
+                </p>
             </Layouts.Information>
         </>
     );

--- a/ui/src/pages/terms.tsx
+++ b/ui/src/pages/terms.tsx
@@ -18,19 +18,17 @@ const Terms: Types.NextPage = (): React.ReactElement => {
             </Head>
 
             <Layouts.Information>
-                <section className="mx-auto mb-10 grid grid-cols-1 gap-4 text-grey-900 transition-colors duration-500 dark:text-white-50 lg:w-8/12">
-                    <Components.PageTitle text="Terms" />
-                    <h2 className="text-xl font-medium">Licence</h2>
-                    <p className="mb-4">This project code is licensed under the GNU General Public Licence v3.0.</p>
-                    <p>The full text of the licence can be found here:</p>
-                    <Components.Link
-                        className="mb-4 w-fit rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
-                        openNew
-                        href="https://www.gnu.org/licenses/gpl-3.0.en.html"
-                    >
-                        <span>https://www.gnu.org/licenses/gpl-3.0.en.html</span>
-                    </Components.Link>
-                </section>
+                <Components.PageTitle text="Terms" />
+                <h2 className="text-xl font-medium">Licence</h2>
+                <p className="mb-4">This project code is licensed under the GNU General Public Licence v3.0.</p>
+                <p>The full text of the licence can be found here:</p>
+                <Components.Link
+                    className="mb-4 w-fit rounded underline decoration-teal-500 underline-offset-2 outline-0 focus:ring-2 focus:ring-yellow-400"
+                    openNew
+                    href="https://www.gnu.org/licenses/gpl-3.0.en.html"
+                >
+                    <span>https://www.gnu.org/licenses/gpl-3.0.en.html</span>
+                </Components.Link>
             </Layouts.Information>
         </>
     );


### PR DESCRIPTION
The purpose of this PR was to add a cookie policy page that explains the cookies in place on Octopus.

This is the same as #763 but without the banner that directs users to this page, as I've been advised that we may not need the banner. However, it would be good to get this page merged in either way.

Most of the changes other than the cookie policy page itself are correcting `space-nowrap` to `whitespace-nowrap`, or moving a section element that was common to multiple pages into the layout file that they were all using.

---

### Acceptance Criteria:

- A Cookie Policy page is present on the site (copy attached to jira ticket).
    - A link to this policy is present below the “Accessibility” link in Octopus' footer

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI/E2E passed as per #763 
