### PR TITLE
PubRouter fix: pass affiliation data in correct format

### DIFF
--- a/api/src/components/pubRouter/service.ts
+++ b/api/src/components/pubRouter/service.ts
@@ -21,8 +21,8 @@ const getPubRouterMetadata = (publicationVersion: I.PublicationVersion, pdfUrl: 
                     id: coAuthor.user.orcid
                 }
             ],
-            affiliations: coAuthor.affiliations?.map((rawAffiliationJson) => {
-                const affiliation: I.MappedOrcidAffiliation = JSON.parse(rawAffiliationJson as string);
+            affiliations: coAuthor.affiliations?.map((untypedAffiliation) => {
+                const affiliation = untypedAffiliation as unknown as I.MappedOrcidAffiliation;
 
                 return {
                     identifier: [


### PR DESCRIPTION
The purpose of this PR was to fix an issue with the way we process affiliation data when constructing the payload to pubrouter. It seems like the code was written with the assumption that the JSON field data would come through prisma as a string, but in fact it comes out as an object, so runing `JSON.parse()` on it causes an error as that expects a string. The object is ready to use, so this change just passes it straight through, ensuring it's properly typed.

Confirmed locally that some sample metadata with affiliations is correctly constructed with this fix.