### PR TITLE
OC-1034: Allow retain approval flag to be updated via API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ coverage
 
 # Docker
 volume
+
+# Playwright puts things at project root depending on VS code config
+playwright

--- a/api/prisma/migrations/20250401075824_coauthors_retain_approval_flag/migration.sql
+++ b/api/prisma/migrations/20250401075824_coauthors_retain_approval_flag/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "CoAuthors" ADD COLUMN     "retainApproval" BOOLEAN NOT NULL DEFAULT true;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -167,6 +167,7 @@ model CoAuthors {
     code                 String             @default(cuid())
     confirmedCoAuthor    Boolean            @default(false)
     approvalRequested    Boolean            @default(false)
+    retainApproval       Boolean            @default(true)
     linkedUser           String?
     position             Int                @default(0)
     createdAt            DateTime           @default(now())

--- a/api/src/components/coauthor/__tests__/createCoAuthor.test.ts
+++ b/api/src/components/coauthor/__tests__/createCoAuthor.test.ts
@@ -25,7 +25,8 @@ describe('create coauthor', () => {
                     email: 'emailtest@emailtest.com',
                     linkedUser: null,
                     approvalRequested: false,
-                    confirmedCoAuthor: false
+                    confirmedCoAuthor: false,
+                    retainApproval: true
                 }
             ]);
 

--- a/api/src/components/coauthor/__tests__/getCoAuthors.test.ts
+++ b/api/src/components/coauthor/__tests__/getCoAuthors.test.ts
@@ -19,23 +19,27 @@ describe('Get co-authors of a publication version', () => {
                 confirmedCoAuthor: true,
                 linkedUser: 'test-user-5',
                 isIndependent: true,
-                affiliations: []
+                affiliations: [],
+                retainApproval: true
             },
             {
                 id: 'coauthor-test-user-6-problem-draft',
                 email: 'test-user-6@jisc.ac.uk',
                 confirmedCoAuthor: true,
-                linkedUser: 'test-user-6'
+                linkedUser: 'test-user-6',
+                retainApproval: true
             },
             {
                 id: 'coauthor-test-user-7-problem-draft',
                 email: 'test-user-7@jisc.ac.uk',
-                confirmedCoAuthor: false
+                confirmedCoAuthor: false,
+                retainApproval: true
             },
             {
                 id: 'coauthor-test-user-8-problem-draft',
                 email: 'test-user-8@jisc.ac.uk',
-                confirmedCoAuthor: false
+                confirmedCoAuthor: false,
+                retainApproval: true
             }
         ]);
     });

--- a/api/src/components/coauthor/__tests__/updateCoAuthor.test.ts
+++ b/api/src/components/coauthor/__tests__/updateCoAuthor.test.ts
@@ -1,3 +1,4 @@
+import * as client from 'lib/client';
 import * as testUtils from 'lib/testUtils';
 
 describe('Update co-author status', () => {
@@ -48,5 +49,24 @@ describe('Update co-author status', () => {
             });
 
         expect(coAuthor.status).toEqual(403);
+    });
+
+    test('Co-author can choose whether their approval is retained', async () => {
+        const confirmation = await testUtils.agent
+            .patch('/publication-versions/publication-problem-locked-1-v1/coauthor-confirmation')
+            .query({ apiKey: '000000006' })
+            .send({
+                confirm: true,
+                retainApproval: false
+            });
+
+        expect(confirmation.status).toEqual(200);
+        const coAuthor = await client.prisma.coAuthors.findFirst({
+            where: {
+                publicationVersionId: 'publication-problem-locked-1-v1',
+                linkedUser: 'test-user-6'
+            }
+        });
+        expect(coAuthor?.retainApproval).toEqual(false);
     });
 });

--- a/api/src/components/coauthor/schema/updateAll.ts
+++ b/api/src/components/coauthor/schema/updateAll.ts
@@ -23,6 +23,9 @@ const updateAll: I.Schema = {
             approvalRequested: {
                 type: 'boolean'
             },
+            retainApproval: {
+                type: 'boolean'
+            },
             linkedUser: {
                 type: ['string', 'null']
             },

--- a/api/src/components/coauthor/schema/updateConfirmation.ts
+++ b/api/src/components/coauthor/schema/updateConfirmation.ts
@@ -3,6 +3,9 @@ const updateConfirmationSchema = {
     properties: {
         confirm: {
             type: 'boolean'
+        },
+        retainApproval: {
+            type: 'boolean'
         }
     },
     required: ['confirm'],

--- a/api/src/components/coauthor/service.ts
+++ b/api/src/components/coauthor/service.ts
@@ -70,8 +70,6 @@ export const updateAll = async (publicationVersionId: string, authors: I.CoAutho
                 },
                 create: {
                     email: author.email.toLowerCase(),
-                    approvalRequested: false,
-                    confirmedCoAuthor: false,
                     publicationVersionId,
                     position: index
                 },
@@ -158,14 +156,20 @@ export const removeFromPublicationVersion = async (publicationVersionId: string,
     return removeCoAuthor;
 };
 
-export const updateConfirmation = async (publicationVersionId: string, userId: string, confirm: boolean) => {
+export const updateConfirmation = async (
+    publicationVersionId: string,
+    userId: string,
+    confirm: boolean,
+    retainApproval: boolean
+) => {
     const updateCoAuthor = await client.prisma.coAuthors.updateMany({
         where: {
             publicationVersionId,
             linkedUser: userId
         },
         data: {
-            confirmedCoAuthor: confirm
+            confirmedCoAuthor: confirm,
+            retainApproval
         }
     });
     await publicationVersionService.update(publicationVersionId, {

--- a/api/src/components/publicationVersion/service.ts
+++ b/api/src/components/publicationVersion/service.ts
@@ -52,6 +52,7 @@ export const defaultPublicationVersionInclude = {
             publicationVersionId: true,
             confirmedCoAuthor: true,
             approvalRequested: true,
+            retainApproval: true,
             createdAt: true,
             reminderDate: true,
             isIndependent: true,

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -565,6 +565,7 @@ export interface CoAuthor {
     linkedUser: null | string;
     confirmedCoAuthor: boolean;
     approvalRequested: boolean;
+    retainApproval: boolean;
     email: string;
     publicationVersionId: string;
     createdAt?: string;
@@ -605,6 +606,7 @@ export interface ConfirmCoAuthorBody {
 
 export interface ChangeCoAuthorRequestBody {
     confirm: boolean;
+    retainApproval: boolean;
 }
 export interface UpdateCoAuthorPathParams {
     publicationVersionId: string;


### PR DESCRIPTION
The purpose of this PR was to begin the work to allow coauthors to "retain" their approval, once given to a publication.

These first tasks were to:
- Create a DB migration for the new field
- Accept and save it in the updateCoAuthor endpoint, if it's provided
    - This is the endpoint that will be used to update this field
- Return it in some responses that will need it
- Accept it in the updateAll coauthors endpoint

---

### Acceptance Criteria:

- Retain approval flag can be updated via a new or existing co-author endpoint

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

API
![Screenshot 2025-04-01 111216](https://github.com/user-attachments/assets/add029eb-1083-4ce0-8b22-8cb98b8dd838)

E2E

