### PR TITLE
OC-1034-fix: Include confirmedCoAuthor in response for UI

### DIFF
--- a/api/docs/api.yml
+++ b/api/docs/api.yml
@@ -630,6 +630,8 @@ paths:
                                         $ref: "#/components/schemas/CoAuthorId"
                                       linkedUser:
                                         $ref: "#/components/schemas/CoAuthorLinkedUser"
+                                      confirmedCoAuthor:
+                                        $ref: "#/components/schemas/CoAuthorConfirmedCoAuthor"
                                       user:
                                         type: object
                                         properties:

--- a/api/src/components/publicationVersion/service.ts
+++ b/api/src/components/publicationVersion/service.ts
@@ -212,6 +212,7 @@ export const getAllByPublicationIds = async (ids: string[]) => {
                 select: {
                     id: true,
                     linkedUser: true,
+                    confirmedCoAuthor: true,
                     user: {
                         select: {
                             orcid: true,


### PR DESCRIPTION
The purpose of this PR was to add a field to the GET `/publication-versions` response that is required by the UI when rendering the publication card component. This was masked until now because the card component was mocking up an author if the filter statement relying on this field (which would always have been returning an empty array) did not include the corresponding author. As a result the card was not displaying publication authors unless this field was included in the data from the API.

---

### Acceptance Criteria:

Author details are shown on the publication card component.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [x] Documentation updated

---

### Tests:

---

### Screenshots:

Before
![Screenshot 2025-04-09 092924](https://github.com/user-attachments/assets/d952520a-69f6-4fcb-bb0e-9ece4096c1d9)

After
![Screenshot 2025-04-09 092904](https://github.com/user-attachments/assets/2f9d28b1-4216-47d7-912f-37a7087b7562)
