### PR TITLE
OC-1012: Generic banner function

### DIFF
--- a/ui/src/__tests__/components/AnnouncementBanner.test.tsx
+++ b/ui/src/__tests__/components/AnnouncementBanner.test.tsx
@@ -1,0 +1,12 @@
+import * as Components from '@/components';
+import { render, screen } from '@testing-library/react';
+
+describe('Announcement banner', () => {
+    beforeEach(() => {
+        render(<Components.AnnouncementBanner>Placholder message</Components.AnnouncementBanner>);
+    });
+    it('Contains dismiss button', () => {
+        expect(screen.getByRole('button')).toHaveTextContent('Dismiss');
+        // TODO: can't work out how to mock zustand and check that the toggle function from the preferencesStore is called when this button is clicked.
+    });
+});

--- a/ui/src/components/AnnouncementBanner/index.tsx
+++ b/ui/src/components/AnnouncementBanner/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import * as Components from '@/components';
+import * as Stores from '@/stores';
+
+type Props = { children: React.ReactNode };
+
+const AnnouncementBanner: React.FC<Props> = (props: Props): React.ReactElement => {
+    const { showAnnouncementBanner, toggleAnnouncementBanner } = Stores.usePreferencesStore();
+    return showAnnouncementBanner ? (
+        <div className="fixed bottom-0 w-full">
+            <Components.Banner>
+                <span className="flex font-montserrat items-center gap-4 p-2">
+                    <span className="w-full">{props.children}</span>
+                    <div className="flex">
+                        <Components.Button variant="underlined" onClick={toggleAnnouncementBanner} title="Dismiss" />
+                    </div>
+                </span>
+            </Components.Banner>
+        </div>
+    ) : (
+        <></>
+    );
+};
+
+export default AnnouncementBanner;

--- a/ui/src/components/Footer/index.tsx
+++ b/ui/src/components/Footer/index.tsx
@@ -25,7 +25,7 @@ const Footer: React.FC<Props> = (props: Props): React.ReactElement => (
                 bottom="fill-teal-700 dark:fill-grey-800"
             />
         )}
-        <footer className="relative bg-teal-700 py-28 transition-all duration-500 dark:bg-grey-800 print:hidden">
+        <footer className="bg-teal-700 py-28 transition-all duration-500 dark:bg-grey-800 print:hidden">
             <div className="container mx-auto grid grid-cols-1 gap-8 px-8 md:grid-cols-4">
                 {/** Title and social icons */}
                 <h2 className="col-span-1 block font-montserrat text-4xl font-bold text-white-50 lg:mb-12">Octopus</h2>

