### PR TITLE
OC-798: A11Y Mark publication text using selected language 

### DIFF
--- a/api/src/components/pdf/service.ts
+++ b/api/src/components/pdf/service.ts
@@ -50,6 +50,9 @@ const createPublicationHTMLTemplate = (
     // parsing the publication content can sometimes help with unpaired opening/closing tags
     const mainText = content ? cheerio.load(content).html() : '';
 
+    // For setting lang attribute on HTML
+    const languageIfNotEnglish = language !== 'en' ? language : undefined;
+
     const authors = coAuthors.filter((author) => Boolean(author.confirmedCoAuthor && author.linkedUser));
 
     // If corresponding author is not found in coauthors list, and we have the necessary fields, mock them up
@@ -306,7 +309,7 @@ const createPublicationHTMLTemplate = (
                 </style>
             </head>
             <body>
-            <h1 id="title">${title}</h1>
+            <h1 id="title" lang=${languageIfNotEnglish}>${title}</h1>
                 <p class="metadata">
                     <strong>Authors:</strong> ${authorsWithAffiliationNumbers
                         .map(
@@ -344,7 +347,7 @@ const createPublicationHTMLTemplate = (
                     </a>
                 </p>
     
-                <div id="main-text">
+                <div id="main-text" lang=${languageIfNotEnglish}>
                     ${mainText}
                 </div>
     
@@ -357,10 +360,12 @@ const createPublicationHTMLTemplate = (
                             .map(
                                 (additionalInfoEntry) =>
                                     `<li>
-                                        <h3 class="section-subtitle"><b>${additionalInfoEntry.title}</b></h3>
+                                        <h3 class="section-subtitle" lang=${languageIfNotEnglish}><b>${
+                                        additionalInfoEntry.title
+                                    }</b></h3>
                                         ${
                                             additionalInfoEntry.description &&
-                                            `<p>${additionalInfoEntry.description}</p>`
+                                            `<p lang=${languageIfNotEnglish}>${additionalInfoEntry.description}</p>`
                                         }
                                         <p><a href="${additionalInfoEntry.url}" aria-label="${
                                         additionalInfoEntry.title
@@ -446,8 +451,12 @@ const createPublicationHTMLTemplate = (
                     ethicalStatement
                         ? ` <div class="section">
                                 <h2 class="section-title">Ethical statement</h2>
-                                <p>${ethicalStatement}</p>
-                                ${ethicalStatementFreeText ? `<p>${ethicalStatementFreeText}</p>` : ''}
+                                <p lang=${languageIfNotEnglish}>${ethicalStatement}</p>
+                                ${
+                                    ethicalStatementFreeText
+                                        ? `<p lang=${languageIfNotEnglish}>${ethicalStatementFreeText}</p>`
+                                        : ''
+                                }
                             </div>`
                         : ''
                 }
@@ -456,7 +465,7 @@ const createPublicationHTMLTemplate = (
                     dataPermissionsStatement
                         ? ` <div class="section">
                                 <h2 class="section-title">Data permissions statement</h2>
-                                <p>${dataPermissionsStatement}</p>
+                                <p lang=${languageIfNotEnglish}>${dataPermissionsStatement}</p>
                                 ${
                                     dataPermissionsStatementProvidedBy
                                         ? `<p>${dataPermissionsStatementProvidedBy}</p>`
@@ -470,7 +479,7 @@ const createPublicationHTMLTemplate = (
                     dataAccessStatement
                         ? ` <div class="section">
                                 <h2 class="section-title">Data access statement</h2>
-                                <p>${dataAccessStatement}</p>
+                                <p lang=${languageIfNotEnglish}>${dataAccessStatement}</p>
                             </div>`
                         : ''
                 }
@@ -497,7 +506,7 @@ const createPublicationHTMLTemplate = (
                     <h2 class="section-title">Conflict of interest</h2>
                     ${
                         conflictOfInterestText
-                            ? `<p>${conflictOfInterestText}</p>`
+                            ? `<p lang=${languageIfNotEnglish}>${conflictOfInterestText}</p>`
                             : '<p>This publication does not have any specified conflicts of interest.</p>'
                     }
                 </div>   

--- a/ui/src/__tests__/components/AdditionalInformationCard.test.tsx
+++ b/ui/src/__tests__/components/AdditionalInformationCard.test.tsx
@@ -1,0 +1,37 @@
+import * as Components from '@/components';
+
+import { render, screen } from '@testing-library/react';
+
+describe('Additional Information Card', () => {
+    beforeEach(() => {
+        render(
+            <Components.AdditionalInformationCard
+                additionalInformation={{
+                    title: 'Some data somewhere else',
+                    url: 'https://example.com',
+                    description: 'This data clarifies part of the publication'
+                }}
+                publicationLanguage="fr"
+            />
+        );
+    });
+
+    it('Displays title', () => {
+        expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('Some data somewhere else');
+    });
+
+    it('Displays description', () => {
+        expect(screen.getByText('This data clarifies part of the publication')).toBeInTheDocument();
+    });
+
+    it('Displays link to url', () => {
+        expect(screen.getByRole('link', { name: 'Some data somewhere else' })).toHaveAttribute(
+            'href',
+            'https://example.com'
+        );
+    });
+
+    it('Marked up with language', () => {
+        expect(screen.getByTestId('additional-information-card')).toHaveAttribute('lang', 'fr');
+    });
+});

--- a/ui/src/components/AdditionalInformationCard/index.tsx
+++ b/ui/src/components/AdditionalInformationCard/index.tsx
@@ -1,34 +1,46 @@
 import React from 'react';
 
+import * as Helpers from '@/helpers';
+import * as Types from '@/types';
+
 type Props = {
     additionalInformation: {
         title: string;
         url: string;
         description?: string;
     };
+    publicationLanguage?: Types.Languages;
 };
 
 const AdditionalInformationCard: React.FC<Props> = ({
-    additionalInformation: { title, url, description }
-}): React.ReactElement => (
-    <section className="w-full space-y-4 rounded bg-white-50 px-6 py-6 shadow transition-colors duration-500 dark:bg-grey-700">
-        <h3 className="font-montserrat font-bold text-grey-800 transition-colors duration-500 dark:text-white-100">
-            {title}
-        </h3>
-        {description && (
-            <p className="leading-relaxed text-grey-800 transition-colors duration-500 dark:text-grey-100">
-                {description}
-            </p>
-        )}
-        <a
-            href={url}
-            title={title}
-            aria-label={title}
-            className="block text-sm font-semibold text-teal-600 underline transition-colors duration-500 dark:text-teal-300"
+    additionalInformation: { title, url, description },
+    publicationLanguage: language
+}): React.ReactElement => {
+    const languageIfNotEnglish = language ? Helpers.languageIfNotEnglish(language) : undefined;
+    return (
+        <section
+            lang={languageIfNotEnglish}
+            className="w-full space-y-4 rounded bg-white-50 px-6 py-6 shadow transition-colors duration-500 dark:bg-grey-700"
+            data-testid="additional-information-card"
         >
-            {url}
-        </a>
-    </section>
-);
+            <h3 className="font-montserrat font-bold text-grey-800 transition-colors duration-500 dark:text-white-100">
+                {title}
+            </h3>
+            {description && (
+                <p className="leading-relaxed text-grey-800 transition-colors duration-500 dark:text-grey-100">
+                    {description}
+                </p>
+            )}
+            <a
+                href={url}
+                title={title}
+                aria-label={title}
+                className="block text-sm font-semibold text-teal-600 underline transition-colors duration-500 dark:text-teal-300"
+            >
+                {url}
+            </a>
+        </section>
+    );
+};
 
 export default AdditionalInformationCard;

--- a/ui/src/lib/helpers.tsx
+++ b/ui/src/lib/helpers.tsx
@@ -660,3 +660,9 @@ export const extractNextQueryParam = (param: string | string[] | undefined, chec
         return rawValue;
     }
 };
+
+// Return a language value if it is not english, otherwise undefined.
+// Useful for setting the HTML lang attribute - if it's underfined it won't be added.
+export const languageIfNotEnglish = (language: Types.Languages): Types.Languages | undefined => {
+    return language !== 'en' ? language : undefined;
+};

--- a/ui/src/pages/publications/[id]/versions/[versionId].tsx
+++ b/ui/src/pages/publications/[id]/versions/[versionId].tsx
@@ -286,6 +286,11 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
         { title: 'Conflict of interest', href: 'coi' }
     ];
 
+    const languageIfNotEnglish = React.useMemo(
+        () => (publicationVersion?.language ? Helpers.languageIfNotEnglish(publicationVersion.language) : undefined),
+        [publicationVersion?.language]
+    );
+
     const currentCoAuthor = React.useMemo(
         () => publicationVersion?.coAuthors?.find((coAuthor) => coAuthor.linkedUser === user?.id),
         [publicationVersion, user?.id]
@@ -652,11 +657,23 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
     return publication && publicationVersion ? (
         <>
             <Head>
-                <title>{pageTitle}</title>
-                <meta name="description" content={props.publicationVersion.description || ''} />
-                <meta name="og:title" content={Helpers.truncateString(pageTitle, 70)} />
-                <meta name="og:description" content={Helpers.truncateString(contentText, 200)} />
-                <meta name="keywords" content={props.publicationVersion.keywords?.join(', ') || ''} />
+                <title lang={languageIfNotEnglish}>{pageTitle}</title>
+                <meta
+                    name="description"
+                    lang={languageIfNotEnglish}
+                    content={props.publicationVersion.description || ''}
+                />
+                <meta name="og:title" lang={languageIfNotEnglish} content={Helpers.truncateString(pageTitle, 70)} />
+                <meta
+                    name="og:description"
+                    lang={languageIfNotEnglish}
+                    content={Helpers.truncateString(contentText, 200)}
+                />
+                <meta
+                    name="keywords"
+                    lang={languageIfNotEnglish}
+                    content={props.publicationVersion.keywords?.join(', ') || ''}
+                />
                 <link
                     rel="canonical"
                     href={`${Config.urls.viewPublication.canonical}/${props.publicationVersion.versionOf}`}
@@ -751,7 +768,10 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                                     publicationType={publication.type}
                                 />
                             )}
-                            <h1 className="col-span-7 mb-4 block font-montserrat text-2xl font-bold leading-tight text-grey-800 transition-colors duration-500 dark:text-white-50 md:text-3xl xl:text-3xl xl:leading-normal">
+                            <h1
+                                lang={languageIfNotEnglish}
+                                className="col-span-7 mb-4 block font-montserrat text-2xl font-bold leading-tight text-grey-800 transition-colors duration-500 dark:text-white-50 md:text-3xl xl:text-3xl xl:leading-normal"
+                            >
                                 {publicationVersion.title}
                             </h1>
                             {isBookmarkButtonVisible && (
@@ -822,7 +842,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
 
                     {/** Full text */}
                     <Components.ContentSection id="main-text" hasBreak isMainText>
-                        <div>
+                        <div lang={languageIfNotEnglish}>
                             <Components.ParseHTML content={publicationVersion.content ?? ''} />
                         </div>
                     </Components.ContentSection>
@@ -839,6 +859,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                                     <Components.AdditionalInformationCard
                                         key={additionalInfoEntry.id}
                                         additionalInformation={additionalInfoEntry}
+                                        publicationLanguage={languageIfNotEnglish}
                                     />
                                 ))}
                             </div>
@@ -849,7 +870,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                     {showReferences && (
                         <Components.ContentSection id="references" title="References" hasBreak>
                             {references.map((reference) => (
-                                <div key={reference.id} className="py-2 break-anywhere">
+                                <div lang={languageIfNotEnglish} key={reference.id} className="py-2 break-anywhere">
                                     <Components.ParseHTML content={reference.text} />
                                     {reference.location && (
                                         <div className="break-all underline dark:text-white-50">
@@ -953,11 +974,17 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                     {showEthicalStatement && (
                         <Components.ContentSection id="ethical-statement" title="Ethical statement" hasBreak>
                             <>
-                                <p className="block text-grey-800 transition-colors duration-500 dark:text-white-50">
+                                <p
+                                    lang={languageIfNotEnglish}
+                                    className="block text-grey-800 transition-colors duration-500 dark:text-white-50"
+                                >
                                     {publicationVersion.ethicalStatement && parse(publicationVersion.ethicalStatement)}
                                 </p>
                                 {!!publicationVersion.ethicalStatementFreeText && (
-                                    <p className="mt-4 block text-sm text-grey-700 transition-colors duration-500 dark:text-white-100">
+                                    <p
+                                        lang={languageIfNotEnglish}
+                                        className="mt-4 block text-sm text-grey-700 transition-colors duration-500 dark:text-white-100"
+                                    >
                                         {parse(publicationVersion.ethicalStatementFreeText)}
                                     </p>
                                 )}
@@ -973,11 +1000,17 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                             hasBreak
                         >
                             <>
-                                <p className="mb-2 block text-grey-800 transition-colors duration-500 dark:text-white-50">
+                                <p
+                                    lang={languageIfNotEnglish}
+                                    className="mb-2 block text-grey-800 transition-colors duration-500 dark:text-white-50"
+                                >
                                     {parse(publicationVersion.dataPermissionsStatement)}
                                 </p>
                                 {publicationVersion.dataPermissionsStatementProvidedBy?.length && (
-                                    <p className="mt-4 block text-sm text-grey-700 transition-colors duration-500 dark:text-white-100">
+                                    <p
+                                        lang={languageIfNotEnglish}
+                                        className="mt-4 block text-sm text-grey-700 transition-colors duration-500 dark:text-white-100"
+                                    >
                                         {parse(publicationVersion.dataPermissionsStatementProvidedBy)}
                                     </p>
                                 )}
@@ -988,7 +1021,10 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                     {/* Data access statement */}
                     {!!publicationVersion.dataAccessStatement && (
                         <Components.ContentSection id="data-access-statement" title="Data access statement" hasBreak>
-                            <p className="block text-grey-800 transition-colors duration-500 dark:text-white-50">
+                            <p
+                                lang={languageIfNotEnglish}
+                                className="block text-grey-800 transition-colors duration-500 dark:text-white-50"
+                            >
                                 {parse(publicationVersion.dataAccessStatement)}
                             </p>
                         </Components.ContentSection>
@@ -1078,7 +1114,10 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                                     </>
                                 ) : null}
                                 {publicationVersion.fundersStatement ? (
-                                    <p className="block pt-2 leading-relaxed text-grey-800 transition-colors duration-500 dark:text-grey-100">
+                                    <p
+                                        lang={languageIfNotEnglish}
+                                        className="block pt-2 leading-relaxed text-grey-800 transition-colors duration-500 dark:text-grey-100"
+                                    >
                                         {parse(publicationVersion.fundersStatement)}
                                     </p>
                                 ) : null}
@@ -1088,7 +1127,10 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
 
                     {/** Conflict of interest */}
                     <Components.ContentSection id="coi" title="Conflict of interest">
-                        <p className="block leading-relaxed text-grey-800 transition-colors duration-500 dark:text-grey-100">
+                        <p
+                            lang={publicationVersion.conflictOfInterestText ? languageIfNotEnglish : undefined}
+                            className="block leading-relaxed text-grey-800 transition-colors duration-500 dark:text-grey-100"
+                        >
                             {publicationVersion.conflictOfInterestStatus
                                 ? publicationVersion.conflictOfInterestText
                                 : `This ${Helpers.formatPublicationType(


### PR DESCRIPTION
The purpose of this PR was to add the `lang` attribute to HTML markup where a publication's language is not the default (English) and its custom content is being shown, so that assistive technology can be made aware of the content language.

---

### Acceptance Criteria:

- On the publication page, the fields listed below are marked up with the identifier for the language selected by the author during their editing process.
- On PDFs, the fields listed below are marked up with the identifier for the language selected by the author during their editing process.
- Items to mark up in the selected language are:
    - title
    - main text
    - keywords
    - description
    - additional information title / description
    - references
    - ethical statement free text
    - data permissions statement free text
    - data access statement free text
    - funders statement
    - conflict of interest text

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
![Screenshot 2025-02-24 115336](https://github.com/user-attachments/assets/db7fa683-d8cb-4652-be26-4a22ac640587)

