### PR TITLE
OC-1008: Change date format on search to dd/mmm/yyyy

### DIFF
--- a/ui/src/__tests__/components/Publication/RelatedPublications/Result.test.tsx
+++ b/ui/src/__tests__/components/Publication/RelatedPublications/Result.test.tsx
@@ -26,7 +26,7 @@ describe('Related publication result', () => {
     it('Author attribution is shown', () => {
         expect(
             screen.getByText(
-                `By ${Helpers.abbreviateUserName(crosslink.linkedPublication.latestLiveVersion.user)} | ${Helpers.relativeDate(crosslink.linkedPublication.latestLiveVersion.publishedDate)}`
+                `By ${Helpers.abbreviateUserName(crosslink.linkedPublication.latestLiveVersion.user)} | ${Helpers.formatDate(crosslink.linkedPublication.latestLiveVersion.publishedDate)}`
             )
         ).toBeInTheDocument();
     });

--- a/ui/src/__tests__/components/Publication/SearchResult.test.tsx
+++ b/ui/src/__tests__/components/Publication/SearchResult.test.tsx
@@ -51,7 +51,7 @@ describe('Publication search result', () => {
 
     it('Shows pubished date with author list', () => {
         expect(
-            screen.getByText(`Published ${Helpers.relativeDate(publishedDate)}, by E. User, A. One`)
+            screen.getByText(`Published ${Helpers.formatDate(publishedDate)}, by E. User, A. One`)
         ).toBeInTheDocument();
     });
 });

--- a/ui/src/components/Publication/RelatedPublications/Result/index.tsx
+++ b/ui/src/components/Publication/RelatedPublications/Result/index.tsx
@@ -80,7 +80,7 @@ const RelatedPublicationsResult: React.FC<Props> = (props): React.ReactElement =
                     className="block overflow-hidden text-ellipsis whitespace-nowrap text-xs tracking-wide text-grey-800 transition-colors duration-500 dark:text-grey-100"
                     title={authorNames}
                 >
-                    By {authorNames} | {Helpers.relativeDate(publicationVersion.publishedDate)}
+                    By {authorNames} | {Helpers.formatDate(publicationVersion.publishedDate)}
                 </span>
                 <span className="flex">
                     <Components.Link

--- a/ui/src/components/Publication/RelatedPublications/SuggestModal/index.tsx
+++ b/ui/src/components/Publication/RelatedPublications/SuggestModal/index.tsx
@@ -187,7 +187,7 @@ const RelatedPublicationsSuggestModal: React.FC<Props> = (props): React.ReactEle
                                                     title={authorNames}
                                                 >
                                                     By {authorNames} |{' '}
-                                                    {Helpers.relativeDate(publicationVersion.publishedDate || '')}
+                                                    {Helpers.formatDate(publicationVersion.publishedDate || '')}
                                                 </span>
                                             </div>
                                         </HeadlessUI.Combobox.Option>
@@ -212,7 +212,7 @@ const RelatedPublicationsSuggestModal: React.FC<Props> = (props): React.ReactEle
                                 title={selectedPublicationVersionAuthorNames}
                             >
                                 By {selectedPublicationVersionAuthorNames} |{' '}
-                                {Helpers.relativeDate(selectedPublicationVersion.publishedDate || '')}
+                                {Helpers.formatDate(selectedPublicationVersion.publishedDate || '')}
                             </span>
                         </div>
                         <Components.Button

--- a/ui/src/components/Publication/SearchResult/index.tsx
+++ b/ui/src/components/Publication/SearchResult/index.tsx
@@ -54,7 +54,7 @@ const SearchResult: React.FC<Props<GenericCoAuthor>> = (props): React.ReactEleme
                     className="overflow-hidden text-ellipsis whitespace-nowrap text-xs tracking-wide text-grey-800 transition-colors duration-500 dark:text-grey-100"
                     title={authors}
                 >
-                    {props.publishedDate ? `Published ${Helpers.relativeDate(props.publishedDate)}` : 'Draft'}, by{' '}
+                    {props.publishedDate ? `Published ${Helpers.formatDate(props.publishedDate)}` : 'Draft'}, by{' '}
                     {authors}
                 </p>
                 <Components.EngagementCounts flagCount={props.flagCount} peerReviewCount={props.peerReviewCount} />

--- a/ui/src/lib/helpers.tsx
+++ b/ui/src/lib/helpers.tsx
@@ -52,15 +52,6 @@ export const formatDateTime = (value: string, formatType?: 'short' | 'long'): st
 };
 
 /**
- * @description Formats a ISO string date to a relative to now string
- */
-export const relativeDate = (value: string): string | null => {
-    const date = luxon.DateTime.fromISO(value, { zone: 'utc' }).toRelativeCalendar();
-
-    return date === 'Invalid DateTime' ? 'N/A' : date;
-};
-
-/**
  * @description Format a publication type returned from the DB
  */
 export const formatPublicationType = (publicationType: Types.PublicationType): string => {


### PR DESCRIPTION
The purpose of this PR was to convert the formatting of dates from relative (e.g. "yesterday", "last year") to the specific dates (e.g. 13th Feb 2025). The relative dates could make the site seem inactive as in some cases, "last month" may be yesterday; "last year" may be a month ago, etc.

---

### Acceptance Criteria:

- Results on the publication search include the publication date in a DD MMM YYYY format (e.g. 20 January 2025)
- Publications on the author pages include the publication date in a DD MMM YYYY format (e.g. 20 January 2025)

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
![Screenshot 2025-02-13 133823](https://github.com/user-attachments/assets/502e5681-c16b-4f58-b0aa-313477dd91de)

E2E
![Screenshot 2025-02-13 143540](https://github.com/user-attachments/assets/3c4a3620-9e73-4234-80e7-1eb0fc824a30)

---

### Screenshots:

![Screenshot 2025-02-13 144104](https://github.com/user-attachments/assets/1c7dc26b-cb7a-4ba0-a6fb-f04b98679262)
