### PR TITLE
OC-1014: New endpoint to fetch user's drafts

### DIFF
--- a/api/src/components/user/__tests__/getUserPublications.test.ts
+++ b/api/src/components/user/__tests__/getUserPublications.test.ts
@@ -2,6 +2,8 @@ import { Prisma } from '@prisma/client';
 import * as testUtils from 'lib/testUtils';
 import * as userService from 'user/service';
 
+type UserPublications = Prisma.PromiseReturnType<typeof userService.getPublications>;
+
 describe("Get a given user's publications", () => {
     beforeAll(async () => {
         await testUtils.clearDB();
@@ -58,7 +60,6 @@ describe("Get a given user's publications", () => {
 
     test('Results can be filtered by a query term', async () => {
         const queryTerm = 'interpretation';
-        type UserPublications = Prisma.PromiseReturnType<typeof userService.getPublications>;
         const publications = await testUtils.agent.get('/users/test-user-1/publications').query({ query: queryTerm });
 
         expect(publications.status).toEqual(200);
@@ -68,6 +69,57 @@ describe("Get a given user's publications", () => {
                 publication.versions.some(
                     (version) => version.isLatestLiveVersion && version.title?.toLowerCase().includes(queryTerm)
                 )
+            )
+        ).toEqual(true);
+    });
+
+    test('Results can be filtered to publications having at least one version currently in a given status', async () => {
+        const publications = await testUtils.agent
+            .get('/users/test-user-1/publications')
+            .query({ apiKey: 123456789, versionStatus: 'DRAFT' });
+
+        expect(publications.status).toEqual(200);
+        expect(publications.body.data.length).toEqual(10); // a full page
+        expect(
+            (publications.body as UserPublications).data.every((publication) =>
+                publication.versions.some((version) => version.currentStatus === 'DRAFT')
+            )
+        ).toEqual(true);
+    });
+
+    test('versionStatus param cannot be used if initialDraftsOnly param is true', async () => {
+        const publications = await testUtils.agent
+            .get('/users/test-user-1/publications')
+            .query({ apiKey: 123456789, versionStatus: 'DRAFT', initialDraftsOnly: true });
+
+        expect(publications.status).toEqual(400);
+        expect(publications.body.message).toBe(
+            'The "versionStatus" query parameter cannot be used when "initialDraftsOnly" is set to true.'
+        );
+    });
+
+    test('versionStatus param can be used if initialDraftsOnly param is false', async () => {
+        const publications = await testUtils.agent
+            .get('/users/test-user-1/publications')
+            .query({ apiKey: 123456789, versionStatus: 'DRAFT', initialDraftsOnly: false });
+
+        expect(publications.status).toEqual(200);
+    });
+
+    test('Only initial drafts are returned if initialDraftsOnly param is true', async () => {
+        const publications = await testUtils.agent
+            .get('/users/test-user-1/publications')
+            .query({ apiKey: 123456789, initialDraftsOnly: true });
+
+        expect(publications.status).toEqual(200);
+        expect(publications.body.data.length).toBeGreaterThan(0);
+        // Every version on every publication should be a draft, and the only version.
+        expect(
+            (publications.body as UserPublications).data.every(
+                (publication) =>
+                    publication.versions.length === 1 &&
+                    publication.versions[0].currentStatus === 'DRAFT' &&
+                    publication.versions[0].versionNumber === 1
             )
         ).toEqual(true);
     });

--- a/api/src/components/user/controller.ts
+++ b/api/src/components/user/controller.ts
@@ -47,9 +47,15 @@ export const getPublications = async (
     const versionStatus = event.queryStringParameters?.versionStatus;
     const versionStatusArray = versionStatus ? versionStatus.split(',') : [];
 
+    if (event.queryStringParameters.initialDraftsOnly && versionStatusArray.length) {
+        return response.json(400, {
+            message: 'The "versionStatus" query parameter cannot be used when "initialDraftsOnly" is set to true.'
+        });
+    }
+
     if (versionStatusArray.length && versionStatusArray.some((status) => !I.PublicationStatusEnum[status])) {
         return response.json(400, {
-            message: "Invalid version status provided. Valid values include 'DRAFT', 'LIVE', 'LOCKED"
+            message: "Invalid version status provided. Valid values include 'DRAFT', 'LIVE', and 'LOCKED'."
         });
     }
 

--- a/api/src/components/user/schema/getPublications.ts
+++ b/api/src/components/user/schema/getPublications.ts
@@ -20,6 +20,11 @@ const getPublicationsSchema: I.JSONSchemaType<I.UserPublicationsFilters> = {
         versionStatus: {
             type: 'string',
             nullable: true
+        },
+        initialDraftsOnly: {
+            type: 'boolean',
+            default: false,
+            nullable: true
         }
     },
     required: []

--- a/api/src/components/user/schema/getPublications.ts
+++ b/api/src/components/user/schema/getPublications.ts
@@ -25,6 +25,10 @@ const getPublicationsSchema: I.JSONSchemaType<I.UserPublicationsFilters> = {
             type: 'boolean',
             default: false,
             nullable: true
+        },
+        exclude: {
+            type: 'string',
+            nullable: true
         }
     },
     required: []

--- a/api/src/components/user/service.ts
+++ b/api/src/components/user/service.ts
@@ -265,18 +265,18 @@ export const getPublications = async (
         ...authorshipFilter,
         ...versionStatusFilter,
         // If a query is supplied, the query matches the latest live title.
-        ...(params.query
-            ? {
-                  versions: {
-                      some: {
-                          isLatestLiveVersion: true,
-                          title: {
-                              search: Helpers.sanitizeSearchQuery(params.query)
-                          }
-                      }
-                  }
-              }
-            : {})
+        ...(params.query && {
+            versions: {
+                some: {
+                    isLatestLiveVersion: true,
+                    title: {
+                        search: Helpers.sanitizeSearchQuery(params.query)
+                    }
+                }
+            }
+        }),
+        // If a publication is to be excluded, it is not included in the results.
+        ...(params.exclude && { id: { notIn: params.exclude.split(',') } })
     };
 
     const userPublications = await client.prisma.publication.findMany({

--- a/api/src/components/user/service.ts
+++ b/api/src/components/user/service.ts
@@ -239,26 +239,40 @@ export const getPublications = async (
     };
 
     // WHERE clauses related to the requested publication status of publications.
-    const versionStatusFilter: Prisma.PublicationWhereInput =
-        // If the requester is not the account owner, get only publications that have a published version.
-        !isAccountOwner
-            ? { versions: { some: { isLatestLiveVersion: true } } }
-            : // Otherwise...
-            // If only initial drafts are requested, return only these.
-            initialDraftsOnly
-            ? { versions: { every: { currentStatus: 'DRAFT', versionNumber: 1 } } }
-            : // If another version status filter has been supplied, get publications with at least one version with a current status matching the given filters.
-            versionStatusArray
-            ? {
-                  versions: {
-                      some: {
-                          currentStatus: {
-                              in: versionStatusArray
-                          }
-                      }
-                  }
-              }
-            : {};
+    let versionStatusFilter: Prisma.PublicationWhereInput;
+
+    if (!isAccountOwner) {
+        versionStatusFilter = {
+            versions: {
+                some: {
+                    isLatestLiveVersion: true
+                }
+            }
+        };
+    } else {
+        if (initialDraftsOnly) {
+            versionStatusFilter = {
+                versions: {
+                    every: {
+                        currentStatus: 'DRAFT',
+                        versionNumber: 1
+                    }
+                }
+            };
+        } else if (versionStatusArray) {
+            versionStatusFilter = {
+                versions: {
+                    some: {
+                        currentStatus: {
+                            in: versionStatusArray
+                        }
+                    }
+                }
+            };
+        } else {
+            versionStatusFilter = {};
+        }
+    }
 
     // Get publications where:
     const where: Prisma.PublicationWhereInput = {

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -742,6 +742,7 @@ export interface UserPublicationsFilters {
     limit: number;
     query?: string;
     versionStatus?: string;
+    initialDraftsOnly?: boolean;
 }
 
 export interface SendApprovalReminderPathParams {

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -743,6 +743,7 @@ export interface UserPublicationsFilters {
     query?: string;
     versionStatus?: string;
     initialDraftsOnly?: boolean;
+    exclude?: string;
 }
 
 export interface SendApprovalReminderPathParams {


### PR DESCRIPTION
The purpose of this PR was to do some back end set up for allowing octopus users to choose a draft they have access to for linking. It specified a new endpoint but it makes more sense to add an option to the existing "get user publications" endpoint to filter to initial drafts only.

The item didn't stipulate this, but non-initial drafts (version 2+) don't apply to this use case, hence the filtering by version number when the new parameter is provided.

It also needs to be able to exclude certain publications, as the user will not need to see the draft they are trying to link from in the search results.

There was version filtering in place already which is a bit confusing, but that was to return publications with at least one version matching the filter. This new filter returns publications with only 1 version which is a bit different, so I thought it made sense to be its own parameter.

---

### Acceptance Criteria:

- A new endpoint fetches all drafts that the user is an author on for use on the “linked publications” section of the draft edit workflow

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

API
![Screenshot 2025-03-07 091506](https://github.com/user-attachments/assets/c40c359f-61ff-4eec-b010-ce7263aa77f6)

E2E
![Screenshot 2025-03-06 163504](https://github.com/user-attachments/assets/2b5bb97a-921c-46d7-b9de-46cb85acc485)
