### PR TITLE
OC-647: Image upload opens two dialogs

### DIFF
--- a/ui/src/components/FileUpload/index.tsx
+++ b/ui/src/components/FileUpload/index.tsx
@@ -25,7 +25,7 @@ const FileUpload: React.FC<Props> = (props): React.ReactElement => {
         }
     }, []);
 
-    const { getRootProps, getInputProps, isDragActive } = DropZone.useDropzone({ onDrop });
+    const { getRootProps, getInputProps, isDragActive } = DropZone.useDropzone({ noClick: true, onDrop });
 
     return (
         <section className="relative">


### PR DESCRIPTION
The purpose of this PR was to fix an issue where clicking in the file upload area opens 2 file explorer windows rather than one. This was a simple fix outlined in the [readme](https://github.com/react-dropzone/react-dropzone?tab=readme-ov-file#using-label-as-root) of the library we use for this file dropzone.

---

### Acceptance Criteria:

- The file upload area only opens one file explorer window.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
![Screenshot 2025-02-13 103637](https://github.com/user-attachments/assets/ce0219d8-566c-4dac-b222-528c8bdeb44f)

E2E
![Screenshot 2025-02-13 103616](https://github.com/user-attachments/assets/45768df0-3def-49fa-bfc1-b606b36cdaff)

