### PR TITLE
OC-1056: Strikethrough resolved red flags on account page and add red flag list logging

### DIFF
--- a/ui/src/components/Search/PaginatedResults/index.tsx
+++ b/ui/src/components/Search/PaginatedResults/index.tsx
@@ -16,6 +16,7 @@ type Props = {
     total: number;
 };
 const PaginatedResults: React.FC<Props> = (props: Props) => {
+    console.log('Results in PaginatedResults', props.results);
     const articleId = useId();
     const upperPageBound = props.limit + props.offset > props.total ? props.total : props.limit + props.offset;
     const scrollToTop = () =>


### PR DESCRIPTION
The purpose of this PR was to add some logging to help diagnose issues that occur with the red flag list on the author page on deployed environments, and to put in place a missed AC from a previous ticket where resolved flag results should have the flag details struck through.

---

### Acceptance Criteria:

- Logging is in place to help debug erroneous flag result sets in the UI
- Resolved flag results have the flag details struck through with " (Resolved)" added afterwards

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

E2E
![Screenshot 2025-04-22 121011](https://github.com/user-attachments/assets/0ed092e8-b1c1-4192-bbdf-4c8fedc20e60)

---

### Screenshots:

![Screenshot 2025-04-22 100455](https://github.com/user-attachments/assets/189add54-4b75-45f1-bc39-1be2447ab4f4)
