### PR TITLE
OC-1033: Retain approval field against co-authors

### DIFF
--- a/api/prisma/seeds/local/unitTesting/publications.ts
+++ b/api/prisma/seeds/local/unitTesting/publications.ts
@@ -337,7 +337,8 @@ const publicationSeeds: Prisma.PublicationCreateInput[] = [
                             confirmedCoAuthor: true,
                             linkedUser: 'test-user-2',
                             isIndependent: true,
-                            affiliations: []
+                            affiliations: [],
+                            retainApproval: false
                         }
                     ]
                 }
@@ -377,7 +378,7 @@ const publicationSeeds: Prisma.PublicationCreateInput[] = [
                             id: 'coauthor-test-user-6-problem-draft',
                             email: 'test-user-6@jisc.ac.uk',
                             code: 'test-code-user-6',
-                            confirmedCoAuthor: true,
+                            confirmedCoAuthor: false,
                             linkedUser: 'test-user-6'
                         },
                         {
@@ -470,7 +471,8 @@ const publicationSeeds: Prisma.PublicationCreateInput[] = [
                             confirmedCoAuthor: true,
                             linkedUser: 'test-user-6',
                             isIndependent: true,
-                            affiliations: []
+                            affiliations: [],
+                            approvalRequested: true
                         },
                         {
                             id: 'coauthor-test-user-7-problem-locked-1',
@@ -478,7 +480,8 @@ const publicationSeeds: Prisma.PublicationCreateInput[] = [
                             code: 'test-code-user-7',
                             confirmedCoAuthor: false,
                             isIndependent: true,
-                            affiliations: []
+                            affiliations: [],
+                            approvalRequested: true
                         }
                     ]
                 },
@@ -563,7 +566,13 @@ const publicationSeeds: Prisma.PublicationCreateInput[] = [
                 currentStatus: 'DRAFT',
                 keywords: ['science', 'technology'],
                 user: { connect: { id: 'test-user-5' } },
-                publicationStatus: { create: [{ status: 'DRAFT', createdAt: '2022-01-20T15:51:42.523Z' }] },
+                publicationStatus: {
+                    create: [
+                        { status: 'DRAFT', createdAt: '2022-01-20T15:51:42.523Z' },
+                        { status: 'LOCKED', createdAt: '2022-01-20T16:51:42.523Z' },
+                        { status: 'DRAFT', createdAt: '2022-01-20T17:51:42.523Z' }
+                    ]
+                },
                 coAuthors: {
                     create: [
                         {
@@ -576,13 +585,15 @@ const publicationSeeds: Prisma.PublicationCreateInput[] = [
                             id: 'coauthor-test-user-6-hypothesis-draft',
                             email: 'test-user-6@jisc.ac.uk',
                             code: 'test-code-user-6',
-                            confirmedCoAuthor: false,
-                            linkedUser: 'test-user-6'
+                            linkedUser: 'test-user-6',
+                            approvalRequested: true,
+                            retainApproval: false
                         },
                         {
                             id: 'coauthor-test-user-7-hypothesis-draft',
                             email: 'test-user-7@jisc.ac.uk',
-                            code: 'test-code-user-7'
+                            code: 'test-code-user-7',
+                            approvalRequested: true
                         }
                     ]
                 }
@@ -1614,6 +1625,45 @@ const publicationSeeds: Prisma.PublicationCreateInput[] = [
                         }
                     ]
                 }
+            }
+        }
+    },
+    {
+        id: 'publication-method-not-ready-to-lock',
+        doi: '10.82259/cty5-2g36',
+        type: 'PROTOCOL',
+        linkedTo: {
+            create: {
+                publicationToId: 'publication-hypothesis-live',
+                versionToId: 'publication-hypothesis-live-v1',
+                draft: true
+            }
+        },
+        versions: {
+            create: {
+                id: 'publication-method-not-ready-to-lock-v1',
+                versionNumber: 1,
+                title: 'Method (not ready to lock)',
+                conflictOfInterestStatus: true,
+                content: 'Method (not ready to lock)',
+                currentStatus: 'DRAFT',
+                user: { connect: { id: 'test-user-1' } },
+                coAuthors: {
+                    create: [
+                        {
+                            id: 'coauthor-test-user-1-publication-method-not-ready-to-lock-v1',
+                            email: 'test-user-1@jisc.ac.uk',
+                            confirmedCoAuthor: true,
+                            linkedUser: 'test-user-1',
+                            isIndependent: true
+                        },
+                        {
+                            id: 'coauthor-test-user-2-publication-method-not-ready-to-lock-v1',
+                            email: 'test-user-2@jisc.ac.uk'
+                        }
+                    ]
+                },
+                publicationStatus: { create: [{ status: 'DRAFT', createdAt: '2022-01-20T15:51:42.523Z' }] }
             }
         }
     }

