### PR TITLE
OC-1010: Add trigger to build ECS task docker image automatically

### DIFF
--- a/infra/modules/codepipeline/buildspec/deploy-docker-image.yml
+++ b/infra/modules/codepipeline/buildspec/deploy-docker-image.yml
@@ -16,4 +16,4 @@ phases:
       - echo Pushing docker image...
       - docker push $ACCOUNT_ID.dkr.ecr.$DEFAULT_REGION.amazonaws.com/$PROJECT_NAME-$ENVIRONMENT:$IMAGE_NAME
       - docker push $ACCOUNT_ID.dkr.ecr.$DEFAULT_REGION.amazonaws.com/$PROJECT_NAME-$ENVIRONMENT:$COMMIT_ID
-# Dev work - Comment to trigger build
+# Dev work - Comment to trigger build. Edit

--- a/infra/modules/codepipeline/buildspec/deploy-docker-image.yml
+++ b/infra/modules/codepipeline/buildspec/deploy-docker-image.yml
@@ -16,3 +16,4 @@ phases:
       - echo Pushing docker image...
       - docker push $ACCOUNT_ID.dkr.ecr.$DEFAULT_REGION.amazonaws.com/$PROJECT_NAME-$ENVIRONMENT:$IMAGE_NAME
       - docker push $ACCOUNT_ID.dkr.ecr.$DEFAULT_REGION.amazonaws.com/$PROJECT_NAME-$ENVIRONMENT:$COMMIT_ID
+# Dev work - Comment to trigger build

--- a/infra/modules/codepipeline/buildspec/deploy-docker-image.yml
+++ b/infra/modules/codepipeline/buildspec/deploy-docker-image.yml
@@ -16,4 +16,3 @@ phases:
       - echo Pushing docker image...
       - docker push $ACCOUNT_ID.dkr.ecr.$DEFAULT_REGION.amazonaws.com/$PROJECT_NAME-$ENVIRONMENT:$IMAGE_NAME
       - docker push $ACCOUNT_ID.dkr.ecr.$DEFAULT_REGION.amazonaws.com/$PROJECT_NAME-$ENVIRONMENT:$COMMIT_ID
-# Dev work - Comment to trigger build. Edit again

--- a/infra/modules/codepipeline/buildspec/deploy-docker-image.yml
+++ b/infra/modules/codepipeline/buildspec/deploy-docker-image.yml
@@ -16,4 +16,4 @@ phases:
       - echo Pushing docker image...
       - docker push $ACCOUNT_ID.dkr.ecr.$DEFAULT_REGION.amazonaws.com/$PROJECT_NAME-$ENVIRONMENT:$IMAGE_NAME
       - docker push $ACCOUNT_ID.dkr.ecr.$DEFAULT_REGION.amazonaws.com/$PROJECT_NAME-$ENVIRONMENT:$COMMIT_ID
-# Dev work - Comment to trigger build. Edit
+# Dev work - Comment to trigger build. Edit again

--- a/infra/modules/codepipeline/codepipeline.tf
+++ b/infra/modules/codepipeline/codepipeline.tf
@@ -57,6 +57,22 @@ resource "aws_codepipeline" "docker-image-codepipeline" {
       }
     }
   }
+
+  trigger {
+    provider_type = "CodeStarSourceConnection"
+    git_configuration {
+      source_action_name = "Source"
+      push {
+        branches {
+          includes = [var.environment]
+        }
+        file_paths {
+          # Whenever something to do with the ARI ingest code or this docker container is changed.
+          includes = ["infra/modules/codepipeline/buildspec/deploy-docker-image.yml", "api"]
+        }
+      }
+    }
+  }
 }
 
 data "aws_iam_policy_document" "codepipeline_role_policy" {


### PR DESCRIPTION
The purpose of this PR was to add a trigger to the code pipeline that generates the docker image for the ARI ingest job. We need this so that whenever the code involved in the ARI ingest process changes, the docker container that will run the job will have the latest code and do the job correctly.

Tested by applying these changes to int, with the only difference being the branch that is referred to in the trigger was this development branch. The final code uses the int/prod branches as defined in the terraform `environment` var.

---

### Acceptance Criteria:

A trigger exists that will run the docker build codepipeline when the relevant branch (int or prod) is updated.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated
