### PR TITLE
OC-1000: Make formatting options in text editor follow user's view

### DIFF
--- a/ui/src/components/TextEditor/index.tsx
+++ b/ui/src/components/TextEditor/index.tsx
@@ -301,9 +301,9 @@ const MenuBar: React.FC<MenuBarProps> = (props) => {
     return (
         props.editor && (
             <>
-                <div className="flex">
+                <div className="flex sticky top-0 w-full pt-2 bg-white-50 z-10 border-b-2 border-grey-300">
                     <HeadlessUi.Listbox value={selected} onChange={setSelected}>
-                        <div className="relative mt-1">
+                        <div className="relative my-1">
                             <HeadlessUi.Listbox.Button className="relative w-full cursor-default rounded-lg py-2 pl-3 pr-10 text-left hover:cursor-pointer hover:bg-grey-100 focus:outline-yellow-500 sm:text-sm">
                                 <span className="block truncate">{selected.name}</span>
                                 <span className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
@@ -346,7 +346,7 @@ const MenuBar: React.FC<MenuBarProps> = (props) => {
                         </div>
                     </HeadlessUi.Listbox>
 
-                    <div className="flex max-w-full items-center overflow-x-auto lg:max-w-md xl:max-w-xl 2xl:max-w-full">
+                    <div className="flex max-w-full items-center overflow-x-auto">
                         <span className="mx-2 inline-block h-6 w-[1px] bg-grey-300" />
                         <button
                             type="button"
@@ -744,7 +744,7 @@ const TextEditor: React.FC<TextEditorProps> = (props) => {
                 <span>Import from Microsoft Word (.docx)</span>
             </button>
 
-            <div className="mb-4 rounded-md border border-grey-100 bg-white-50 px-4 pb-4 pt-2 shadow focus-within:ring-2 focus-within:ring-yellow-500">
+            <div className="mb-4 rounded-md border border-grey-100 bg-white-50 shadow focus-within:ring-2 focus-within:ring-yellow-500">
                 <MenuBar
                     editor={textEditor}
                     loading={loading}
@@ -752,8 +752,9 @@ const TextEditor: React.FC<TextEditorProps> = (props) => {
                     importModalVisible={importModalVisible}
                     setImportModalVisible={setImportModalVisible}
                 />
-
-                <tiptap.EditorContent editor={textEditor} />
+                <div className="px-4 pb-2">
+                    <tiptap.EditorContent editor={textEditor} />
+                </div>
             </div>
         </>
     ) : null;


### PR DESCRIPTION
As a corresponding author, I shouldn’t need to scroll back to the top of the text editor when filling out a long main-text entry. I should be able to access formatting options at all times.

---

### Acceptance Criteria:

- On the main text field, the formatting options for the text editor follow the user’s view, remaining in the text editor at the top of the user’s window if they scrolls below the top of the text editor. 

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
![Screenshot 2025-02-14 114037](https://github.com/user-attachments/assets/a26f0cd0-d042-489a-8c2f-af681bd83725)

E2E
![Screenshot 2025-02-14 113929](https://github.com/user-attachments/assets/122ce90f-43ef-4de9-b887-28e2a582ee25)

---

### Screenshots:

![Screenshot 2025-02-14 114353](https://github.com/user-attachments/assets/cfad73c8-0309-4c71-9679-17ce82f67dab)
