### PR TITLE
OC-1026: Configure intelligent tiering for S3 buckets

### DIFF
--- a/infra/modules/s3/main.tf
+++ b/infra/modules/s3/main.tf
@@ -8,6 +8,18 @@ resource "aws_s3_bucket" "image_bucket" {
   bucket = "science-octopus-publishing-images-${var.environment}"
 }
 
+resource "aws_s3_bucket_lifecycle_configuration" "image_bucket_lifecycle" {
+  bucket = aws_s3_bucket.image_bucket.id
+
+  rule {
+    id     = "image_bucket_intelligent_tiering"
+    status = "Enabled"
+    transition {
+      storage_class = "INTELLIGENT_TIERING"
+    }
+  }
+}
+
 resource "aws_s3_bucket_public_access_block" "image_bucket_allow_public" {
   bucket = aws_s3_bucket.image_bucket.id
 
@@ -19,6 +31,18 @@ resource "aws_s3_bucket" "pdf_bucket" {
   bucket = "science-octopus-publishing-pdfs-${var.environment}"
 }
 
+resource "aws_s3_bucket_lifecycle_configuration" "pdf_bucket_lifecycle" {
+  bucket = aws_s3_bucket.pdf_bucket.id
+
+  rule {
+    id     = "pdf_bucket_intelligent_tiering"
+    status = "Enabled"
+    transition {
+      storage_class = "INTELLIGENT_TIERING"
+    }
+  }
+}
+
 resource "aws_s3_bucket_public_access_block" "pdf_bucket_allow_public" {
   bucket = aws_s3_bucket.pdf_bucket.id
 
@@ -28,6 +52,18 @@ resource "aws_s3_bucket_public_access_block" "pdf_bucket_allow_public" {
 
 resource "aws_s3_bucket" "sitemap_bucket" {
   bucket = "science-octopus-publishing-sitemaps-${var.environment}"
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "sitemap_bucket_lifecycle" {
+  bucket = aws_s3_bucket.sitemap_bucket.id
+
+  rule {
+    id     = "sitemap_bucket_intelligent_tiering"
+    status = "Enabled"
+    transition {
+      storage_class = "INTELLIGENT_TIERING"
+    }
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "sitemap_bucket_allow_public" {


### PR DESCRIPTION
The purpose of this PR was to make use of the intelligent tiering storage class for AWS S3 that intelligently moves objects into a different archival class based on the frequency of their retrieval for a small management fee.

I've applied it to the buckets that I expect to have lots of files and variable rates of retrieval.

---

### Acceptance Criteria:

Intelligent tiering is used where beneficial.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Screenshots:

The lifecycle rules have moved items above 128KB to intelligent tiering. Any smaller file doesn't qualify for it. This transition happens overnight each day.

![Screenshot 2025-03-12 095053](https://github.com/user-attachments/assets/4fe5b914-9c0c-4770-9cd3-44516d9d2e5c)
