### PR TITLE
OC-1003 fix: Don't exclude entities + katex from deployment package

### DIFF
--- a/api/serverless-config-default.yml
+++ b/api/serverless-config-default.yml
@@ -522,8 +522,6 @@ package:
         - '!node_modules/@swc/**'
         - '!node_modules/aws-sdk/**'
         - '!node_modules/chromium-bidi/**'
-        - '!node_modules/entities/**'
-        - '!node_modules/katex/**'
         - '!node_modules/prisma/engines/**'
         - '!node_modules/prisma/libquery_engine-*'
         - '!node_modules/puppeteer-core/**'
@@ -539,7 +537,6 @@ package:
     # Mostly as above but:
     # - With a different prisma engine (due to different architecture - chromium binary doesn't work on arm64)
     # - Included chromium binary
-    # - Didn't exclude Katex and entities (used for rendering latex in PDFs)
     pdfFunctionPatterns:
         - '!.eslintrc.json'
         - '!.localstack/**'


### PR DESCRIPTION
The purpose of this PR was to fix an issue with the work in OC-1003 (PR #773). The newly added modules entities and katex were excluded from the serverless deployment as they were not needed outside of PDF generation, which has a separately configured deployment package. However, because they're still imported in helpers, this caused a module not found exception.