--- a/ui/src/components/Header/index.tsx
+++ b/ui/src/components/Header/index.tsx
@@ -24,18 +24,24 @@ const Header: React.FC<Props> = (props): React.ReactElement => {
     return (
         <>
             <Components.Banner>
-                Help us improve by providing{' '}
-                <Components.Link
-                    href="https://forms.office.com/e/80g02emciH"
-                    className="w-fit underline  underline-offset-4"
-                    openNew
-                >
-                    feedback
-                </Components.Link>{' '}
-                or contacting{' '}
-                <Components.Link href="mailto:help@jisc.ac.uk" openNew className="w-fit underline  underline-offset-4">
-                    help@jisc.ac.uk
-                </Components.Link>
+                <span className="font-montserrat">
+                    Help us improve by providing{' '}
+                    <Components.Link
+                        href="https://forms.office.com/e/80g02emciH"
+                        className="w-fit underline  underline-offset-4"
+                        openNew
+                    >
+                        feedback
+                    </Components.Link>{' '}
+                    or contacting{' '}
+                    <Components.Link
+                        href="mailto:help@jisc.ac.uk"
+                        openNew
+                        className="w-fit underline  underline-offset-4"
+                    >
+                        help@jisc.ac.uk
+                    </Components.Link>
+                </span>
             </Components.Banner>
             {/* Missing info banner */}
             {(showConfirmEmailBanner || showMissingNamesBanner) && (

--- a/ui/src/components/ScrollToTop/index.tsx
+++ b/ui/src/components/ScrollToTop/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import * as SolidIcons from '@heroicons/react/24/solid';
 import * as Framer from 'framer-motion';
 import * as Helpers from '@/helpers';
+import * as Stores from '@/stores';
 
 const getButtonVisibility = () =>
     document.documentElement.scrollTop > 0 &&
@@ -11,6 +12,7 @@ const getButtonVisibility = () =>
 
 const ScrollToTop: React.FC = (): React.ReactElement => {
     const [visible, setVisible] = React.useState(getButtonVisibility());
+    const { showAnnouncementBanner } = Stores.usePreferencesStore();
 
     React.useEffect(() => {
         const handleScroll = () => {
@@ -33,7 +35,7 @@ const ScrollToTop: React.FC = (): React.ReactElement => {
             whileInView={{ scale: visible ? 1 : 0, type: 'spring' }}
             transition={{ duration: 0.3 }}
             type="button"
-            className="fixed bottom-24 right-4 z-20 h-fit rounded-full border-transparent outline-0 focus:ring-2 focus:ring-yellow-400 print:hidden lg:bottom-12 lg:right-12"
+            className={`fixed bottom-24 right-4 z-20 h-fit rounded-full border-transparent outline-0 focus:ring-2 focus:ring-yellow-400 print:hidden ${showAnnouncementBanner ? '' : 'lg:bottom-12 lg:right-12'}`}
             onClick={Helpers.scrollTopSmooth}
         >
             <SolidIcons.ArrowUpCircleIcon className="h-14 w-14 text-teal-300" />

--- a/ui/src/components/index.tsx
+++ b/ui/src/components/index.tsx
@@ -6,6 +6,7 @@ export { default as AdditionalInformationTable } from './Publication/Creation/Ad
 export { default as AddReferences } from './References/AddReferences';
 export { default as AffiliationCard } from './Publication/AffiliationCard';
 export { default as Alert } from './Alert';
+export { default as AnnouncementBanner } from './AnnouncementBanner';
 export { default as ApprovalsTracker } from './ApprovalsTracker';
 export { default as AuthorAffiliations } from './Publication/AuthorAffiliations';
 export { default as AuthorList } from './Publication/AuthorList';

--- a/ui/src/config/keys.ts
+++ b/ui/src/config/keys.ts
@@ -2,7 +2,7 @@ const prefix = `${process.env.NODE_ENV}-octopus`;
 
 const keys = {
     localStorage: {
-        darkMode: `${prefix}-dark-mode`,
+        preferences: `${prefix}-preferences`,
         token: `${prefix}-token`,
         user: `${prefix}-user`
     },

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -16,8 +16,8 @@ export type { AxiosError } from 'axios';
 export type PreferencesStoreTypes = {
     darkMode: boolean;
     toggleDarkMode: () => void;
-    feedback: boolean;
-    toggleFeedback: () => void;
+    showAnnouncementBanner: boolean;
+    toggleAnnouncementBanner: () => void;
 };
 
 export type UserRole = 'USER' | 'ORGANISATION' | 'SUPER_USER';

--- a/ui/src/pages/_app.tsx
+++ b/ui/src/pages/_app.tsx
@@ -20,7 +20,6 @@ type CustomProps = {
 };
 
 const App = ({ Component, pageProps }: Types.AppProps<CustomProps>) => {
-    const { user } = Stores.useAuthStore();
     const { darkMode } = Stores.usePreferencesStore();
 
     // check authentication client side
@@ -75,6 +74,10 @@ const App = ({ Component, pageProps }: Types.AppProps<CustomProps>) => {
                     <div className={darkMode ? 'dark' : ''}>
                         <div className="bg-teal-50 transition-colors duration-500 dark:bg-grey-800">
                             <Components.Toast />
+                            {/* Uncomment to show announcement banner at the bottom of all pages.
+                            <Components.AnnouncementBanner>
+                                Announcement placeholder
+                            </Components.AnnouncementBanner> */}
                             <Component {...pageProps} />
                         </div>
                     </div>

--- a/ui/src/stores/preferences.ts
+++ b/ui/src/stores/preferences.ts
@@ -10,11 +10,12 @@ const usePreferencesStore = create<Types.PreferencesStoreTypes>()(
             (set) => ({
                 darkMode: true,
                 toggleDarkMode: () => set((state) => ({ darkMode: !state.darkMode })),
-                feedback: true,
-                toggleFeedback: () => set((state) => ({ feedback: !state.feedback }))
+                showAnnouncementBanner: true,
+                toggleAnnouncementBanner: () =>
+                    set((state) => ({ showAnnouncementBanner: !state.showAnnouncementBanner }))
             }),
             {
-                name: Config.keys.localStorage.darkMode,
+                name: Config.keys.localStorage.preferences,
                 skipHydration: true
             }
         )


### PR DESCRIPTION
The purpose of this PR was to add a generic banner for announcements on the site, such as new features, scheduled maintenance and (possibly) cookies consent.

---

### Acceptance Criteria:

- A banner can be made visible on Octopus including custom text, with a dismiss option that hides the banner until it is either removed and re-added, or its contents are changed

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
![Screenshot 2025-02-17 135703](https://github.com/user-attachments/assets/05cfbac2-7207-4996-ab26-29fc5f078342)

E2E
![Screenshot 2025-02-17 145630](https://github.com/user-attachments/assets/7d09630e-2442-4eef-93d5-c4a2c1f53024)

---

### Screenshots:

<img width="939" alt="Screenshot 2025-02-17 150133" src="https://github.com/user-attachments/assets/be8fa130-febc-4cb6-8fc7-7bc0d7a26e85" />
