### PR TITLE
OC-1051: Display only first author on browse page tiles

### DIFF
--- a/ui/src/__tests__/components/Publication/Card.test.tsx
+++ b/ui/src/__tests__/components/Publication/Card.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+
+import * as Components from '@/components';
+import * as Config from '@/config';
+import * as Helpers from '@/helpers';
+import * as TestUtils from '@/testUtils';
+
+describe('Publication card', () => {
+    beforeEach(() => {
+        render(<Components.PublicationCard publicationVersion={TestUtils.testPublicationVersion} />);
+    });
+    it('Title is shown', () => {
+        expect(screen.getByText(TestUtils.testPublicationVersion.title)).toBeInTheDocument();
+    });
+    it('Abbreviated author name is shown', () => {
+        expect(
+            screen.getByText(Helpers.abbreviateUserName(TestUtils.testPublicationVersion.coAuthors[0].user))
+        ).toBeInTheDocument();
+    });
+    it('Publication type is shown', () => {
+        expect(
+            screen.getByText(Helpers.formatPublicationType(TestUtils.testPublicationVersion.publication.type))
+        ).toBeInTheDocument();
+    });
+    it('Publication date is shown', () => {
+        expect(
+            screen.getByText(Helpers.formatDate(TestUtils.testPublicationVersion.publishedDate as string))
+        ).toBeInTheDocument();
+    });
+    it('Link to view publication is shown', () => {
+        const viewPublicationLink = screen.getByRole('link', { name: 'View this publication' });
+        expect(viewPublicationLink).toBeInTheDocument();
+        expect(viewPublicationLink).toHaveAttribute(
+            'href',
+            `${Config.urls.viewPublication.path}/${TestUtils.testPublicationVersion.versionOf}`
+        );
+    });
+});
+
+describe('Individual cases', () => {
+    it('Title is truncated to 69 characters if above 80 characters', () => {
+        const longTitle =
+            'This is a very long title that exceeds the maximum length of 80 characters for testing purposes';
+        render(
+            <Components.PublicationCard
+                publicationVersion={{ ...TestUtils.testPublicationVersion, title: longTitle }}
+            />
+        );
+        expect(screen.getByText(Helpers.truncateString(longTitle, 69))).toBeInTheDocument();
+    });
+    it('"et al." is shown after main author name if there are multiple authors', () => {
+        render(
+            <Components.PublicationCard
+                publicationVersion={{
+                    ...TestUtils.testPublicationVersion,
+                    coAuthors: [
+                        ...TestUtils.testPublicationVersion.coAuthors,
+                        {
+                            id: 'test-coauthor-2',
+                            confirmedCoAuthor: true,
+                            approvalRequested: true,
+                            email: 'test-coauthor-email@mailinator.com',
+                            publicationVersionId: TestUtils.testPublicationVersion.id,
+                            linkedUser: 'test-2',
+                            affiliations: [],
+                            isIndependent: true,
+                            user: {
+                                firstName: 'Test',
+                                lastName: 'User',
+                                role: 'USER',
+                                orcid: '0000-0002-1234-5678'
+                            }
+                        }
+                    ]
+                }}
+            />
+        );
+        expect(
+            screen.getByText(`${Helpers.abbreviateUserName(TestUtils.testPublicationVersion.coAuthors[0].user)} et al.`)
+        ).toBeInTheDocument();
+    });
+});

--- a/ui/src/__tests__/testUtils/index.tsx
+++ b/ui/src/__tests__/testUtils/index.tsx
@@ -1,5 +1,17 @@
 import * as Interfaces from '@/interfaces';
 