--- a/api/src/components/coauthor/__tests__/getCoAuthors.test.ts
+++ b/api/src/components/coauthor/__tests__/getCoAuthors.test.ts
@@ -25,7 +25,7 @@ describe('Get co-authors of a publication version', () => {
             {
                 id: 'coauthor-test-user-6-problem-draft',
                 email: 'test-user-6@jisc.ac.uk',
-                confirmedCoAuthor: true,
+                confirmedCoAuthor: false,
                 linkedUser: 'test-user-6',
                 retainApproval: true
             },

--- a/api/src/components/coauthor/__tests__/requestApproval.test.ts
+++ b/api/src/components/coauthor/__tests__/requestApproval.test.ts
@@ -1,9 +1,20 @@
+import { Prisma } from '@prisma/client';
+import * as client from 'lib/client';
 import * as testUtils from 'lib/testUtils';
 
 describe('Request co-authors approvals', () => {
     beforeEach(async () => {
         await testUtils.clearDB();
         await testUtils.testSeed();
+    });
+
+    test('Cannot request approvals for a non-existent publication version', async () => {
+        const requestApprovals = await testUtils.agent
+            .put('/publication-versions/non-existent-publication-version/coauthors/request-approval')
+            .query({ apiKey: '123456789' });
+
+        expect(requestApprovals.status).toEqual(404);
+        expect(requestApprovals.body.message).toEqual('Publication version not found');
     });
 
     test('Can request approvals only if the publication version is DRAFT or LOCKED', async () => {
@@ -20,12 +31,53 @@ describe('Request co-authors approvals', () => {
         expect(lockedPublicationVersionResponse.status).toEqual(200);
     });
 
+    test('Requesting approval sets approvalRequested field to true', async () => {
+        const coAuthorQuery: Prisma.CoAuthorsFindManyArgs = {
+            where: {
+                publicationVersionId: 'publication-problem-draft-v1',
+                confirmedCoAuthor: false
+            },
+            select: {
+                approvalRequested: true
+            }
+        };
+        const pendingCoAuthors = await client.prisma.coAuthors.findMany(coAuthorQuery);
+        expect(pendingCoAuthors.every((coAuthor) => !coAuthor.approvalRequested)).toBe(true);
+
+        const requestApprovals = await testUtils.agent
+            .put('/publication-versions/publication-problem-draft-v1/coauthors/request-approval')
+            .query({ apiKey: '000000005' });
+
+        expect(requestApprovals.status).toEqual(200);
+
+        const requestedCoAuthors = await client.prisma.coAuthors.findMany(coAuthorQuery);
+        expect(requestedCoAuthors.every((coAuthor) => coAuthor.approvalRequested)).toBe(true);
+    });
+
+    test('Requesting approval sends emails to co-authors', async () => {
+        const requestApprovals = await testUtils.agent
+            .put('/publication-versions/publication-problem-draft-v1/coauthors/request-approval')
+            .query({ apiKey: '000000005' });
+
+        expect(requestApprovals.status).toEqual(200);
+
+        const coAuthorEmails = ['test-user-6@jisc.ac.uk', 'test-user-7@jisc.ac.uk', 'test-user-8@jisc.ac.uk'];
+
+        for (const coAuthorEmail of coAuthorEmails) {
+            const findMail = await testUtils.getEmails(coAuthorEmail);
+            expect(findMail.messages[0].Subject).toContain('You’ve been added as a co-author on Octopus');
+        }
+    });
+
     test('Cannot request approvals for a LIVE publication version', async () => {
         const livePublicationVersionResponse = await testUtils.agent
             .put('/publication-versions/publication-problem-live-v1/coauthors/request-approval')
             .query({ apiKey: '123456789' });
 
         expect(livePublicationVersionResponse.status).toEqual(400);
+        expect(livePublicationVersionResponse.body.message).toEqual(
+            'Cannot request approvals for a LIVE publication version.'
+        );
     });
 
     test('Cannot request approvals if user is not the creator', async () => {
@@ -34,6 +86,9 @@ describe('Request co-authors approvals', () => {
             .query({ apiKey: '000000006' });
 
         expect(draftPublicationVersionResponse.status).toEqual(403);
+        expect(draftPublicationVersionResponse.body.message).toEqual(
+            'You are not allowed to request approvals for this publication version.'
+        );
     });
 
     test('Cannot request approvals if publication has no-coauthors', async () => {
@@ -42,5 +97,30 @@ describe('Request co-authors approvals', () => {
             .query({ apiKey: '987654321' });
 
         expect(draftPublicationVersionResponse.status).toEqual(403);
+        expect(draftPublicationVersionResponse.body.message).toEqual('There is no co-author to request approval from.');
+    });
+
+    test('Cannot request approvals if publication is not ready to be locked', async () => {
+        const draftPublicationVersionResponse = await testUtils.agent
+            .put('/publication-versions/publication-method-not-ready-to-lock-v1/coauthors/request-approval')
+            .query({ apiKey: '123456789' });
+
+        expect(draftPublicationVersionResponse.status).toEqual(403);
+        expect(draftPublicationVersionResponse.body.message).toEqual(
+            'Approval emails cannot be sent because the publication is not ready to be LOCKED. Make sure all fields are filled in.'
+        );
+    });
+
+    test('If publication has previously been locked, coauthor without approval retention receives an email', async () => {
+        const requestApprovals = await testUtils.agent
+            .put('/publication-versions/publication-hypothesis-draft-v1/coauthors/request-approval')
+            .query({ apiKey: '000000005' });
+
+        expect(requestApprovals.status).toEqual(200);
+
+        const findMail = await testUtils.getEmails('test-user-6@jisc.ac.uk');
+        expect(findMail.messages[0].Subject).toContain(
+            'Changes have been made to a publication that you are an author on'
+        );
     });
 });

--- a/api/src/components/coauthor/__tests__/updateAll.test.ts
+++ b/api/src/components/coauthor/__tests__/updateAll.test.ts
@@ -20,7 +20,7 @@ describe('Batch update co-authors', () => {
         {
             id: 'coauthor-test-user-6-problem-draft',
             email: 'test-user-6@jisc.ac.uk',
-            confirmedCoAuthor: true,
+            confirmedCoAuthor: false,
             linkedUser: 'test-user-6',
             retainApproval: true
         },

--- a/api/src/components/coauthor/controller.ts
+++ b/api/src/components/coauthor/controller.ts
@@ -436,13 +436,15 @@ export const requestApproval = async (
                 );
 
                 for (const linkedCoAuthor of linkedCoAuthors) {
-                    await email.notifyCoAuthorsAboutChanges({
-                        coAuthor: { email: linkedCoAuthor.email },
-                        publication: {
-                            title: version.title || '',
-                            url: Helpers.getPublicationUrl(version.versionOf)
-                        }
-                    });
+                    if (!linkedCoAuthor.retainApproval) {
+                        await email.notifyCoAuthorsAboutChanges({
+                            coAuthor: { email: linkedCoAuthor.email },
+                            publication: {
+                                title: version.title || '',
+                                url: Helpers.getPublicationUrl(version.versionOf)
+                            }
+                        });
+                    }
                 }
             }
         }

--- a/api/src/components/coauthor/service.ts
+++ b/api/src/components/coauthor/service.ts
@@ -193,7 +193,7 @@ export const resetCoAuthors = async (publicationVersionId: string) => {
         where: {
             publicationVersionId,
             NOT: {
-                linkedUser: publicationVersion?.createdBy
+                OR: [{ linkedUser: publicationVersion?.createdBy }, { retainApproval: true }]
             }
         },
         data: {

--- a/api/src/components/link/__tests__/miscFunctions.test.ts
+++ b/api/src/components/link/__tests__/miscFunctions.test.ts
@@ -153,7 +153,8 @@ describe('Removing invalid links for a publication', () => {
                         id: true,
                         code: true,
                         confirmedCoAuthor: true,
-                        linkedUser: true
+                        linkedUser: true,
+                        retainApproval: true
                     }
                 },
                 createdBy: true
@@ -167,9 +168,9 @@ describe('Removing invalid links for a publication', () => {
         // Expect the publication to be unlocked.
         expect(fromVersion.currentStatus).toEqual('DRAFT');
 
-        // Expect co-authors to be reset.)
+        // Expect co-authors to be reset if they do not have approval retention set.
         for (const coAuthor of fromVersion.coAuthors) {
-            if (coAuthor.linkedUser !== fromVersion.createdBy) {
+            if (coAuthor.linkedUser !== fromVersion.createdBy && coAuthor.retainApproval === false) {
                 expect(coAuthor.confirmedCoAuthor).toEqual(false);
                 const coAuthorBefore = coAuthorsBefore.find((coAuthorBefore) => coAuthorBefore.id === coAuthor.id);
                 expect(coAuthorBefore).toBeDefined();

--- a/api/src/components/publicationVersion/__tests__/updateStatus.test.ts
+++ b/api/src/components/publicationVersion/__tests__/updateStatus.test.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@prisma/client';
 import * as testUtils from 'lib/testUtils';
 import * as client from 'lib/client';
 
@@ -212,6 +213,19 @@ describe('Update publication version status', () => {
         expect(response.body.message).toEqual('Publication status is already DRAFT.');
     });
 
+    test('Publication status cannot be updated from DRAFT to LOCKED if missing mandatory data', async () => {
+        const updateStatusResponse = await testUtils.agent
+            .put('/publication-versions/publication-method-not-ready-to-lock-v1/status/LOCKED')
+            .query({
+                apiKey: '123456789'
+            });
+
+        expect(updateStatusResponse.status).toEqual(403);
+        expect(updateStatusResponse.body.message).toEqual(
+            'Publication is not ready to be LOCKED. Make sure all fields are filled in.'
+        );
+    });
+
     test('Publication status can be updated from DRAFT to LOCKED only after requesting approvals', async () => {
         // try to update status to LOCKED
         const updateStatusResponse1 = await testUtils.agent
@@ -254,6 +268,84 @@ describe('Update publication version status', () => {
 
         expect(response.status).toEqual(200);
         expect(response.body.message).toEqual('Publication is now LIVE.');
+    });
+
+    test('Publication status can be updated from LOCKED to DRAFT', async () => {
+        const response = await testUtils.agent
+            .put('/publication-versions/publication-problem-locked-1-v1/status/DRAFT')
+            .query({
+                apiKey: '000000005'
+            });
+
+        expect(response.status).toEqual(200);
+        expect(response.body.message).toEqual('Publication unlocked for editing');
+
+        const version = await client.prisma.publicationVersion.findUnique({
+            where: {
+                id: 'publication-problem-locked-1-v1'
+            },
+            select: {
+                currentStatus: true
+            }
+        });
+        expect(version?.currentStatus).toEqual('DRAFT');
+    });
+
+    test('Changing status to DRAFT from LOCKED resets coauthors if they do not have approval retention set', async () => {
+        const response = await testUtils.agent
+            .put('/publication-versions/locked-publication-problem-confirmed-co-authors-v1/status/DRAFT')
+            .query({
+                apiKey: '123456789'
+            });
+
+        expect(response.status).toEqual(200);
+
+        const coAuthors = await client.prisma.coAuthors.findMany({
+            where: {
+                publicationVersionId: 'locked-publication-problem-confirmed-co-authors-v1',
+                retainApproval: false
+            }
+        });
+
+        expect(coAuthors.length).toBeGreaterThan(0);
+        expect(coAuthors.every((coAuthor) => coAuthor.confirmedCoAuthor === false)).toBe(true);
+    });
+
+    test('Changing status to DRAFT from LOCKED does not reset coauthors if they have approval retention set', async () => {
+        const applicableCoAuthorQuery: Prisma.CoAuthorsFindManyArgs = {
+            where: {
+                publicationVersionId: 'publication-problem-locked-1-v1',
+                approvalRequested: true,
+                retainApproval: true,
+                confirmedCoAuthor: true
+            },
+            select: {
+                id: true,
+                code: true,
+                confirmedCoAuthor: true
+            }
+        };
+        const applicableCoAuthorsBefore = await client.prisma.coAuthors.findMany(applicableCoAuthorQuery);
+        expect(applicableCoAuthorsBefore.length).toBeGreaterThan(0);
+
+        const response = await testUtils.agent
+            .put('/publication-versions/publication-problem-locked-1-v1/status/DRAFT')
+            .query({
+                apiKey: '000000005'
+            });
+
+        expect(response.status).toEqual(200);
+
+        const applicableCoAuthorsAfter = await client.prisma.coAuthors.findMany(applicableCoAuthorQuery);
+
+        expect(applicableCoAuthorsAfter.length).toBe(applicableCoAuthorsBefore.length);
+        expect(
+            applicableCoAuthorsAfter.every((coAuthor) => {
+                const oldCoAuthor = applicableCoAuthorsBefore.find((oldCoAuthor) => oldCoAuthor.id === coAuthor.id);
+
+                return coAuthor.confirmedCoAuthor && coAuthor.code === oldCoAuthor?.code;
+            })
+        ).toBe(true);
     });
 
     test('User can publish a new version for an existing publication', async () => {

--- a/api/src/components/user/__tests__/getUserPublications.test.ts
+++ b/api/src/components/user/__tests__/getUserPublications.test.ts
@@ -16,7 +16,6 @@ describe("Get a given user's publications", () => {
             .query({ apiKey: 123456789, offset: 0, limit: 100 });
 
         expect(publications.status).toEqual(200);
-        expect(publications.body.data.length).toEqual(26);
         expect(
             publications.body.data.some(
                 (publication) => publication.versions.some((version) => version.currentStatus === 'DRAFT') as boolean

--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -1256,8 +1256,56 @@ test.describe('Publication flow + co-authors', () => {
         await page.close();
     });
 
-    test('Editing a publication removes existing approvals', async ({ browser }) => {
-        test.slow();
+    // TODO: uncomment these tests once it is possible to disable approval retention with the UI.
+
+    // test('Editing a publication removes existing approvals', async ({ browser }) => {
+    //     test.slow();
+    //     const page = await Helpers.users.getPageAsUser(browser);
+
+    //     await Helpers.publicationCreation.createPublishReadyPublication(page);
+    //     await addCoAuthorsAndRequestApproval(page, [Helpers.users.user2]);
+
+    //     await confirmCoAuthorInvitation(browser, Helpers.users.user2);
+
+    //     await page.reload();
+    //     await expect(page.getByText('All authors have approved this publication').first()).toBeVisible();
+
+    //     await unlockPublication(page);
+
+    //     // Request approval from co author
+    //     await expect(page.locator(PageModel.publish.requestApprovalButton)).toBeEnabled();
+    //     await requestApproval(page);
+
+    //     await expect(page.getByText('Approval Pending')).toBeVisible();
+
+    //     await page.close();
+    // });
+
+    // test('Co-authors are notified if the publication was edited after they confirmed their involvement', async ({
+    //     browser
+    // }) => {
+    //     test.slow();
+    //     const page = await Helpers.users.getPageAsUser(browser);
+
+    //     await Helpers.publicationCreation.createPublishReadyPublication(page);
+    //     await addCoAuthorsAndRequestApproval(page, [Helpers.users.user2]);
+
+    //     await confirmCoAuthorInvitation(browser, Helpers.users.user2);
+
+    //     // unlock and request approvals again
+    //     await unlockPublication(page);
+    //     await requestApproval(page);
+
+    //     await verifyLastEmailNotification(
+    //         browser,
+    //         Helpers.users.user2,
+    //         'Changes have been made to a publication that you are an author on'
+    //     );
+
+    //     await page.close();
+    // });
+
+    test('Co-author approval is retained by default', async ({ browser }) => {
         const page = await Helpers.users.getPageAsUser(browser);
 
         await Helpers.publicationCreation.createPublishReadyPublication(page);
@@ -1270,36 +1318,8 @@ test.describe('Publication flow + co-authors', () => {
 
         await unlockPublication(page);
 
-        // Request approval from co author
-        await expect(page.locator(PageModel.publish.requestApprovalButton)).toBeEnabled();
-        await requestApproval(page);
-
-        await expect(page.getByText('Approval Pending')).toBeVisible();
-
-        await page.close();
-    });
-
-    test('Co-authors are notified if the publication was edited after they confirmed their involvement', async ({
-        browser
-    }) => {
-        test.slow();
-        const page = await Helpers.users.getPageAsUser(browser);
-
-        await Helpers.publicationCreation.createPublishReadyPublication(page);
-        await addCoAuthorsAndRequestApproval(page, [Helpers.users.user2]);
-
-        await confirmCoAuthorInvitation(browser, Helpers.users.user2);
-
-        // unlock and request approvals again
-        await unlockPublication(page);
-        await requestApproval(page);
-
-        await verifyLastEmailNotification(
-            browser,
-            Helpers.users.user2,
-            'Changes have been made to a publication that you are an author on'
-        );
-
+        // Because co-authors have approved, there is no need to re-request approval.
+        await expect(page.locator(PageModel.publish.publishButton)).toBeEnabled();
         await page.close();
     });
 


### PR DESCRIPTION
The purpose of this PR was to add the effects related to the new `retainApproval` coAuthor field.

---

### Acceptance Criteria:

- A retain approval flag is present in the co-authors table (already done in #788)
- The state of this flag is checked to determine the “Publish”/”Request approval” option when the corresponding author is editing a draft, with “Publish” appearing if all co-authors have it set to retain.
    - The flag is not actually checked at this point; rather, it is checked when approval would be unset (in the `resetCoAuthors` function) and prevents unsetting if true.
- The state of the retain approval flag is checked when sending emails to request approval to determine if they should be sent

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

API
![Screenshot 2025-04-09 133358](https://github.com/user-attachments/assets/801610b2-9c72-49ce-8ef1-471a106e568e)

E2E
![Screenshot 2025-04-09 150125](https://github.com/user-attachments/assets/919d9246-4ca0-4ccd-9f4c-7522f9f0da42)

