### PR TITLE
OC-1055: Fix Information Exposure vulnerability

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -38,7 +38,7 @@
                 "katex": "^0.16.21",
                 "luxon": "^3.4.4",
                 "mammoth": "^1.7.0",
-                "next": "^14.2.25",
+                "next": "^14.2.26",
                 "next-nprogress-bar": "^2.3.5",
                 "react": "^18.2.0",
                 "react-beautiful-dnd": "^13.1.1",
@@ -1981,9 +1981,9 @@
             }
         },
         "node_modules/@next/env": {
-            "version": "14.2.25",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.25.tgz",
-            "integrity": "sha512-JnzQ2cExDeG7FxJwqAksZ3aqVJrHjFwZQAEJ9gQZSoEhIow7SNoKZzju/AwQ+PLIR4NY8V0rhcVozx/2izDO0w==",
+            "version": "14.2.28",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.28.tgz",
+            "integrity": "sha512-PAmWhJfJQlP+kxZwCjrVd9QnR5x0R3u0mTXTiZDgSd4h5LdXmjxCCWbN9kq6hkZBOax8Rm3xDW5HagWyJuT37g==",
             "license": "MIT"
         },
         "node_modules/@next/eslint-plugin-next": {
@@ -2046,9 +2046,9 @@
             }
         },
         "node_modules/@next/swc-darwin-arm64": {
-            "version": "14.2.25",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.25.tgz",
-            "integrity": "sha512-09clWInF1YRd6le00vt750s3m7SEYNehz9C4PUcSu3bAdCTpjIV4aTYQZ25Ehrr83VR1rZeqtKUPWSI7GfuKZQ==",
+            "version": "14.2.28",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.28.tgz",
+            "integrity": "sha512-kzGChl9setxYWpk3H6fTZXXPFFjg7urptLq5o5ZgYezCrqlemKttwMT5iFyx/p1e/JeglTwDFRtb923gTJ3R1w==",
             "cpu": [
                 "arm64"
             ],
@@ -2062,9 +2062,9 @@
             }
         },
         "node_modules/@next/swc-darwin-x64": {
-            "version": "14.2.25",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.25.tgz",
-            "integrity": "sha512-V+iYM/QR+aYeJl3/FWWU/7Ix4b07ovsQ5IbkwgUK29pTHmq+5UxeDr7/dphvtXEq5pLB/PucfcBNh9KZ8vWbug==",
+            "version": "14.2.28",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.28.tgz",
+            "integrity": "sha512-z6FXYHDJlFOzVEOiiJ/4NG8aLCeayZdcRSMjPDysW297Up6r22xw6Ea9AOwQqbNsth8JNgIK8EkWz2IDwaLQcw==",
             "cpu": [
                 "x64"
             ],
@@ -2078,9 +2078,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "14.2.25",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.25.tgz",
-            "integrity": "sha512-LFnV2899PJZAIEHQ4IMmZIgL0FBieh5keMnriMY1cK7ompR+JUd24xeTtKkcaw8QmxmEdhoE5Mu9dPSuDBgtTg==",
+            "version": "14.2.28",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.28.tgz",
+            "integrity": "sha512-9ARHLEQXhAilNJ7rgQX8xs9aH3yJSj888ssSjJLeldiZKR4D7N08MfMqljk77fAwZsWwsrp8ohHsMvurvv9liQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2094,9 +2094,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "14.2.25",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.25.tgz",
-            "integrity": "sha512-QC5y5PPTmtqFExcKWKYgUNkHeHE/z3lUsu83di488nyP0ZzQ3Yse2G6TCxz6nNsQwgAx1BehAJTZez+UQxzLfw==",
+            "version": "14.2.28",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.28.tgz",
+            "integrity": "sha512-p6gvatI1nX41KCizEe6JkF0FS/cEEF0u23vKDpl+WhPe/fCTBeGkEBh7iW2cUM0rvquPVwPWdiUR6Ebr/kQWxQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2110,9 +2110,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-gnu": {
-            "version": "14.2.25",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.25.tgz",
-            "integrity": "sha512-y6/ML4b9eQ2D/56wqatTJN5/JR8/xdObU2Fb1RBidnrr450HLCKr6IJZbPqbv7NXmje61UyxjF5kvSajvjye5w==",
+            "version": "14.2.28",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.28.tgz",
+            "integrity": "sha512-nsiSnz2wO6GwMAX2o0iucONlVL7dNgKUqt/mDTATGO2NY59EO/ZKnKEr80BJFhuA5UC1KZOMblJHWZoqIJddpA==",
             "cpu": [
                 "x64"
             ],
@@ -2126,9 +2126,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-musl": {
-            "version": "14.2.25",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.25.tgz",
-            "integrity": "sha512-sPX0TSXHGUOZFvv96GoBXpB3w4emMqKeMgemrSxI7A6l55VBJp/RKYLwZIB9JxSqYPApqiREaIIap+wWq0RU8w==",
+            "version": "14.2.28",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.28.tgz",
+            "integrity": "sha512-+IuGQKoI3abrXFqx7GtlvNOpeExUH1mTIqCrh1LGFf8DnlUcTmOOCApEnPJUSLrSbzOdsF2ho2KhnQoO0I1RDw==",
             "cpu": [
                 "x64"
             ],
@@ -2142,9 +2142,9 @@
             }
         },
         "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "14.2.25",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.25.tgz",