+export const testCoreUser: Interfaces.CoreUser = {
+    id: 'test',
+    firstName: 'John',
+    lastName: 'Doe',
+    email: 'john_doe@mailinator.com',
+    role: 'USER',
+    createdAt: '2023-02-27T09:50:00.000Z',
+    updatedAt: '2023-02-27T09:50:00.000Z',
+    orcid: 'test',
+    employment: []
+};
+
 export const testPublicationVersion: Interfaces.PublicationVersion = {
     id: 'test-v1',
     versionOf: 'test',
@@ -26,16 +38,7 @@ export const testPublicationVersion: Interfaces.PublicationVersion = {
     content: null,
     language: 'en',
     fundersStatement: null,
-    user: {
-        id: 'test',
-        orcid: 'test',
-        firstName: 'John',
-        lastName: 'Doe',
-        email: 'john_doe@mailinator.com',
-        createdAt: '2023-02-27T09:50:00.000Z',
-        updatedAt: '2023-02-27T09:50:00.000Z',
-        role: 'USER'
-    },
+    user: testCoreUser as Interfaces.PublicationVersionUser,
     publicationStatus: [
         {
             status: 'LIVE',
@@ -49,7 +52,24 @@ export const testPublicationVersion: Interfaces.PublicationVersion = {
         }
     ],
     funders: [],
-    coAuthors: [],
+    coAuthors: [
+        {
+            id: 'test-coauthor',
+            confirmedCoAuthor: true,
+            linkedUser: testCoreUser.id,
+            approvalRequested: false,
+            email: testCoreUser.email as string,
+            publicationVersionId: 'test-v1',
+            affiliations: [],
+            isIndependent: true,
+            user: {
+                firstName: testCoreUser.firstName,
+                lastName: testCoreUser.lastName,
+                role: testCoreUser.role,
+                orcid: testCoreUser.orcid
+            }
+        }
+    ],
     publication: {
         id: 'test',
         type: 'PROBLEM',
@@ -69,18 +89,6 @@ export const testPublication: Interfaces.Publication = {
     linkedFrom: [],
     publicationFlags: [],
     versions: [testPublicationVersion]
-};
-
-export const testCoreUser: Interfaces.CoreUser = {
-    id: 'test',
-    firstName: 'John',
-    lastName: 'Doe',
-    email: 'john_doe@mailinator.com',
-    role: 'USER',
-    createdAt: '2023-02-27T09:50:00.000Z',
-    updatedAt: '2023-02-27T09:50:00.000Z',
-    orcid: 'test',
-    employment: []
 };
 
 export const testUser: Interfaces.User = {

--- a/ui/src/components/Publication/Card/index.tsx
+++ b/ui/src/components/Publication/Card/index.tsx
@@ -18,11 +18,7 @@ const Card: React.FC<Props> = (props): React.ReactElement => {
         const authors = props.publicationVersion.coAuthors.filter((author) => author.confirmedCoAuthor && author.user);
         return authors;
     }, [props.publicationVersion]);
-
-    const authorNames = React.useMemo(
-        () => authors.map((author) => Helpers.abbreviateUserName(author.user)).join(', '),
-        [authors]
-    );
+    const correspondingAuthor = authors.find((author) => author.linkedUser === props.publicationVersion.createdBy);
 
     const { flagCount, peerReviewCount } = props.publicationVersion.publication;
     const hasFlagAndPeerReview = flagCount && peerReviewCount;
@@ -39,42 +35,24 @@ const Card: React.FC<Props> = (props): React.ReactElement => {
                         : props.publicationVersion.title}
                 </p>
                 <span className="mb-4 block font-montserrat text-sm text-grey-800 transition-colors duration-500 dark:text-white-50">
-                    <div className="overflow-hidden text-ellipsis whitespace-nowrap" title={authorNames}>
-                        {authors.map((author, index) => (
-                            <div key={author.id} className="flex">
-                                <span
-                                    className={`${
-                                        hasFlagAndPeerReview ? 'w-1/2' : hasOneOfFlagOrPeerReview ? 'w-3/4' : ''
-                                    } truncate`}
-                                >
-                                    <Components.Link href={`${Config.urls.viewUser.path}/${author.linkedUser}`}>
-                                        {Helpers.abbreviateUserName(author.user)}
-                                    </Components.Link>
-                                    {author.linkedUser !== 'octopus' && author.user && author.user.orcid && (
-                                        <>
-                                            &nbsp;
-                                            <a
-                                                href={`https://${
-                                                    process.env.NEXT_PUBLIC_STAGE === 'local' ? 'sandbox.' : ''
-                                                }orcid.org/${author.user?.orcid}`}
-                                                target="_blank"
-                                                rel="noreferrer"
-                                            >
-                                                <Assets.OrcidLogoIcon width={16} className="inline align-middle" />
-                                            </a>
-                                        </>
-                                    )}
-                                    {index < authors.length - 1 ? ', ' : ''}
-                                </span>
-                                <Components.EngagementCounts
-                                    className={`justify-end ${
-                                        hasFlagAndPeerReview ? 'w-1/2' : hasOneOfFlagOrPeerReview ? 'w-1/4' : ''
-                                    }`}
-                                    flagCount={flagCount}
-                                    peerReviewCount={peerReviewCount}
-                                />
-                            </div>
-                        ))}
+                    <div className="overflow-hidden text-ellipsis whitespace-nowrap">
+                        <div className="flex">
+                            <span
+                                className={`${
+                                    hasFlagAndPeerReview ? 'w-1/2' : hasOneOfFlagOrPeerReview ? 'w-3/4' : ''
+                                } truncate`}
+                            >
+                                {Helpers.abbreviateUserName(correspondingAuthor?.user)}
+                                {authors.length > 1 && ' et al.'}
+                            </span>
+                            <Components.EngagementCounts
+                                className={`justify-end ${
+                                    hasFlagAndPeerReview ? 'w-1/2' : hasOneOfFlagOrPeerReview ? 'w-1/4' : ''
+                                }`}
+                                flagCount={flagCount}
+                                peerReviewCount={peerReviewCount}
+                            />
+                        </div>
                     </div>
                 </span>
                 <div className="flex items-center justify-between">


### PR DESCRIPTION
The purpose of this PR was to ensure that browse page tiles have a consistent height and appearance by limiting the author display to a certain size.

---

### Acceptance Criteria:

- Browse page tiles show only the primary author for each publication
- If any additional authors are present, the text “et al” appears after their name
- The ORCiD logo does not appear on browse page tiles  
- The author’s name is not clickable

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
![Screenshot 2025-04-23 155634](https://github.com/user-attachments/assets/916d4c0b-7eef-4cb4-8562-70bccc47238b)

E2E
![Screenshot 2025-04-23 142939](https://github.com/user-attachments/assets/16ab9967-1b45-4ce2-85c2-2b139a6286dd)

---

### Screenshots:

![Screenshot 2025-04-24 090328](https://github.com/user-attachments/assets/b22a806a-8180-4d55-b0e8-2e53247907cf)

