### PR TITLE
OC-1050: Set up RDS metric alarms

### DIFF
--- a/infra/create-app/main.tf
+++ b/infra/create-app/main.tf
@@ -64,9 +64,10 @@ module "ses" {
 }
 
 module "sqs" {
-  source      = "../modules/sqs"
-  sns_arn     = module.sns.arn
-  environment = local.environment
+  source       = "../modules/sqs"
+  sns_arn      = module.sns.topic_arn
+  environment  = local.environment
+  project_name = local.project_name
 }
 
 module "sns" {
@@ -110,4 +111,12 @@ module "codepipeline" {
   source       = "../modules/codepipeline"
   environment  = local.environment
   project_name = local.project_name
+}
+
+module "cloudwatch_alarms" {
+  source                  = "../modules/cloudwatch-alarms"
+  environment             = local.environment
+  project_name            = local.project_name
+  notification_topic_arn  = module.sns.topic_arn
+  rds_instance_identifier = module.postgres.rds_instance_identifier
 }

--- a/infra/modules/cloudwatch-alarms/main.tf
+++ b/infra/modules/cloudwatch-alarms/main.tf
@@ -1,0 +1,57 @@
+locals {
+  alarm_namespace = "${var.project_name}/RDS"
+}
+
+resource "aws_cloudwatch_log_metric_filter" "rds_log_filter" {
+  name           = "rds-used-percent-${var.environment}-${var.project_name}"
+  pattern        = "{$.instanceID=\"${var.rds_instance_identifier}\" && $.fileSys[0].usedPercent=*}"
+  log_group_name = "RDSOSMetrics"
+
+  metric_transformation {
+    name      = "RDSUsedPercent"
+    namespace = local.alarm_namespace
+    value     = "$.fileSys[0].usedPercent"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "rds_90_percent" {
+  alarm_name          = "rds-used-90-percent-${var.environment}-${var.project_name}"
+  comparison_operator = "GreaterThanThreshold"
+  alarm_description   = "RDS storage space used is above 90%"
+  evaluation_periods  = 1
+  metric_name         = aws_cloudwatch_log_metric_filter.rds_log_filter.metric_transformation[0].name
+  namespace           = local.alarm_namespace
+  statistic           = "Average"
+  threshold           = 90
+  period              = 60
+  alarm_actions       = [var.notification_topic_arn]
+  ok_actions          = [var.notification_topic_arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "rds_95_percent" {
+  alarm_name          = "rds-used-95-percent-${var.environment}-${var.project_name}"
+  comparison_operator = "GreaterThanThreshold"
+  alarm_description   = "RDS storage space used is above 95%"
+  evaluation_periods  = 1
+  metric_name         = aws_cloudwatch_log_metric_filter.rds_log_filter.metric_transformation[0].name
+  namespace           = local.alarm_namespace
+  statistic           = "Average"
+  threshold           = 95
+  period              = 60
+  alarm_actions       = [var.notification_topic_arn]
+  ok_actions          = [var.notification_topic_arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "rds_99_percent" {
+  alarm_name          = "rds-used-99-percent-${var.environment}-${var.project_name}"
+  comparison_operator = "GreaterThanThreshold"
+  alarm_description   = "RDS storage space used is above 99%"
+  evaluation_periods  = 1
+  metric_name         = aws_cloudwatch_log_metric_filter.rds_log_filter.metric_transformation[0].name
+  namespace           = local.alarm_namespace
+  statistic           = "Average"
+  threshold           = 99
+  period              = 60
+  alarm_actions       = [var.notification_topic_arn]
+  ok_actions          = [var.notification_topic_arn]
+}

--- a/infra/modules/cloudwatch-alarms/vars.tf
+++ b/infra/modules/cloudwatch-alarms/vars.tf
@@ -1,0 +1,15 @@
+variable "project_name" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "notification_topic_arn" {
+  type = string
+}
+
+variable "rds_instance_identifier" {
+  type = string
+}

--- a/infra/modules/postgres/outputs.tf
+++ b/infra/modules/postgres/outputs.tf
@@ -1,0 +1,3 @@
+output "rds_instance_identifier" {
+  value = aws_db_instance.rds.identifier
+}

--- a/infra/modules/sns/main.tf
+++ b/infra/modules/sns/main.tf
@@ -2,8 +2,8 @@ data "aws_ssm_parameter" "slack_channel_email" {
   name = "slack_channel_email_${var.environment}_${var.project_name}"
 }
 
-resource "aws_sns_topic" "pdf-queue-dlq-messages-topic" {
-  name            = "pdf-queue-dlq-messages-topic-${var.environment}"
+resource "aws_sns_topic" "dev-team-messages-topic" {
+  name            = "dev-team-messages-topic-${var.environment}"
   delivery_policy = <<EOF
 {
   "http": {
@@ -27,7 +27,7 @@ EOF
 
 
 resource "aws_sns_topic_subscription" "notify-slack-dlq" {
-  topic_arn = aws_sns_topic.pdf-queue-dlq-messages-topic.arn
+  topic_arn = aws_sns_topic.dev-team-messages-topic.arn
   protocol  = "email"
   endpoint  = data.aws_ssm_parameter.slack_channel_email.value
 }

--- a/infra/modules/sns/outputs.tf
+++ b/infra/modules/sns/outputs.tf
@@ -1,3 +1,3 @@
-output "arn" {
-  value = aws_sns_topic.pdf-queue-dlq-messages-topic.arn
+output "topic_arn" {
+  value = aws_sns_topic.dev-team-messages-topic.arn
 }

--- a/infra/modules/sqs/main.tf
+++ b/infra/modules/sqs/main.tf
@@ -1,5 +1,5 @@
-resource "aws_sqs_queue" "science-octopus-pdf-queue" {
-  name = "science-octopus-pdf-queue-${var.environment}"
+resource "aws_sqs_queue" "pdf-generation-queue" {
+  name = "pdf-generation-queue-${var.environment}-${var.project_name}"
 
   visibility_timeout_seconds = 30
   delay_seconds              = 0
@@ -9,19 +9,19 @@ resource "aws_sqs_queue" "science-octopus-pdf-queue" {
   sqs_managed_sse_enabled    = (var.environment == "prod")
 
   redrive_policy = jsonencode({
-    deadLetterTargetArn = aws_sqs_queue.science-octopus-pdf-queue-dlq.arn
+    deadLetterTargetArn = aws_sqs_queue.pdf-generation-dlq.arn
     maxReceiveCount     = 1
   })
 
 }
 
-resource "aws_sqs_queue" "science-octopus-pdf-queue-dlq" {
-  name                    = "science-octopus-pdf-queue-dlq-${var.environment}"
+resource "aws_sqs_queue" "pdf-generation-dlq" {
+  name                    = "pdf-generation-dlq-${var.environment}-${var.project_name}"
   sqs_managed_sse_enabled = (var.environment == "prod")
 }
 
 resource "aws_cloudwatch_metric_alarm" "dlq-messages-sent-alarm" {
-  alarm_name          = "science-octopus-pdf-dlq-messages-sent-alarm-${var.environment}"
+  alarm_name          = "pdf-generation-dlq-messages-sent-alarm-${var.environment}-${var.project_name}"
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
   metric_name         = "ApproximateNumberOfMessagesVisible"
@@ -33,7 +33,7 @@ resource "aws_cloudwatch_metric_alarm" "dlq-messages-sent-alarm" {
   alarm_actions       = [var.sns_arn]
 
   dimensions = {
-    QueueName = aws_sqs_queue.science-octopus-pdf-queue-dlq.name
+    QueueName = aws_sqs_queue.pdf-generation-dlq.name
   }
 
 }

--- a/infra/modules/sqs/vars.tf
+++ b/infra/modules/sqs/vars.tf
@@ -5,3 +5,7 @@ variable "sns_arn" {
 variable "environment" {
   type = string
 }
+
+variable "project_name" {
+  type = string
+}


### PR DESCRIPTION
The purpose of this PR was to set up alarms that will email the dev team when RDS space usage is above a certain level. This will allow us to downsize the database instance with more confidence because we will know when it is approaching full usage and can upsize it again when needed.

Confirmed that emails are received by lowering the alarm threshold for a rule to 0% (caused ALARM state email) and back to normal (caused OK state email).

---

### Acceptance Criteria:

Cloudwatch alarms are in place that alert the octopus notifications slack channel when RDS usage is above a certain level.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

Only infra code changed.
