### PR TITLE
OC-378: Backfill publications without corresponding author in coauthor list

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -33,6 +33,7 @@
         "test:watch": "npm run test:local -- --watch",
         "type": "tsc --noEmit",
         "ariImport": "tsx scripts/ariImport.ts",
+        "backfillCoAuthors": "tsx scripts/backfillCoAuthors.ts",
         "createOrganisationalAccounts": "tsx scripts/createOrganisationalAccounts.ts",
         "createTopicMappings": "tsx scripts/createTopicMappings.ts",
         "createTopics": "tsx scripts/createTopics.ts",

--- a/api/scripts/backfillCoAuthors.ts
+++ b/api/scripts/backfillCoAuthors.ts
@@ -1,0 +1,66 @@
+import * as client from 'lib/client';
+
+const backfillCoAuthors = async (): Promise<string> => {
+    const versions = await client.prisma.publicationVersion.findMany({
+        include: {
+            coAuthors: true,
+            user: true
+        }
+    });
+    const affectedVersions = versions.filter(
+        (version) =>
+            version.coAuthors.length === 0 ||
+            !version.coAuthors.find((coAuthor) => coAuthor.linkedUser === version.user.id)
+    );
+
+    if (affectedVersions.length === 0) {
+        console.log('No affected versions found');
+    }
+
+    for (const version of affectedVersions) {
+        console.log(
+            `Processing version ${version.id}, ${
+                version.publishedDate ? 'Published on ' + new Date(version.publishedDate).toISOString() : 'unpublished'
+            }, by ${version.user.firstName} ${version.user.lastName}.`
+        );
+
+        // Increment position of any existing coauthors - corresponding author should be in position 1.
+        for (const coAuthor of version.coAuthors) {
+            console.log('Updating coauthor position', coAuthor.id);
+            await client.prisma.coAuthors.update({
+                where: {
+                    id: coAuthor.id
+                },
+                data: {
+                    position: coAuthor.position + 1
+                }
+            });
+        }
+
+        // Add a coauthor record for the corresponding author.
+        await client.prisma.coAuthors.create({
+            data: {
+                publicationVersion: {
+                    connect: {
+                        id: version.id
+                    }
+                },
+                user: {
+                    connect: {
+                        id: version.user.id
+                    }
+                },
+                email: version.user.email ?? '',
+                confirmedCoAuthor: true,
+                affiliations: [],
+                position: 0
+            }
+        });
+    }
+
+    return 'Done';
+};
+
+backfillCoAuthors()
+    .then((message) => console.log(message))
+    .catch((err) => console.log(err));


### PR DESCRIPTION
Publications exist on int and prod environments that are missing the corresponding author from the coauthor list. This is because we introduced the coauthor features, and made the corresponding author a coauthor by default for new publications, without updating the existing ones. As far as I have seen this only applies to seed data though.

It causes issues because certain UI components expect a populated list of coauthors.

A script is written that we will run on each environment to populate the coauthor.

---

### Acceptance Criteria:

- A script has been written that ensures every publication version has a record for the corresponding author in its coauthor list.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Screenshots:

Simulating the issue, a publication with no coauthors - the author list on the search result is empty ("by ..."):
![Screenshot 2025-02-24 144728](https://github.com/user-attachments/assets/376e517a-4013-4332-b013-358e5f0985cc)

Running the script:
![Screenshot 2025-02-24 144745](https://github.com/user-attachments/assets/2119b388-fb37-420d-82cf-b7b6c92368b4)

The search result after the script was run:
![Screenshot 2025-02-24 144802](https://github.com/user-attachments/assets/b14c27f4-93c8-4ffd-8bcc-a1a47f2f4816)