-            "integrity": "sha512-ReO9S5hkA1DU2cFCsGoOEp7WJkhFzNbU/3VUF6XxNGUCQChyug6hZdYL/istQgfT/GWE6PNIg9cm784OI4ddxQ==",
+            "version": "14.2.28",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.28.tgz",
+            "integrity": "sha512-l61WZ3nevt4BAnGksUVFKy2uJP5DPz2E0Ma/Oklvo3sGj9sw3q7vBWONFRgz+ICiHpW5mV+mBrkB3XEubMrKaA==",
             "cpu": [
                 "arm64"
             ],
@@ -2158,9 +2158,9 @@
             }
         },
         "node_modules/@next/swc-win32-ia32-msvc": {
-            "version": "14.2.25",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.25.tgz",
-            "integrity": "sha512-DZ/gc0o9neuCDyD5IumyTGHVun2dCox5TfPQI/BJTYwpSNYM3CZDI4i6TOdjeq1JMo+Ug4kPSMuZdwsycwFbAw==",
+            "version": "14.2.28",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.28.tgz",
+            "integrity": "sha512-+Kcp1T3jHZnJ9v9VTJ/yf1t/xmtFAc/Sge4v7mVc1z+NYfYzisi8kJ9AsY8itbgq+WgEwMtOpiLLJsUy2qnXZw==",
             "cpu": [
                 "ia32"
             ],
@@ -2174,9 +2174,9 @@
             }
         },
         "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "14.2.25",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.25.tgz",
-            "integrity": "sha512-KSznmS6eFjQ9RJ1nEc66kJvtGIL1iZMYmGEXsZPh2YtnLtqrgdVvKXJY2ScjjoFnG6nGLyPFR0UiEvDwVah4Tw==",
+            "version": "14.2.28",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.28.tgz",
+            "integrity": "sha512-1gCmpvyhz7DkB1srRItJTnmR2UwQPAUXXIg9r0/56g3O8etGmwlX68skKXJOp9EejW3hhv7nSQUJ2raFiz4MoA==",
             "cpu": [
                 "x64"
             ],
