### PR TITLE
OC-1017: Clarify author guide publication types

### DIFF
--- a/ui/src/config/values.ts
+++ b/ui/src/config/values.ts
@@ -15,49 +15,64 @@ export const publicationTypes: Types.PublicationType[] = [
 export const authorTypes = ['individual', 'organisational'];
 
 export const octopusInformation: Interfaces.OctopusInformation = {
-    publications: {
+    publicationTypes: {
         PROBLEM: {
             id: 'PROBLEM',
-            heading: 'Research Problem',
-            content: 'A neatly defined scientific problem.'
+            label: 'Research Problem',
+            inlineDescription: 'A neatly defined scientific problem.',
+            faqDescription:
+                'A &apos;research problem&apos; publication defines a research problem or question. You will need to explain what is known so far about the problem, rather like the &apos;introduction&apos; to a traditional paper.'
         },
         HYPOTHESIS: {
             id: 'HYPOTHESIS',
-            heading: 'Rationale/Hypothesis',
-            content:
-                'An original hypothesis relating to an existing published Research Problem or the rationale for how you think the Research Problem could be addressed.'
+            label: 'Rationale/Hypothesis',
+            inlineDescription:
+                'An original hypothesis relating to an existing published Research Problem or the rationale for how you think the Research Problem could be addressed.',
+            faqDescription:
+                'A &apos;rationale/hypothesis&apos; publication sets out the theoretical basis for a potential solution, or partial solution, to the &apos;research problem&apos; it is linked to. In some fields a formal hypothesis is appropriate, in other fields it might be a description of an approach that might be taken.'
         },
         PROTOCOL: {
             id: 'PROTOCOL',
-            heading: 'Method',
-            content: 'A practical method of testing an existing published Rationale/Hypothesis.'
+            label: 'Method',
+            inlineDescription: 'A practical method of testing an existing published Rationale/Hypothesis.',
+            faqDescription: `A &apos;method&apos; publication is a detailed description of ways of testing a hypothesis, or carrying out a theoretical rationale. You can include links to sites such as <a href='https://protocols.io' className='underline' target='_blank'>protocols.io</a> to give more detail of the method if that would be helpful to readers.`
         },
         DATA: {
             id: 'DATA',
-            heading: 'Results',
-            content:
-                'Raw data or summarised results collected according to an existing published Method (can be linked to a data repository).'
+            label: 'Results',
+            inlineDescription:
+                'Raw data or summarised results collected according to an existing published Method (can be linked to a data repository).',
+            faqDescription:
+                'A &apos;results&apos; publication comprises raw data or summarised results collected according to an existing published &apos;method&apos;. It should describe the data or results themselves, without any analysis. It should provide details of the exact conditions under which the method was carried out and anything needed for an analysis or interpretation of the results. You can include links to the raw data files if they are in a specialist repository. Octopus is not a data repository itself.'
         },
         ANALYSIS: {
             id: 'ANALYSIS',
-            heading: 'Analysis',
-            content: 'A statistical or thematic analysis of existing published Results.'
+            label: 'Analysis',
+            inlineDescription: 'A statistical or thematic analysis of existing published Results.',
+            faqDescription:
+                'An &apos;analysis&apos; publication describes manipulations of results to help draw conclusions from them. For example, thematic or statistical analysis.'
         },
         INTERPRETATION: {
             id: 'INTERPRETATION',
-            heading: 'Interpretation',
-            content: 'A discussion around an existing published Analysis.'
+            label: 'Interpretation',
+            inlineDescription: 'A discussion around an existing published Analysis.',
+            faqDescription:
+                'An &apos;interpretation&apos; publication describes conclusions drawn from an &apos;analysis&apos; of results.'
         },
         REAL_WORLD_APPLICATION: {
             id: 'REAL_WORLD_APPLICATION',
-            heading: 'Real World Application',
-            content: 'Real World Applications arising from an existing published Interpretation.'
+            label: 'Real World Application',
+            inlineDescription: 'Real World Applications arising from an existing published Interpretation.',
+            faqDescription:
+                'A &apos;real world application&apos; publication describes how findings might have (or have had) an impact in the real world. This might be through a practical or policy application, and would be the appropriate publication type for case studies.'
         },
         PEER_REVIEW: {
             id: 'PEER_REVIEW',
-            heading: 'Review',
-            content:
-                'A considered, detailed peer review of one of the other kinds of publication. Octopus reviews are open and post-publication.'
+            label: 'Review',
+            inlineDescription:
+                'A considered, detailed peer review of one of the other kinds of publication. Octopus reviews are open and post-publication.',
+            faqDescription:
+                'A &apos;peer review&apos; publication is open and post-publication. It should be a carefully considered and constructive critique of an existing publication by someone else. Your review should help other readers assess the publication, and should be written in the same style as any other kind of publication, with relevant references. Authors may reversion publications in the light of reviews.'
         }
     },
     licences: {

--- a/ui/src/layouts/BuildPublication.tsx
+++ b/ui/src/layouts/BuildPublication.tsx
@@ -88,7 +88,7 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
             if (publicationVersion.conflictOfInterestStatus === null) {
                 ready = { ready: false, message: 'You must select a conflict of interest option' };
             }
-            if (publicationVersion.publication.type === Config.values.octopusInformation.publications.DATA.id) {
+            if (publicationVersion.publication.type === Config.values.octopusInformation.publicationTypes.DATA.id) {
                 if (publicationVersion.ethicalStatement === null)
                     ready = { ready: false, message: 'You must select an ethical statement option' };
                 if (publicationVersion.dataPermissionsStatement === null)
@@ -143,7 +143,7 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
             if (publicationVersion.conflictOfInterestStatus === null) {
                 ready = { ready: false, message: 'You must select a conflict of interest option' };
             }
-            if (publicationVersion.publication.type === Config.values.octopusInformation.publications.DATA.id) {
+            if (publicationVersion.publication.type === Config.values.octopusInformation.publicationTypes.DATA.id) {
                 if (publicationVersion.ethicalStatement === null)
                     ready = { ready: false, message: 'You must select an ethical statement option' };
                 if (publicationVersion.dataPermissionsStatement === null)

--- a/ui/src/lib/interfaces.ts
+++ b/ui/src/lib/interfaces.ts
@@ -292,11 +292,12 @@ export interface BookmarkedTopic {
 }
 
 export interface OctopusInformation {
-    publications: {
+    publicationTypes: {
         [key in Types.PublicationType]: {
             id: Types.PublicationType;
-            heading: string;
-            content: string;
+            label: string;
+            inlineDescription: string;
+            faqDescription: string;
         };
     };
     licences: {

--- a/ui/src/pages/author-guide.tsx
+++ b/ui/src/pages/author-guide.tsx
@@ -1,16 +1,21 @@
 import React from 'react';
 import { NextPage } from 'next';
 import Head from 'next/head';
+import parse from 'html-react-parser';
 
 import * as Components from '@/components';
 import * as Layouts from '@/layouts';
 import * as Config from '@/config';
+import * as Types from '@/types';
 
 type AuthorGuideSection = {
     title: string;
     id: string;
     content: React.ReactNode;
 };
+
+const publicationTypes = Config.values.octopusInformation.publicationTypes;
+const publicationTypeIds: Types.PublicationType[] = Object.keys(publicationTypes) as Types.PublicationType[];
 
 const authorGuideSections: AuthorGuideSection[] = [
     {
@@ -87,18 +92,30 @@ const authorGuideSections: AuthorGuideSection[] = [
         )
     },
     {
-        title: 'Publication types',
-        id: 'publication-types',
+        title: 'Choosing a publication type',
+        id: 'choosing-a-publication-type',
         content: (
-            <p>
-                The eight publication types in Octopus are intended to align with the research process, so select the
-                stage which matches where you are in your work.{' '}
-                <a href="/faq" target="_blank" className="underline">
-                    See our FAQ
-                </a>{' '}
-                for more information on the publication types. You can publish each stage as it happens, publish when
-                the project is finished, or adapt existing papers to record prior work to Octopus.
-            </p>
+            <>
+                <p>
+                    The eight publication types in Octopus are intended to align with the research process, so select
+                    the stage which matches where you are in your work. If you would like to publish work that does not
+                    build on a publication that is already on Octopus, you will need to start with a research problem.
+                    You can publish each stage as it happens, publish when the project is finished, or adapt existing
+                    papers to record prior work to Octopus.
+                </p>
+                <p className="mb-2">
+                    Below are the eight publication types. You should select the one which matches where you are in the
+                    research process.
+                </p>
+                {publicationTypeIds.map((type, index) => (
+                    <>
+                        <p className="mb-2 font-bold">{publicationTypes[type].label}:</p>
+                        <p className={index !== publicationTypeIds.length - 1 ? 'mb-2' : ''}>
+                            {parse(publicationTypes[type].faqDescription)}
+                        </p>
+                    </>
+                ))}
+            </>
         )
     },
     {

--- a/ui/src/pages/create.tsx
+++ b/ui/src/pages/create.tsx
@@ -191,7 +191,8 @@ const Create: Types.NextPage<PageProps> = (props): React.ReactElement => {
                             )}
                         </select>
                         <SupportText>
-                            Definition: {Config.values.octopusInformation.publications[publicationType].content}
+                            Definition:{' '}
+                            {Config.values.octopusInformation.publicationTypes[publicationType].inlineDescription}
                         </SupportText>
                     </div>
                     <Components.Checkbox

--- a/ui/src/pages/faq.tsx
+++ b/ui/src/pages/faq.tsx
@@ -6,7 +6,10 @@ import { NextPage } from 'next';
 import * as Components from '@/components';
 import * as Layouts from '@/layouts';
 import * as Config from '@/config';
+import * as Types from '@/types';
 
+const publicationTypes = Config.values.octopusInformation.publicationTypes;
+const publicationTypeIds: Types.PublicationType[] = Object.keys(publicationTypes) as Types.PublicationType[];
 const faqContents = [
     {
         title: 'What is Octopus?',
@@ -65,25 +68,14 @@ const faqContents = [
         href: 'pub_type_octopus',
         id: 'pub_type_octopus',
         heading: 'Which publication type should I use?',
-        content: `
-            <p className='mb-2'>Below are the eight publication types. You should select the one which matches where you are in the research process.</p>
-            <p className='mb-2 font-bold'>Research problem</p>
-            <p className='mb-2'>A &apos;research problem&apos; publication defines a research problem or question. You will need to explain what is known so far about the problem, rather like the &apos;introduction&apos; to a traditional paper.</p>
-            <p className='mb-2 font-bold'>Rationale/Hypothesis:</p>
-            <p className='mb-2'>A &apos;rationale/hypothesis&apos; publication sets out the theoretical basis for a potential solution, or partial solution, to the &apos;research problem&apos; it is linked to. In some fields a formal hypothesis is appropriate, in other fields it might be a description of an approach that might be taken.</p>
-            <p className='mb-2 font-bold'>Method:</p>
-            <p className='mb-2'>A &apos;method&apos; publication is a detailed description of ways of testing a hypothesis, or carrying out a theoretical rationale. You can include links to sites such as <a href='https://protocols.io' className='underline' target='_blank'>protocols.io</a> to give more detail of the method if that would be helpful to readers.</p>
-            <p className='mb-2 font-bold'>Results:</p>
-            <p className='mb-2'>A &apos;results&apos; publication comprises raw data or summarised results collected according to an existing published &apos;method&apos;. It should describe the data or results themselves, without any analysis. It should provide details of the exact conditions under which the method was carried out and anything needed for an analysis or interpretation of the results. You can include links to the raw data files if they are in a specialist repository. Octopus is not a data repository itself.</p>
-            <p className='mb-2 font-bold'>Analysis:</p>
-            <p className='mb-2'>An &apos;analysis&apos; publication describes manipulations of results to help draw conclusions from them. For example, thematic or statistical analysis.</p>
-            <p className='mb-2 font-bold'>Interpretation:</p>
-            <p className='mb-2'>An &apos;interpretation&apos; publication describes conclusions drawn from an &apos;analysis&apos; of results.</p>
-            <p className='mb-2 font-bold'>Real World Application:</p>
-            <p className='mb-2'>A &apos;real world application&apos; publication describes how findings might have (or have had) an impact in the real world. This might be through a practical or policy application, and would be the appropriate publication type for case studies.</p>
-            <p className='mb-2 font-bold'>Peer Review:</p>
-            <p>A &apos;peer review&apos; publication is open and post-publication. It should be a carefully considered and constructive critique of an existing publication by someone else. Your review should help other readers assess the publication, and should be written in the same style as any other kind of publication, with relevant references. Authors may reversion publications in the light of reviews.</p>
-        `
+        content:
+            `<p className='mb-2'>Below are the eight publication types. You should select the one which matches where you are in the research process.</p>` +
+            publicationTypeIds
+                .map(
+                    (type, index) =>
+                        `<p className='mb-2 font-bold'>${publicationTypes[type].label}:</p><p ${index !== publicationTypeIds.length - 1 ? 'className="mb-2"' : ''}>${publicationTypes[type].faqDescription}</p>`
+                )
+                .join('')
     },
     {
         title: 'How do I format my publications?',

--- a/ui/src/pages/publications/[id]/edit.tsx
+++ b/ui/src/pages/publications/[id]/edit.tsx
@@ -157,13 +157,13 @@ const Edit: Types.NextPage<Props> = (props): React.ReactElement => {
             steps.FUNDERS
         ];
         switch (props.publicationVersion.publication.type) {
-            case Config.values.octopusInformation.publications.DATA.id:
+            case Config.values.octopusInformation.publicationTypes.DATA.id:
                 arr = [...arr, steps.DATA_STATEMENT, steps.CO_AUTHORS];
                 break;
-            case Config.values.octopusInformation.publications.PROTOCOL.id:
+            case Config.values.octopusInformation.publicationTypes.PROTOCOL.id:
                 arr = [...arr, steps.RESEARCH_PROCESS, steps.CO_AUTHORS];
                 break;
-            case Config.values.octopusInformation.publications.HYPOTHESIS.id:
+            case Config.values.octopusInformation.publicationTypes.HYPOTHESIS.id:
                 arr = [...arr, steps.RESEARCH_PROCESS, steps.CO_AUTHORS];
                 break;
             default:


### PR DESCRIPTION
The purpose of this PR was to clarify the guidance on which publication types to use.

Because this is reusing content from the FAQ, I added it to the octopus information config values and changed that around a bit to make the properties make more sense.

---

### Acceptance Criteria:

- The author guide “Publication types” section is now titled “Choosing a publication type”
- The “Choosing a publication type” section now reads “The eight publication types in Octopus are intended to align with the research process, so select the stage which matches where you are in your work. If you would like to publish work that does not build on a publication that is already on Octopus, you will need to start with a research problem. You can publish each stage as it happens, publish when the project is finished, or adapt existing papers to record prior work to Octopus.” followed by the entire content of the “Which publication type should I use” FAQ section.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
![Screenshot 2025-02-25 102936](https://github.com/user-attachments/assets/8a095883-b847-4782-a385-97693a7ae797)

E2E (logged out only - orcid sandbox is down preventing login, but changes are not significantly within the logged in tests' coverage)
![Screenshot 2025-02-25 103335](https://github.com/user-attachments/assets/a4c7d282-64d0-4a94-ae05-0679454dbcc4)


---

### Screenshots:
![Screenshot 2025-02-25 103521](https://github.com/user-attachments/assets/1e110db0-0417-4bbc-b5d6-d7cb2fb38df7)

