### PR TITLE
OC-1019: Peer reviews do not populate DOIs with relevant links

### DIFF
--- a/api/prisma/seeds/local/unitTesting/publications.ts
+++ b/api/prisma/seeds/local/unitTesting/publications.ts
@@ -58,7 +58,7 @@ const publicationSeeds: Prisma.PublicationCreateInput[] = [
                     isLatestVersion: false,
                     isLatestLiveVersion: false,
                     publishedDate: '2022-01-22T15:51:42.523Z',
-                    user: { connect: { id: 'test-user-1' } },
+                    createdBy: 'test-user-1',
                     publicationStatus: {
                         create: [
                             { status: 'DRAFT', createdAt: '2022-01-20T15:51:42.523Z' },
@@ -110,7 +110,7 @@ const publicationSeeds: Prisma.PublicationCreateInput[] = [
                     isLatestLiveVersion: true,
                     isLatestVersion: true,
                     publishedDate: '2022-01-22T15:51:42.523Z',
-                    user: { connect: { id: 'test-user-1' } },
+                    createdBy: 'test-user-1',
                     publicationStatus: {
                         create: [
                             { status: 'DRAFT', createdAt: '2022-01-20T15:51:42.523Z' },
@@ -132,6 +132,27 @@ const publicationSeeds: Prisma.PublicationCreateInput[] = [
                                 code: 'test-code-user-6',
                                 confirmedCoAuthor: true,
                                 linkedUser: 'test-user-6'
+                            }
+                        ]
+                    },
+                    References: {
+                        create: [
+                            {
+                                id: 'publication-problem-live-reference-1',
+                                type: 'DOI',
+                                text: 'doi reference',
+                                location: 'https://example.doi.url'
+                            },
+                            {
+                                id: 'publication-problem-live-reference-2',
+                                type: 'TEXT',
+                                text: 'text reference'
+                            },
+                            {
+                                id: 'publication-problem-live-reference-3',
+                                type: 'URL',
+                                text: 'URL reference',
+                                location: 'https://example.url'
                             }
                         ]
                     }

--- a/api/prisma/seeds/local/unitTesting/publications.ts
+++ b/api/prisma/seeds/local/unitTesting/publications.ts
@@ -50,6 +50,7 @@ const publicationSeeds: Prisma.PublicationCreateInput[] = [
             create: [
                 {
                     id: 'publication-problem-live-v1',
+                    doi: '10.82259/ver1-2g03',
                     versionNumber: 1,
                     title: 'Publication PROBLEM-LIVE',
                     content: 'Publication PROBLEM-LIVE',
@@ -101,6 +102,7 @@ const publicationSeeds: Prisma.PublicationCreateInput[] = [
                 },
                 {
                     id: 'publication-problem-live-v2',
+                    doi: '10.82259/ver2-2g03',
                     versionNumber: 2,
                     title: 'Publication PROBLEM-LIVE v2',
                     content: 'Publication PROBLEM-LIVE v2',

--- a/api/src/components/publicationVersion/service.ts
+++ b/api/src/components/publicationVersion/service.ts
@@ -1,10 +1,10 @@
-import axios, { AxiosResponse } from 'axios';
 import nodemailer from 'nodemailer';
 import { convert } from 'html-to-text';
 import { createId } from '@paralleldrive/cuid2';
 import { Prisma } from '@prisma/client';
 
 import * as client from 'lib/client';
+import * as doi from 'lib/doi';
 import * as email from 'lib/email';
 import * as eventService from 'event/service';
 import * as Helpers from 'lib/helpers';
@@ -640,330 +640,6 @@ export const transferOwnership = (publicationVersionId: string, requesterId: str
         }
     });
 
-// DOI functions
-const createCreatorObject = (user: I.DataCiteUser): I.DataCiteCreator => {
-    return {
-        name: Helpers.abbreviateUserName(user), // datacite expects full name in lastname, firstname order
-        givenName: user?.firstName,
-        familyName: user?.lastName,
-        nameType: user.role === 'ORGANISATION' ? 'Organizational' : 'Personal',
-        nameIdentifiers: [
-            {
-                nameIdentifier: user?.orcid ? user?.orcid : 'ORCID iD not provided',
-                nameIdentifierScheme: 'ORCID',
-                schemeUri: 'https://orcid.org/'
-            }
-        ],
-        affiliation: user.affiliations.map((affiliation) => ({
-            name: affiliation.organization.name,
-            nameType: 'Organizational',
-            affiliationIdentifier:
-                affiliation.organization['disambiguated-organization']?.['disambiguated-organization-identifier'] || '',
-            affiliationIdentifierScheme:
-                affiliation.organization['disambiguated-organization']?.['disambiguation-source'] || ''
-        }))
-    };
-};
-
-const getFullDOIsStrings = (text: string): [] | RegExpMatchArray =>
-    text.match(
-        /(\s+)?(\(|\(\s+)?(?:DOI((\s+)?([:-])?(\s+)?))?(10\.[0-9a-zA-Z]+\/(?:(?!["&\'])\S)+)\b(\)|\s+\))?(\.)?/gi //eslint-disable-line
-    ) || [];
-
-const createDOIPayload = async (
-    data:
-        | {
-              payloadType: 'canonical';
-              doi: string;
-              publicationVersion: I.PublicationVersion;
-              oldPublicationVersionDOIs: string[];
-          }
-        | {
-              payloadType: 'newVersion';
-              publicationVersion: I.PublicationVersion;
-              previousPublicationVersionDOI?: string;
-          }
-        | {
-              payloadType: 'previousVersion';
-              publicationVersion: I.PublicationVersion;
-              newPublicationVersionDOI: string;
-              previousPublicationVersionDOI?: string;
-          }
-): Promise<Record<string, unknown>> => {
-    const { payloadType, publicationVersion } = data;
-
-    const references = await referenceService.getAllByPublicationVersion(publicationVersion.id);
-    const { linkedTo } = await publicationService.getDirectLinksForPublication(publicationVersion.versionOf, true);
-
-    const creators: I.DataCiteCreator[] = [];
-    publicationVersion.coAuthors.forEach((author) => {
-        if (author.user) {
-            creators.push(
-                createCreatorObject({
-                    firstName: author.user.firstName,
-                    lastName: author.user.lastName,
-                    orcid: author.user.orcid,
-                    affiliations: author.affiliations as unknown as I.MappedOrcidAffiliation[],
-                    role: author.user.role
-                })
-            );
-        }
-    });
-
-    // check if the creator of this version of the publication is not listed as an author
-    if (!publicationVersion.coAuthors.find((author) => author.linkedUser === publicationVersion.createdBy)) {
-        // add creator to authors list as first author
-        creators?.unshift(
-            createCreatorObject({
-                firstName: publicationVersion.user.firstName,
-                lastName: publicationVersion.user.lastName,
-                orcid: publicationVersion.user.orcid,
-                affiliations: [],
-                role: publicationVersion.user.role
-            })
-        );
-    }
-
-    const linkedPublicationDOIs = linkedTo.map((link) => ({
-        relatedIdentifier: link.doi,
-        relatedIdentifierType: 'DOI',
-        relationType: link.type === 'PEER_REVIEW' ? 'Reviews' : 'Continues'
-    }));
-
-    const referenceDOIs = references
-        .filter((reference) => reference.type === 'DOI' && reference.location)
-        .map((reference) => {
-            const doi = getFullDOIsStrings(reference.location as string);
-
-            return {
-                relatedIdentifier: doi[0],
-                relatedIdentifierType: 'DOI',
-                relationType: 'References'
-            };
-        });
-
-    const otherReferences = references
-        .filter((reference) => reference.type !== 'DOI')
-        .map((reference) => {
-            const mutatedReference = {
-                titles: [
-                    {
-                        title: reference.text.replace(/(<([^>]+)>)/gi, '')
-                    }
-                ],
-                relationType: 'References',
-                relatedItemType: 'Other'
-            };
-
-            return reference.location
-                ? {
-                      ...mutatedReference,
-                      relatedItemIdentifier: {
-                          relatedItemIdentifier: reference.location,
-                          relatedItemIdentifierType: 'URL'
-                      }
-                  }
-                : mutatedReference;
-        });
-
-    const additionalInformation = publicationVersion.additionalInformation.map((additionalInfoEntry) => ({
-        titles: [
-            {
-                title: additionalInfoEntry.title
-            }
-        ],
-        relationType: 'HasPart',
-        relatedItemType: 'Other',
-        relatedItemIdentifier: {
-            relatedItemIdentifier: additionalInfoEntry.url,
-            relatedItemIdentifierType: 'URL'
-        }
-    }));
-
-    const payload = {
-        data: {
-            type: 'dois',
-            attributes: {
-                event: 'publish',
-                url:
-                    payloadType === 'canonical'
-                        ? Helpers.getPublicationUrl(publicationVersion.versionOf)
-                        : `${Helpers.getPublicationUrl(publicationVersion.versionOf)}/versions/${
-                              publicationVersion.versionNumber
-                          }`,
-                creators,
-                titles: [
-                    {
-                        title: publicationVersion.title,
-                        lang: 'en'
-                    }
-                ],
-                publisher: 'Octopus',
-                publicationYear: publicationVersion.createdAt.getFullYear(),
-                contributors: [
-                    {
-                        name: Helpers.abbreviateUserName(publicationVersion.user),
-                        contributorType: 'ContactPerson',
-                        nameType: publicationVersion.user.role === 'ORGANISATION' ? 'Organizational' : 'Personal',
-                        givenName: publicationVersion.user.firstName,
-                        familyName: publicationVersion.user.lastName,
-                        nameIdentifiers: [
-                            {
-                                nameIdentifier: publicationVersion.user.orcid,
-                                nameIdentifierScheme: 'ORCID',
-                                schemeUri: 'https://orcid.org/'
-                            }
-                        ]
-                    }
-                ],
-                language: 'en',
-                types: {
-                    resourceTypeGeneral: publicationVersion.publication.type === 'PEER_REVIEW' ? 'PeerReview' : 'Other',
-                    resourceType: publicationVersion.publication.type
-                },
-                relatedIdentifiers: [...linkedPublicationDOIs, ...referenceDOIs],
-                relatedItems: [...otherReferences, ...additionalInformation],
-                fundingReferences: publicationVersion.funders.map((funder) => ({
-                    funderName: funder.name,
-                    funderIdentifier: funder.ror || funder.link,
-                    funderIdentifierType: funder.ror ? 'ROR' : 'Other'
-                }))
-            }
-        }
-    };
-
-    switch (payloadType) {
-        case 'newVersion': {
-            const { previousPublicationVersionDOI } = data;
-
-            const publicationVersionDOIs = [
-                {
-                    relatedIdentifier: publicationVersion.publication.doi,
-                    relatedIdentifierType: 'DOI',
-                    relationType: 'IsVersionOf',
-                    resourceTypeGeneral: payload.data.attributes.types.resourceTypeGeneral
-                }
-            ];
-
-            if (previousPublicationVersionDOI) {
-                publicationVersionDOIs.push({
-                    relatedIdentifier: previousPublicationVersionDOI,
-                    relatedIdentifierType: 'DOI',
-                    relationType: 'IsNewVersionOf',
-                    resourceTypeGeneral: payload.data.attributes.types.resourceTypeGeneral
-                });
-            }
-
-            Object.assign(payload.data.attributes, {
-                prefix: process.env.DOI_PREFIX,
-                relatedIdentifiers: [...payload.data.attributes.relatedIdentifiers, ...publicationVersionDOIs],
-                version: publicationVersion.versionNumber
-            });
-
-            break;
-        }
-
-        case 'previousVersion': {
-            const { newPublicationVersionDOI, previousPublicationVersionDOI } = data;
-
-            const publicationVersionDOIs = [
-                {
-                    relatedIdentifier: publicationVersion.publication.doi,
-                    relatedIdentifierType: 'DOI',
-                    relationType: 'IsVersionOf',
-                    resourceTypeGeneral: payload.data.attributes.types.resourceTypeGeneral
-                },
-                {
-                    relatedIdentifier: newPublicationVersionDOI,
-                    relatedIdentifierType: 'DOI',
-                    relationType: 'IsPreviousVersionOf',
-                    resourceTypeGeneral: payload.data.attributes.types.resourceTypeGeneral
-                }
-            ];
-
-            if (previousPublicationVersionDOI) {
-                publicationVersionDOIs.push({
-                    relatedIdentifier: previousPublicationVersionDOI,
-                    relatedIdentifierType: 'DOI',
-                    relationType: 'IsNewVersionOf',
-                    resourceTypeGeneral: payload.data.attributes.types.resourceTypeGeneral
-                });
-            }
-
-            Object.assign(payload.data.attributes, {
-                relatedIdentifiers: [...payload.data.attributes.relatedIdentifiers, ...publicationVersionDOIs],
-                version: publicationVersion.versionNumber
-            });
-
-            break;
-        }
-
-        default: {
-            // canonical
-            const { oldPublicationVersionDOIs } = data;
-
-            // It's possible there will be no versioned DOIs at all.
-            // Some types of publication only get a canonical DOI. In this case, skip this part.
-            if (oldPublicationVersionDOIs.length || publicationVersion.doi) {
-                const publicationVersionDOIs = [...oldPublicationVersionDOIs, publicationVersion.doi].map((doi) => ({
-                    relatedIdentifier: doi,
-                    relatedIdentifierType: 'DOI',
-                    relationType: 'HasVersion',
-                    resourceTypeGeneral: payload.data.attributes.types.resourceTypeGeneral
-                }));
-
-                Object.assign(payload.data.attributes, {
-                    doi: data.doi,
-                    identifiers: [
-                        {
-                            identifier: `https://doi.org/${data.doi}`,
-                            identifierType: 'DOI'
-                        }
-                    ],
-                    relatedIdentifiers: [...payload.data.attributes.relatedIdentifiers, ...publicationVersionDOIs]
-                });
-            }
-        }
-    }
-
-    return payload;
-};
-
-const createDOI = (payload: Record<string, unknown>): Promise<AxiosResponse<I.DOIResponse>> =>
-    axios.post<I.DOIResponse>(`${process.env.DATACITE_ENDPOINT}`, payload, {
-        auth: {
-            username: process.env.DATACITE_USER as string,
-            password: process.env.DATACITE_PASSWORD as string
-        }
-    });
-
-const createPublicationVersionDOI = async (
-    publicationVersion: I.PublicationVersion,
-    previousPublicationVersionDOI?: string
-): Promise<I.DOIResponse> => {
-    if (!publicationVersion.isLatestVersion) {
-        throw Error('Supplied version is not current');
-    }
-
-    const payload = await createDOIPayload({
-        payloadType: 'newVersion',
-        publicationVersion,
-        previousPublicationVersionDOI
-    });
-
-    const response = await createDOI(payload);
-
-    return response.data;
-};
-
-const updateDOI = (doi: string, payload: Record<string, unknown>): Promise<AxiosResponse<I.DOIResponse>> =>
-    axios.put<I.DOIResponse>(`${process.env.DATACITE_ENDPOINT}/${doi}`, payload, {
-        auth: {
-            username: process.env.DATACITE_USER as string,
-            password: process.env.DATACITE_PASSWORD as string
-        }
-    });
-
 const updatePreviousPublicationVersionDOI = async (
     previousPublicationVersion: I.PublicationVersion,
     newPublicationVersionDOI: string
@@ -987,36 +663,29 @@ const updatePreviousPublicationVersionDOI = async (
         }
     }
 
-    const payload = await createDOIPayload({
+    const payload = await doi.createDOIPayload({
         payloadType: 'previousVersion',
         newPublicationVersionDOI,
         publicationVersion: previousPublicationVersion,
         previousPublicationVersionDOI: previousVersionDoi
     });
 
-    const response = await updateDOI(previousPublicationVersion.doi, payload);
+    const response = await doi.updateDOI(previousPublicationVersion.doi, payload);
 
     return response.data;
-};
-
-const isExemptFromReversioning = (publicationVersion: I.PublicationVersion) => {
-    const isPeerReview = publicationVersion.publication.type === 'PEER_REVIEW';
-    const isARI = publicationVersion.publication.externalSource === 'ARI';
-
-    return isPeerReview || isARI;
 };
 
 // Create a separate DOI for a specific publication version.
 // Returns the updated version with a DOI, or null if this publication doesn't use reversioning,
 // and thus doesn't have versioned DOIs.
-export const generateNewVersionDOI = async (
+const generateNewVersionDOI = async (
     publicationVersion: I.PublicationVersion,
     previousPublicationVersion?: I.PublicationVersion | null
 ) => {
-    if (isExemptFromReversioning(publicationVersion)) {
+    if (Helpers.isPublicationExemptFromReversioning(publicationVersion.publication)) {
         return null;
     } else {
-        const newPublicationVersionDOI = await createPublicationVersionDOI(
+        const newPublicationVersionDOI = await doi.createPublicationVersionDOI(
             publicationVersion,
             previousPublicationVersion?.doi as string
         );
@@ -1037,56 +706,14 @@ export const generateNewVersionDOI = async (
     }
 };
 
-export const updateCanonicalDOI = async (
-    doi: string,
-    latestPublicationVersion: I.PublicationVersion
-): Promise<I.DOIResponse> => {
-    if (!latestPublicationVersion.isLatestVersion) {
-        throw Error('Supplied version is not current');
-    }
-
-    // Unless this is exempt from reversioning (so doesn't get versioned DOIs),
-    // we need to have the DOI of the version so we can reference it in the canonical DOI's metadata.
-    if (!latestPublicationVersion.doi && !isExemptFromReversioning(latestPublicationVersion)) {
-        throw Error("Supplied version doesn't have a valid DOI.");
-    }
-
-    const oldPublicationVersionDOIs: string[] = [];
-
-    if (latestPublicationVersion.versionNumber > 1) {
-        // get all the other versions DOIs for this publication
-        const publication = await publicationService.get(latestPublicationVersion.versionOf);
-
-        if (publication) {
-            publication.versions
-                .filter((version) => version.id !== latestPublicationVersion.id)
-                .forEach((version) => {
-                    if (version.doi) {
-                        oldPublicationVersionDOIs.push(version.doi);
-                    }
-                });
-        }
-    }
-
-    const payload = await createDOIPayload({
-        payloadType: 'canonical',
-        doi,
-        publicationVersion: latestPublicationVersion,
-        oldPublicationVersionDOIs
-    });
-
-    const response = await updateDOI(doi, payload);
-
-    return response.data;
-};
-
 // Actions that run after a version is published (changes status to LIVE).
 // Pulled out to a separate function because things may need to run when something is
 // published immediately (i.e. not going through full drafting workflow) and bypasses the updateStatus function.
 export const postPublishHook = async (publicationVersion: I.PublicationVersion, skipPdfGeneration?: boolean) => {
     try {
-        // Ensure links made from a PEER_REVIEW version point to the latest live version of the target publication.
+        // Tasks specific to peer reviews.
         if (publicationVersion.publication.type === 'PEER_REVIEW') {
+            // Ensure links made from a PEER_REVIEW version point to the latest live version of the target publication.
             const outdatedDraftLinks = await client.prisma.links.findMany({
                 where: {
                     publicationFromId: publicationVersion.versionOf,
@@ -1116,6 +743,8 @@ export const postPublishHook = async (publicationVersion: I.PublicationVersion, 
                     });
                 }
             }
+
+            // Update canonical and version DOI for the reviewed publication to show the ReviewedBy relationship.
         }
 
         // Update "draft" links.
@@ -1155,13 +784,13 @@ export const postPublishHook = async (publicationVersion: I.PublicationVersion, 
 
         let versionWithDOI: I.PublicationVersion | null = null;
 
-        if (!isExemptFromReversioning(publicationVersion)) {
+        if (!Helpers.isPublicationExemptFromReversioning(publicationVersion.publication)) {
             versionWithDOI = await generateNewVersionDOI(publicationVersion, previousVersion);
         }
 
         // Update the canonical DOI with the latest details from this version.
         // If we have a version with a DOI, pass that, but if not just pass one without.
-        await updateCanonicalDOI(publicationVersion.publication.doi, versionWithDOI || publicationVersion);
+        await doi.updateCanonicalDOI(publicationVersion.publication.doi, versionWithDOI || publicationVersion);
 
         // (Re)index publication in opensearch.
         // TODO: remove this extra logging if we don't observe ARI imports stalling here for some time.

--- a/api/src/lib/__tests__/doi.test.ts
+++ b/api/src/lib/__tests__/doi.test.ts
@@ -1,0 +1,160 @@
+import * as doi from 'lib/doi';
+import * as Helpers from 'lib/helpers';
+import * as I from 'interface';
+import * as publicationVersionService from 'publicationVersion/service';
+import * as testUtils from 'lib/testUtils';
+
+describe('Create creator object', () => {
+    const creator1 = {
+        firstName: 'John',
+        lastName: 'Doe',
+        orcid: '0000-0000-0000-0000',
+        affiliations: [
+            {
+                id: 1,
+                affiliationType: 'education',
+                organization: {
+                    name: 'Test University',
+                    address: {
+                        city: 'Somewhere',
+                        country: 'Someland'
+                    },
+                    'disambiguated-organization': {
+                        'disambiguated-organization-identifier': 'test-uni',
+                        'disambiguation-source': 'some-source'
+                    }
+                },
+                createdAt: 123,
+                updatedAt: 234,
+                source: {
+                    name: 'Test Source',
+                    orcid: '0000-0000-0000-0001'
+                }
+            } as I.MappedOrcidAffiliation
+        ],
+        role: 'USER' as I.Role
+    };
+
+    test('Name is abbreviated user name', () => {
+        const creator = doi.createCreatorObject(creator1);
+        expect(creator.name).toEqual(Helpers.abbreviateUserName(creator1));
+    });
+
+    test('Given name is first name', () => {
+        const creator = doi.createCreatorObject(creator1);
+        expect(creator.givenName).toEqual(creator1.firstName);
+    });
+
+    test('Family name is last name', () => {
+        const creator = doi.createCreatorObject(creator1);
+        expect(creator.familyName).toEqual(creator1.lastName);
+    });
+
+    test('Name type is personal if role is not organisation', () => {
+        const creator = doi.createCreatorObject(creator1);
+        expect(creator.nameType).toEqual('Personal');
+    });
+
+    test('Name type is organizational if role is organisation', () => {
+        const creator = doi.createCreatorObject({ ...creator1, role: 'ORGANISATION' });
+        expect(creator.nameType).toEqual('Organizational');
+    });
+
+    test('Name identifier uses orcid', () => {
+        const creator = doi.createCreatorObject(creator1);
+        expect(creator.nameIdentifiers).toEqual([
+            {
+                nameIdentifier: creator1.orcid,
+                nameIdentifierScheme: 'ORCID',
+                schemeUri: 'https://orcid.org/'
+            }
+        ]);
+    });
+
+    test('Name identifier notes when no orcid is present', () => {
+        const creator = doi.createCreatorObject({ ...creator1, orcid: null });
+        expect(creator.nameIdentifiers[0].nameIdentifier).toEqual('ORCID ID not provided');
+    });
+
+    test('Affiliations are listed', () => {
+        const creator = doi.createCreatorObject(creator1);
+        expect(creator.affiliation).toEqual([
+            {
+                name: 'Test University',
+                nameType: 'Organizational',
+                affiliationIdentifier: 'test-uni',
+                affiliationIdentifierScheme: 'some-source'
+            }
+        ]);
+    });
+});
+
+describe('Create full DOI payload', () => {
+    let version: I.PublicationVersion | null;
+
+    beforeAll(async () => {
+        await testUtils.clearDB();
+        await testUtils.testSeed();
+        version = await publicationVersionService.get('publication-problem-live', 'latestLive');
+    });
+
+    // Static fields that are the same for every case.
+    test('Universal fields check', async () => {
+        if (!version) {
+            fail('Could not find publication version');
+        }
+
+        const payload = await doi.createFullDOIPayload({
+            doiType: 'canonical',
+            publicationVersion: version
+        });
+
+        expect(payload).toMatchObject({
+            data: {
+                attributes: {
+                    prefix: process.env.DOI_PREFIX,
+                    event: 'publish',
+                    publisher: 'Octopus'
+                }
+            }
+        });
+    });
+
+    test('Canonical DOI URL points to the publication', async () => {
+        if (!version) {
+            fail('Could not find publication version');
+        }
+
+        const payload = await doi.createFullDOIPayload({
+            doiType: 'canonical',
+            publicationVersion: version
+        });
+
+        expect(payload).toMatchObject({
+            data: {
+                attributes: {
+                    url: Helpers.getPublicationUrl(version.versionOf)
+                }
+            }
+        });
+    });
+
+    test('Version DOI URL points to the version', async () => {
+        if (!version) {
+            fail('Could not find publication version');
+        }
+
+        const payload = await doi.createFullDOIPayload({
+            doiType: 'version',
+            publicationVersion: version
+        });
+
+        expect(payload).toMatchObject({
+            data: {
+                attributes: {
+                    url: `${Helpers.getPublicationUrl(version.versionOf)}/versions/${version.versionNumber}`
+                }
+            }
+        });
+    });
+});

--- a/api/src/lib/doi.ts
+++ b/api/src/lib/doi.ts
@@ -1,0 +1,375 @@
+import axios, { AxiosResponse } from 'axios';
+
+import * as Helpers from 'lib/helpers';
+import * as I from 'interface';
+import * as publicationService from 'publication/service';
+import * as referenceService from 'reference/service';
+
+const createCreatorObject = (user: I.DataCiteUser): I.DataCiteCreator => {
+    return {
+        name: Helpers.abbreviateUserName(user), // datacite expects full name in lastname, firstname order
+        givenName: user?.firstName,
+        familyName: user?.lastName,
+        nameType: user.role === 'ORGANISATION' ? 'Organizational' : 'Personal',
+        nameIdentifiers: [
+            {
+                nameIdentifier: user?.orcid ? user?.orcid : 'ORCID iD not provided',
+                nameIdentifierScheme: 'ORCID',
+                schemeUri: 'https://orcid.org/'
+            }
+        ],
+        affiliation: user.affiliations.map((affiliation) => ({
+            name: affiliation.organization.name,
+            nameType: 'Organizational',
+            affiliationIdentifier:
+                affiliation.organization['disambiguated-organization']?.['disambiguated-organization-identifier'] || '',
+            affiliationIdentifierScheme:
+                affiliation.organization['disambiguated-organization']?.['disambiguation-source'] || ''
+        }))
+    };
+};
+
+const getFullDOIsStrings = (text: string): [] | RegExpMatchArray =>
+    text.match(
+        /(\s+)?(\(|\(\s+)?(?:DOI((\s+)?([:-])?(\s+)?))?(10\.[0-9a-zA-Z]+\/(?:(?!["&\'])\S)+)\b(\)|\s+\))?(\.)?/gi //eslint-disable-line
+    ) || [];
+
+export const createDOIPayload = async (
+    data:
+        | {
+              payloadType: 'canonical';
+              doi: string;
+              publicationVersion: I.PublicationVersion;
+              oldPublicationVersionDOIs: string[];
+          }
+        | {
+              payloadType: 'newVersion';
+              publicationVersion: I.PublicationVersion;
+              previousPublicationVersionDOI?: string;
+          }
+        | {
+              payloadType: 'previousVersion';
+              publicationVersion: I.PublicationVersion;
+              newPublicationVersionDOI: string;
+              previousPublicationVersionDOI?: string;
+          }
+): Promise<Record<string, unknown>> => {
+    const { payloadType, publicationVersion } = data;
+
+    const references = await referenceService.getAllByPublicationVersion(publicationVersion.id);
+    const { linkedTo } = await publicationService.getDirectLinksForPublication(publicationVersion.versionOf, true);
+
+    const creators: I.DataCiteCreator[] = [];
+    publicationVersion.coAuthors.forEach((author) => {
+        if (author.user) {
+            creators.push(
+                createCreatorObject({
+                    firstName: author.user.firstName,
+                    lastName: author.user.lastName,
+                    orcid: author.user.orcid,
+                    affiliations: author.affiliations as unknown as I.MappedOrcidAffiliation[],
+                    role: author.user.role
+                })
+            );
+        }
+    });
+
+    // check if the creator of this version of the publication is not listed as an author
+    if (!publicationVersion.coAuthors.find((author) => author.linkedUser === publicationVersion.createdBy)) {
+        // add creator to authors list as first author
+        creators?.unshift(
+            createCreatorObject({
+                firstName: publicationVersion.user.firstName,
+                lastName: publicationVersion.user.lastName,
+                orcid: publicationVersion.user.orcid,
+                affiliations: [],
+                role: publicationVersion.user.role
+            })
+        );
+    }
+
+    const linkedPublicationDOIs = linkedTo.map((link) => ({
+        relatedIdentifier: link.doi,
+        relatedIdentifierType: 'DOI',
+        relationType: link.type === 'PEER_REVIEW' ? 'Reviews' : 'Continues'
+    }));
+
+    const referenceDOIs = references
+        .filter((reference) => reference.type === 'DOI' && reference.location)
+        .map((reference) => {
+            const doi = getFullDOIsStrings(reference.location as string);
+
+            return {
+                relatedIdentifier: doi[0],
+                relatedIdentifierType: 'DOI',
+                relationType: 'References'
+            };
+        });
+
+    const otherReferences = references
+        .filter((reference) => reference.type !== 'DOI')
+        .map((reference) => {
+            const mutatedReference = {
+                titles: [
+                    {
+                        title: reference.text.replace(/(<([^>]+)>)/gi, '')
+                    }
+                ],
+                relationType: 'References',
+                relatedItemType: 'Other'
+            };
+
+            return reference.location
+                ? {
+                      ...mutatedReference,
+                      relatedItemIdentifier: {
+                          relatedItemIdentifier: reference.location,
+                          relatedItemIdentifierType: 'URL'
+                      }
+                  }
+                : mutatedReference;
+        });
+
+    const additionalInformation = publicationVersion.additionalInformation.map((additionalInfoEntry) => ({
+        titles: [
+            {
+                title: additionalInfoEntry.title
+            }
+        ],
+        relationType: 'HasPart',
+        relatedItemType: 'Other',
+        relatedItemIdentifier: {
+            relatedItemIdentifier: additionalInfoEntry.url,
+            relatedItemIdentifierType: 'URL'
+        }
+    }));
+
+    const payload = {
+        data: {
+            type: 'dois',
+            attributes: {
+                event: 'publish',
+                url:
+                    payloadType === 'canonical'
+                        ? Helpers.getPublicationUrl(publicationVersion.versionOf)
+                        : `${Helpers.getPublicationUrl(publicationVersion.versionOf)}/versions/${
+                              publicationVersion.versionNumber
+                          }`,
+                creators,
+                titles: [
+                    {
+                        title: publicationVersion.title,
+                        lang: 'en'
+                    }
+                ],
+                publisher: 'Octopus',
+                publicationYear: publicationVersion.createdAt.getFullYear(),
+                contributors: [
+                    {
+                        name: Helpers.abbreviateUserName(publicationVersion.user),
+                        contributorType: 'ContactPerson',
+                        nameType: publicationVersion.user.role === 'ORGANISATION' ? 'Organizational' : 'Personal',
+                        givenName: publicationVersion.user.firstName,
+                        familyName: publicationVersion.user.lastName,
+                        nameIdentifiers: [
+                            {
+                                nameIdentifier: publicationVersion.user.orcid,
+                                nameIdentifierScheme: 'ORCID',
+                                schemeUri: 'https://orcid.org/'
+                            }
+                        ]
+                    }
+                ],
+                language: 'en',
+                types: {
+                    resourceTypeGeneral: publicationVersion.publication.type === 'PEER_REVIEW' ? 'PeerReview' : 'Other',
+                    resourceType: publicationVersion.publication.type
+                },
+                relatedIdentifiers: [...linkedPublicationDOIs, ...referenceDOIs],
+                relatedItems: [...otherReferences, ...additionalInformation],
+                fundingReferences: publicationVersion.funders.map((funder) => ({
+                    funderName: funder.name,
+                    funderIdentifier: funder.ror || funder.link,
+                    funderIdentifierType: funder.ror ? 'ROR' : 'Other'
+                }))
+            }
+        }
+    };
+
+    switch (payloadType) {
+        case 'newVersion': {
+            const { previousPublicationVersionDOI } = data;
+
+            const publicationVersionDOIs = [
+                {
+                    relatedIdentifier: publicationVersion.publication.doi,
+                    relatedIdentifierType: 'DOI',
+                    relationType: 'IsVersionOf',
+                    resourceTypeGeneral: payload.data.attributes.types.resourceTypeGeneral
+                }
+            ];
+
+            if (previousPublicationVersionDOI) {
+                publicationVersionDOIs.push({
+                    relatedIdentifier: previousPublicationVersionDOI,
+                    relatedIdentifierType: 'DOI',
+                    relationType: 'IsNewVersionOf',
+                    resourceTypeGeneral: payload.data.attributes.types.resourceTypeGeneral
+                });
+            }
+
+            Object.assign(payload.data.attributes, {
+                prefix: process.env.DOI_PREFIX,
+                relatedIdentifiers: [...payload.data.attributes.relatedIdentifiers, ...publicationVersionDOIs],
+                version: publicationVersion.versionNumber
+            });
+
+            break;
+        }
+
+        case 'previousVersion': {
+            const { newPublicationVersionDOI, previousPublicationVersionDOI } = data;
+
+            const publicationVersionDOIs = [
+                {
+                    relatedIdentifier: publicationVersion.publication.doi,
+                    relatedIdentifierType: 'DOI',
+                    relationType: 'IsVersionOf',
+                    resourceTypeGeneral: payload.data.attributes.types.resourceTypeGeneral
+                },
+                {
+                    relatedIdentifier: newPublicationVersionDOI,
+                    relatedIdentifierType: 'DOI',
+                    relationType: 'IsPreviousVersionOf',
+                    resourceTypeGeneral: payload.data.attributes.types.resourceTypeGeneral
+                }
+            ];
+
+            if (previousPublicationVersionDOI) {
+                publicationVersionDOIs.push({
+                    relatedIdentifier: previousPublicationVersionDOI,
+                    relatedIdentifierType: 'DOI',
+                    relationType: 'IsNewVersionOf',
+                    resourceTypeGeneral: payload.data.attributes.types.resourceTypeGeneral
+                });
+            }
+
+            Object.assign(payload.data.attributes, {
+                relatedIdentifiers: [...payload.data.attributes.relatedIdentifiers, ...publicationVersionDOIs],
+                version: publicationVersion.versionNumber
+            });
+
+            break;
+        }
+
+        default: {
+            // canonical
+            const { oldPublicationVersionDOIs } = data;
+
+            // It's possible there will be no versioned DOIs at all.
+            // Some types of publication only get a canonical DOI. In this case, skip this part.
+            if (oldPublicationVersionDOIs.length || publicationVersion.doi) {
+                const publicationVersionDOIs = [...oldPublicationVersionDOIs, publicationVersion.doi].map((doi) => ({
+                    relatedIdentifier: doi,
+                    relatedIdentifierType: 'DOI',
+                    relationType: 'HasVersion',
+                    resourceTypeGeneral: payload.data.attributes.types.resourceTypeGeneral
+                }));
+
+                Object.assign(payload.data.attributes, {
+                    doi: data.doi,
+                    identifiers: [
+                        {
+                            identifier: `https://doi.org/${data.doi}`,
+                            identifierType: 'DOI'
+                        }
+                    ],
+                    relatedIdentifiers: [...payload.data.attributes.relatedIdentifiers, ...publicationVersionDOIs]
+                });
+            }
+        }
+    }
+
+    return payload;
+};
+
+const createDOI = (payload: Record<string, unknown>): Promise<AxiosResponse<I.DOIResponse>> =>
+    axios.post<I.DOIResponse>(`${process.env.DATACITE_ENDPOINT}`, payload, {
+        auth: {
+            username: process.env.DATACITE_USER as string,
+            password: process.env.DATACITE_PASSWORD as string
+        }
+    });
+
+export const createPublicationVersionDOI = async (
+    publicationVersion: I.PublicationVersion,
+    previousPublicationVersionDOI?: string
+): Promise<I.DOIResponse> => {
+    if (!publicationVersion.isLatestVersion) {
+        throw Error('Supplied version is not current');
+    }
+
+    const payload = await createDOIPayload({
+        payloadType: 'newVersion',
+        publicationVersion,
+        previousPublicationVersionDOI
+    });
+
+    const response = await createDOI(payload);
+
+    return response.data;
+};
+
+export const updateDOI = (doi: string, payload: Record<string, unknown>): Promise<AxiosResponse<I.DOIResponse>> =>
+    axios.put<I.DOIResponse>(`${process.env.DATACITE_ENDPOINT}/${doi}`, payload, {
+        auth: {
+            username: process.env.DATACITE_USER as string,
+            password: process.env.DATACITE_PASSWORD as string
+        }
+    });
+
+export const updateCanonicalDOI = async (
+    doi: string,
+    latestPublicationVersion: I.PublicationVersion
+): Promise<I.DOIResponse> => {
+    if (!latestPublicationVersion.isLatestVersion) {
+        throw Error('Supplied version is not current');
+    }
+
+    // Unless this is exempt from reversioning (so doesn't get versioned DOIs),
+    // we need to have the DOI of the version so we can reference it in the canonical DOI's metadata.
+    if (
+        !latestPublicationVersion.doi &&
+        !Helpers.isPublicationExemptFromReversioning(latestPublicationVersion.publication)
+    ) {
+        throw Error("Supplied version doesn't have a valid DOI.");
+    }
+
+    const oldPublicationVersionDOIs: string[] = [];
+
+    if (latestPublicationVersion.versionNumber > 1) {
+        // get all the other versions DOIs for this publication
+        const publication = await publicationService.get(latestPublicationVersion.versionOf);
+
+        if (publication) {
+            publication.versions
+                .filter((version) => version.id !== latestPublicationVersion.id)
+                .forEach((version) => {
+                    if (version.doi) {
+                        oldPublicationVersionDOIs.push(version.doi);
+                    }
+                });
+        }
+    }
+
+    const payload = await createDOIPayload({
+        payloadType: 'canonical',
+        doi,
+        publicationVersion: latestPublicationVersion,
+        oldPublicationVersionDOIs
+    });
+
+    const response = await updateDOI(doi, payload);
+
+    return response.data;
+};

--- a/api/src/lib/doi.ts
+++ b/api/src/lib/doi.ts
@@ -64,7 +64,7 @@ const getDOIPayload = (attributes: Record<string, unknown>): DOIPayload => ({
     }
 });
 
-const getRelatedIdentifiers = async (
+export const getRelatedIdentifiers = async (
     doiType: DOIType,
     linkedFrom: I.LinkedFromPublication[],
     linkedTo: I.LinkedToPublication[],
@@ -176,17 +176,14 @@ const getRelatedIdentifiers = async (
         if (!Helpers.isPublicationExemptFromReversioning(publication)) {
             // Add "HasVersion" relationship to all version DOIs.
             for (const version of publication.versions) {
-                if (version.currentStatus === 'LIVE')
-                    if (!version.doi) {
-                        throw Error('Live version ' + version.id + ' does not have a DOI');
-                    } else {
-                        relatedIdentifiers.push({
-                            relatedIdentifier: version.doi,
-                            relatedIdentifierType: 'DOI',
-                            relationType: 'HasVersion',
-                            resourceTypeGeneral
-                        });
-                    }
+                if (version.currentStatus === 'LIVE' && version.doi) {
+                    relatedIdentifiers.push({
+                        relatedIdentifier: version.doi,
+                        relatedIdentifierType: 'DOI',
+                        relationType: 'HasVersion',
+                        resourceTypeGeneral
+                    });
+                }
             }
         }
     }

--- a/api/src/lib/doi.ts
+++ b/api/src/lib/doi.ts
@@ -291,11 +291,11 @@ export const createFullDOIPayload = async (data: {
         titles: [
             {
                 title: publicationVersion.title,
-                lang: 'en'
+                lang: publicationVersion.language
             }
         ],
         publisher: 'Octopus',
-        publicationYear: publicationVersion.createdAt.getFullYear(),
+        publicationYear: publicationVersion.publishedDate?.getFullYear(),
         contributors: [
             {
                 name: Helpers.abbreviateUserName(publicationVersion.user),

--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -254,3 +254,12 @@ export const renderLatexInHTMLString = (htmlString: string): string => {
 
     return replaced;
 };
+
+export const isPublicationExemptFromReversioning = <T extends Pick<I.Publication, 'type' | 'externalSource'>>(
+    publication: T
+): boolean => {
+    const isPeerReview = publication.type === 'PEER_REVIEW';
+    const isARI = publication.externalSource === 'ARI';
+
+    return isPeerReview || isARI;
+};


### PR DESCRIPTION
The purpose of this PR was to fix an issue where we were assigning incorrect "relatedIdentifiers" on the payloads we send when creating/updating DOIs. Peer reviews should have a relationship of "Reviews" to their linked publication, but they were set with "Continues". On the other side of the relationship, reviewed publications needed a "IsReviewedBy" relationship to the peer review.

This was harder to write with the code as it was, so I have reworked it quite a bit, moving the code to construct and send different types payloads into its own file and adding test coverage.

---

### Acceptance Criteria:

- Peer reviews include a DOI metadata related item type of “Reviews” linking to the item they review
- When a peer review is published, the DOI metadata for the item it reviews is updated with a “ReviewedBy” related item type linking to the peer review

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

API
![Screenshot 2025-03-17 144051](https://github.com/user-attachments/assets/d3981b6e-7e80-431d-bc77-07888d28f04c)

E2E
![Screenshot 2025-03-17 160047](https://github.com/user-attachments/assets/4d857a77-4cf4-4928-93d1-f42fd7de91f9)

---

### Screenshots:

From a locally published peer reivew, the following is in its DOI record on datacite test:
![Screenshot 2025-03-17 151125](https://github.com/user-attachments/assets/15f4b1f4-49a1-48e3-95db-96df4c68c90a)

The reviewed publication has this in its DOI record:
![Screenshot 2025-03-17 151152](https://github.com/user-attachments/assets/6547f2fa-71c6-4d98-997b-a2d84924e677)