@@ -11384,12 +11384,12 @@
             }
         },
         "node_modules/next": {
-            "version": "14.2.25",
-            "resolved": "https://registry.npmjs.org/next/-/next-14.2.25.tgz",
-            "integrity": "sha512-N5M7xMc4wSb4IkPvEV5X2BRRXUmhVHNyaXwEM86+voXthSZz8ZiRyQW4p9mwAoAPIm6OzuVZtn7idgEJeAJN3Q==",
+            "version": "14.2.28",
+            "resolved": "https://registry.npmjs.org/next/-/next-14.2.28.tgz",
+            "integrity": "sha512-QLEIP/kYXynIxtcKB6vNjtWLVs3Y4Sb+EClTC/CSVzdLD1gIuItccpu/n1lhmduffI32iPGEK2cLLxxt28qgYA==",
             "license": "MIT",
             "dependencies": {
-                "@next/env": "14.2.25",
+                "@next/env": "14.2.28",
                 "@swc/helpers": "0.5.5",
                 "busboy": "1.6.0",
                 "caniuse-lite": "^1.0.30001579",
@@ -11404,15 +11404,15 @@
                 "node": ">=18.17.0"
             },
             "optionalDependencies": {
-                "@next/swc-darwin-arm64": "14.2.25",
-                "@next/swc-darwin-x64": "14.2.25",
-                "@next/swc-linux-arm64-gnu": "14.2.25",
-                "@next/swc-linux-arm64-musl": "14.2.25",
-                "@next/swc-linux-x64-gnu": "14.2.25",
-                "@next/swc-linux-x64-musl": "14.2.25",
-                "@next/swc-win32-arm64-msvc": "14.2.25",
-                "@next/swc-win32-ia32-msvc": "14.2.25",
-                "@next/swc-win32-x64-msvc": "14.2.25"
+                "@next/swc-darwin-arm64": "14.2.28",
+                "@next/swc-darwin-x64": "14.2.28",
+                "@next/swc-linux-arm64-gnu": "14.2.28",
+                "@next/swc-linux-arm64-musl": "14.2.28",
+                "@next/swc-linux-x64-gnu": "14.2.28",
+                "@next/swc-linux-x64-musl": "14.2.28",
+                "@next/swc-win32-arm64-msvc": "14.2.28",
+                "@next/swc-win32-ia32-msvc": "14.2.28",
+                "@next/swc-win32-x64-msvc": "14.2.28"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.1.0",
@@ -16816,9 +16816,9 @@
             }
         },
         "@next/env": {
-            "version": "14.2.25",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.25.tgz",
-            "integrity": "sha512-JnzQ2cExDeG7FxJwqAksZ3aqVJrHjFwZQAEJ9gQZSoEhIow7SNoKZzju/AwQ+PLIR4NY8V0rhcVozx/2izDO0w=="
+            "version": "14.2.28",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.28.tgz",
+            "integrity": "sha512-PAmWhJfJQlP+kxZwCjrVd9QnR5x0R3u0mTXTiZDgSd4h5LdXmjxCCWbN9kq6hkZBOax8Rm3xDW5HagWyJuT37g=="
         },
         "@next/eslint-plugin-next": {
             "version": "14.2.25",
@@ -16863,57 +16863,57 @@
             }
         },
         "@next/swc-darwin-arm64": {
-            "version": "14.2.25",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.25.tgz",
-            "integrity": "sha512-09clWInF1YRd6le00vt750s3m7SEYNehz9C4PUcSu3bAdCTpjIV4aTYQZ25Ehrr83VR1rZeqtKUPWSI7GfuKZQ==",
+            "version": "14.2.28",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.28.tgz",
+            "integrity": "sha512-kzGChl9setxYWpk3H6fTZXXPFFjg7urptLq5o5ZgYezCrqlemKttwMT5iFyx/p1e/JeglTwDFRtb923gTJ3R1w==",
             "optional": true
         },
         "@next/swc-darwin-x64": {
-            "version": "14.2.25",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.25.tgz",
-            "integrity": "sha512-V+iYM/QR+aYeJl3/FWWU/7Ix4b07ovsQ5IbkwgUK29pTHmq+5UxeDr7/dphvtXEq5pLB/PucfcBNh9KZ8vWbug==",
+            "version": "14.2.28",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.28.tgz",
+            "integrity": "sha512-z6FXYHDJlFOzVEOiiJ/4NG8aLCeayZdcRSMjPDysW297Up6r22xw6Ea9AOwQqbNsth8JNgIK8EkWz2IDwaLQcw==",
             "optional": true
         },
         "@next/swc-linux-arm64-gnu": {
-            "version": "14.2.25",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.25.tgz",
-            "integrity": "sha512-LFnV2899PJZAIEHQ4IMmZIgL0FBieh5keMnriMY1cK7ompR+JUd24xeTtKkcaw8QmxmEdhoE5Mu9dPSuDBgtTg==",
+            "version": "14.2.28",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.28.tgz",
+            "integrity": "sha512-9ARHLEQXhAilNJ7rgQX8xs9aH3yJSj888ssSjJLeldiZKR4D7N08MfMqljk77fAwZsWwsrp8ohHsMvurvv9liQ==",
             "optional": true
         },
         "@next/swc-linux-arm64-musl": {
-            "version": "14.2.25",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.25.tgz",
-            "integrity": "sha512-QC5y5PPTmtqFExcKWKYgUNkHeHE/z3lUsu83di488nyP0ZzQ3Yse2G6TCxz6nNsQwgAx1BehAJTZez+UQxzLfw==",
+            "version": "14.2.28",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.28.tgz",
+            "integrity": "sha512-p6gvatI1nX41KCizEe6JkF0FS/cEEF0u23vKDpl+WhPe/fCTBeGkEBh7iW2cUM0rvquPVwPWdiUR6Ebr/kQWxQ==",
             "optional": true
         },
         "@next/swc-linux-x64-gnu": {
-            "version": "14.2.25",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.25.tgz",
-            "integrity": "sha512-y6/ML4b9eQ2D/56wqatTJN5/JR8/xdObU2Fb1RBidnrr450HLCKr6IJZbPqbv7NXmje61UyxjF5kvSajvjye5w==",
+            "version": "14.2.28",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.28.tgz",
+            "integrity": "sha512-nsiSnz2wO6GwMAX2o0iucONlVL7dNgKUqt/mDTATGO2NY59EO/ZKnKEr80BJFhuA5UC1KZOMblJHWZoqIJddpA==",
             "optional": true
         },
         "@next/swc-linux-x64-musl": {
-            "version": "14.2.25",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.25.tgz",
-            "integrity": "sha512-sPX0TSXHGUOZFvv96GoBXpB3w4emMqKeMgemrSxI7A6l55VBJp/RKYLwZIB9JxSqYPApqiREaIIap+wWq0RU8w==",
+            "version": "14.2.28",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.28.tgz",
+            "integrity": "sha512-+IuGQKoI3abrXFqx7GtlvNOpeExUH1mTIqCrh1LGFf8DnlUcTmOOCApEnPJUSLrSbzOdsF2ho2KhnQoO0I1RDw==",
             "optional": true
         },
         "@next/swc-win32-arm64-msvc": {
-            "version": "14.2.25",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.25.tgz",
-            "integrity": "sha512-ReO9S5hkA1DU2cFCsGoOEp7WJkhFzNbU/3VUF6XxNGUCQChyug6hZdYL/istQgfT/GWE6PNIg9cm784OI4ddxQ==",
+            "version": "14.2.28",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.28.tgz",
+            "integrity": "sha512-l61WZ3nevt4BAnGksUVFKy2uJP5DPz2E0Ma/Oklvo3sGj9sw3q7vBWONFRgz+ICiHpW5mV+mBrkB3XEubMrKaA==",
             "optional": true
         },
         "@next/swc-win32-ia32-msvc": {
-            "version": "14.2.25",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.25.tgz",
-            "integrity": "sha512-DZ/gc0o9neuCDyD5IumyTGHVun2dCox5TfPQI/BJTYwpSNYM3CZDI4i6TOdjeq1JMo+Ug4kPSMuZdwsycwFbAw==",
+            "version": "14.2.28",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.28.tgz",
+            "integrity": "sha512-+Kcp1T3jHZnJ9v9VTJ/yf1t/xmtFAc/Sge4v7mVc1z+NYfYzisi8kJ9AsY8itbgq+WgEwMtOpiLLJsUy2qnXZw==",
             "optional": true
         },
         "@next/swc-win32-x64-msvc": {
-            "version": "14.2.25",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.25.tgz",
-            "integrity": "sha512-KSznmS6eFjQ9RJ1nEc66kJvtGIL1iZMYmGEXsZPh2YtnLtqrgdVvKXJY2ScjjoFnG6nGLyPFR0UiEvDwVah4Tw==",
+            "version": "14.2.28",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.28.tgz",
+            "integrity": "sha512-1gCmpvyhz7DkB1srRItJTnmR2UwQPAUXXIg9r0/56g3O8etGmwlX68skKXJOp9EejW3hhv7nSQUJ2raFiz4MoA==",
             "optional": true
         },
         "@noble/hashes": {
@@ -23681,20 +23681,20 @@
             "dev": true
         },
         "next": {
-            "version": "14.2.25",
-            "resolved": "https://registry.npmjs.org/next/-/next-14.2.25.tgz",
-            "integrity": "sha512-N5M7xMc4wSb4IkPvEV5X2BRRXUmhVHNyaXwEM86+voXthSZz8ZiRyQW4p9mwAoAPIm6OzuVZtn7idgEJeAJN3Q==",
+            "version": "14.2.28",
+            "resolved": "https://registry.npmjs.org/next/-/next-14.2.28.tgz",
+            "integrity": "sha512-QLEIP/kYXynIxtcKB6vNjtWLVs3Y4Sb+EClTC/CSVzdLD1gIuItccpu/n1lhmduffI32iPGEK2cLLxxt28qgYA==",
             "requires": {
-                "@next/env": "14.2.25",
-                "@next/swc-darwin-arm64": "14.2.25",
-                "@next/swc-darwin-x64": "14.2.25",
-                "@next/swc-linux-arm64-gnu": "14.2.25",
-                "@next/swc-linux-arm64-musl": "14.2.25",
-                "@next/swc-linux-x64-gnu": "14.2.25",
-                "@next/swc-linux-x64-musl": "14.2.25",
-                "@next/swc-win32-arm64-msvc": "14.2.25",
-                "@next/swc-win32-ia32-msvc": "14.2.25",
-                "@next/swc-win32-x64-msvc": "14.2.25",
+                "@next/env": "14.2.28",
+                "@next/swc-darwin-arm64": "14.2.28",
+                "@next/swc-darwin-x64": "14.2.28",
+                "@next/swc-linux-arm64-gnu": "14.2.28",
+                "@next/swc-linux-arm64-musl": "14.2.28",
+                "@next/swc-linux-x64-gnu": "14.2.28",
+                "@next/swc-linux-x64-musl": "14.2.28",
+                "@next/swc-win32-arm64-msvc": "14.2.28",
+                "@next/swc-win32-ia32-msvc": "14.2.28",
+                "@next/swc-win32-x64-msvc": "14.2.28",
                 "@swc/helpers": "0.5.5",
                 "busboy": "1.6.0",
                 "caniuse-lite": "^1.0.30001579",

--- a/ui/package.json
+++ b/ui/package.json
@@ -56,7 +56,7 @@
         "katex": "^0.16.21",
         "luxon": "^3.4.4",
         "mammoth": "^1.7.0",
-        "next": "^14.2.25",
+        "next": "^14.2.26",
         "next-nprogress-bar": "^2.3.5",
         "react": "^18.2.0",
         "react-beautiful-dnd": "^13.1.1",


### PR DESCRIPTION
The purpose of this PR was to fix an information exposure vulnerability in nextJS < 14.2.26.

---

### Acceptance Criteria:

NextJS is installed at 14.2.26 or higher.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
![Screenshot 2025-04-22 092329](https://github.com/user-attachments/assets/cc41d9bd-e494-488b-a136-b0dd5029d438)
This test is also failing on main with the previous version of nextJS, so this change hasn't broken the test - it needs to be looked into separately why it's failing.

E2E
![Screenshot 2025-04-15 154914](https://github.com/user-attachments/assets/bdee1f8a-1a86-4a8b-820d-101a881a6aa3)

