### PR TITLE
OC-1062: Deleting links on a new version

### DIFF
--- a/api/prisma/migrations/20250506075626_links_pending_deletion/migration.sql
+++ b/api/prisma/migrations/20250506075626_links_pending_deletion/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Links" ADD COLUMN     "pendingDeletion" BOOLEAN NOT NULL DEFAULT false;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -149,6 +149,7 @@ model Links {
     publicationTo     Publication        @relation("to", fields: [publicationToId], references: [id], onDelete: Cascade)
     versionTo         PublicationVersion @relation("toVersion", fields: [versionToId], references: [id], onDelete: Cascade)
     draft             Boolean            @default(true)
+    pendingDeletion   Boolean            @default(false)
 
     @@unique([publicationFromId, publicationToId])
 }

--- a/api/prisma/seeds/local/unitTesting/publications.ts
+++ b/api/prisma/seeds/local/unitTesting/publications.ts
@@ -1060,6 +1060,7 @@ const publicationSeeds: Prisma.PublicationCreateInput[] = [
         type: 'HYPOTHESIS',
         linkedTo: {
             create: {
+                id: 'hypothesis-live-to-problem-live',
                 publicationToId: 'publication-problem-live',
                 versionToId: 'publication-problem-live-v1',
                 draft: false
@@ -1576,6 +1577,7 @@ const publicationSeeds: Prisma.PublicationCreateInput[] = [
         versions: {
             create: {
                 id: 'publication-problem-locked-2-v1',
+                doi: '10.82259/ver1-2g35',
                 versionNumber: 1,
                 title: 'Publication PROBLEM-LOCKED 2',
                 conflictOfInterestStatus: false,
@@ -1615,6 +1617,92 @@ const publicationSeeds: Prisma.PublicationCreateInput[] = [
                     ]
                 }
             }
+        }
+    },
+    {
+        id: 'multiversion-hypothesis',
+        doi: '10.82259/cty5-2g36',
+        type: 'HYPOTHESIS',
+        linkedTo: {
+            create: [
+                {
+                    id: 'multiversion-hypothesis-draft-link',
+                    publicationToId: 'publication-problem-live-2',
+                    versionToId: 'publication-problem-live-2-v1'
+                },
+                {
+                    id: 'multiversion-hypothesis-link-to-live',
+                    publicationToId: 'publication-problem-live',
+                    versionToId: 'publication-problem-live-v1',
+                    draft: false
+                }
+            ]
+        },
+        versions: {
+            create: [
+                {
+                    id: 'multiversion-hypothesis-v1',
+                    doi: '10.82259/ver1-2g36',
+                    versionNumber: 1,
+                    title: 'Multiversion Hypothesis',
+                    conflictOfInterestStatus: false,
+                    content: 'Multiversion Hypothesis',
+                    currentStatus: 'LIVE',
+                    isLatestLiveVersion: true,
+                    isLatestVersion: false,
+                    user: { connect: { id: 'test-user-5' } },
+                    publicationStatus: {
+                        create: [
+                            { status: 'DRAFT', createdAt: '2025-05-01T00:00:00.000Z' },
+                            {
+                                status: 'LIVE',
+                                createdAt: '2025-05-01T01:00:00.000Z'
+                            }
+                        ]
+                    },
+                    coAuthors: {
+                        create: [
+                            {
+                                id: 'coauthor-test-user-5-multiversion-hypothesis-v1',
+                                email: 'test-user-5@jisc.ac.uk',
+                                code: 'test-code-user-5',
+                                confirmedCoAuthor: true,
+                                linkedUser: 'test-user-5',
+                                isIndependent: true,
+                                affiliations: []
+                            }
+                        ]
+                    }
+                },
+                {
+                    id: 'multiversion-hypothesis-v2',
+                    doi: '10.82259/ver2-2g36',
+                    versionNumber: 2,
+                    title: 'Multiversion Hypothesis v2',
+                    conflictOfInterestStatus: false,
+                    content: 'Multiversion Hypothesis v2',
+                    currentStatus: 'DRAFT',
+                    isLatestLiveVersion: false,
+                    isLatestVersion: true,
+                    user: { connect: { id: 'test-user-5' } },
+                    publicationStatus: {
+                        create: [{ status: 'DRAFT', createdAt: '2025-05-02T00:00:00.000Z' }]
+                    },
+                    coAuthors: {
+                        create: [
+                            {
+                                id: 'coauthor-test-user-5-multiversion-hypothesis-v2',
+                                email: 'test-user-5@jisc.ac.uk',
+                                code: 'test-code-user-5',
+                                confirmedCoAuthor: true,
+                                linkedUser: 'test-user-5',
+                                isIndependent: true,
+                                affiliations: []
+                            }
+                        ]
+                    }
+                }
+            ]
         }
     }
 ];

--- a/api/prisma/seeds/local/unitTesting/publications.ts
+++ b/api/prisma/seeds/local/unitTesting/publications.ts
@@ -853,6 +853,13 @@ const publicationSeeds: Prisma.PublicationCreateInput[] = [
         id: 'publication-interpretation-draft',
         doi: '10.82259/cty5-2g17',
         type: 'INTERPRETATION',
+        linkedTo: {
+            create: {
+                publicationToId: 'publication-analysis-live',
+                versionToId: 'publication-analysis-live-v1',
+                pendingDeletion: true
+            }
+        },
         versions: {
             create: {
                 id: 'publication-interpretation-draft-v1',
@@ -1635,6 +1642,12 @@ const publicationSeeds: Prisma.PublicationCreateInput[] = [
                     publicationToId: 'publication-problem-live',
                     versionToId: 'publication-problem-live-v1',
                     draft: false
+                },
+                {
+                    id: 'multiversion-hypothesis-pending-deletion',
+                    publicationToId: 'publication-problem-live-3',
+                    versionToId: 'publication-problem-live-3-v1',
+                    pendingDeletion: true
                 }
             ]
         },

--- a/api/serverless-config-default.yml
+++ b/api/serverless-config-default.yml
@@ -193,6 +193,13 @@ functions:
                 path: ${self:custom.versions.v1}/links/{id}
                 method: DELETE
                 cors: true
+    markLinkForDeletion:
+        handler: dist/src/components/link/routes.markForDeletion
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/links/{id}/mark-for-deletion
+                method: POST
+                cors: true
     # CoAuthors
     getCoAuthors:
         handler: dist/src/components/coauthor/routes.getAll

--- a/api/src/components/affiliations/__tests__/updateAffiliations.test.ts
+++ b/api/src/components/affiliations/__tests__/updateAffiliations.test.ts
@@ -96,7 +96,7 @@ describe('update coAuthor affiliations per publication', () => {
             .query({ apiKey: '000000005' })
             .send();
 
-        expect(updateStatusResponse.status).toEqual(403);
+        expect(updateStatusResponse.status).toEqual(400);
         expect(updateStatusResponse.body.message).toEqual(
             'Publication is not ready to be LOCKED. Make sure all fields are filled in.'
         );

--- a/api/src/components/link/__tests__/deleteLink.test.ts
+++ b/api/src/components/link/__tests__/deleteLink.test.ts
@@ -1,14 +1,77 @@
+import { Prisma } from '@prisma/client';
+
+import * as client from 'lib/client';
 import * as testUtils from 'lib/testUtils';
 
-describe('Create links', () => {
+describe('Delete links', () => {
     beforeEach(async () => {
         await testUtils.clearDB();
         await testUtils.testSeed();
     });
 
-    test.todo('User can delete a link where they own the fromPublication and it is DRAFT');
-    test.todo('User cannot delete a link where they own the fromPublication and it is LIVE');
-    test.todo('User cannot delete a link where they do not own the fromPublication and it is DRAFT');
-    test.todo('User cannot delete a link where they do not own the fromPublication and it is LIVE');
-    test.todo('Unauthenticated user cannot delete a link where they do not own the fromPublication and it is DRAFT');
+    test('User can delete a draft link where they own the fromPublication and it is DRAFT', async () => {
+        const linkQuery: Prisma.LinksFindUniqueArgs = { where: { id: 'multiversion-hypothesis-draft-link' } };
+        // Confirm link exists first.
+        const link = await client.prisma.links.findUnique(linkQuery);
+        expect(link).toMatchObject({
+            id: 'multiversion-hypothesis-draft-link',
+            draft: true
+        });
+
+        const deleteLink = await testUtils.agent.delete('/links/multiversion-hypothesis-draft-link').query({
+            apiKey: '000000005'
+        });
+        expect(deleteLink.statusCode).toBe(200);
+        expect(deleteLink.body.message).toBe('Link deleted.');
+
+        const linkAfter = await client.prisma.links.findUnique(linkQuery);
+        expect(linkAfter).toBeNull();
+    });
+
+    test('User cannot delete a link where they own the fromPublication and it is LIVE', async () => {
+        const deleteLink = await testUtils.agent.delete('/links/hypothesis-live-to-problem-live').query({
+            apiKey: '123456789'
+        });
+        expect(deleteLink.statusCode).toBe(400);
+        expect(deleteLink.body.message).toBe(
+            'A link can only be deleted if it has been made from a publication currently in draft state.'
+        );
+    });
+
+    test('User cannot delete a link where they do not own the fromPublication and it is DRAFT', async () => {
+        const deleteLink = await testUtils.agent.delete('/links/multiversion-hypothesis-draft-link').query({
+            apiKey: '123456789'
+        });
+        expect(deleteLink.statusCode).toBe(403);
+        expect(deleteLink.body.message).toBe('You do not have permission to delete this link');
+    });
+
+    test('User cannot delete a link where they do not own the fromPublication and it is LIVE', async () => {
+        const deleteLink = await testUtils.agent.delete('/links/hypothesis-live-to-problem-live').query({
+            apiKey: '000000005'
+        });
+        expect(deleteLink.statusCode).toBe(403);
+        expect(deleteLink.body.message).toBe('You do not have permission to delete this link');
+    });
+
+    test('Unauthenticated user cannot delete a link where they do not own the fromPublication and it is DRAFT', async () => {
+        const deleteLink = await testUtils.agent.delete('/links/multiversion-hypothesis-draft-link');
+        expect(deleteLink.statusCode).toBe(401);
+    });
+
+    test('User cannot delete a link inherited from a previous version', async () => {
+        const deleteLink = await testUtils.agent.delete('/links/multiversion-hypothesis-link-to-live').query({
+            apiKey: '000000005'
+        });
+        expect(deleteLink.statusCode).toBe(403);
+        expect(deleteLink.body.message).toBe('You are not allowed to delete inherited links.');
+    });
+
+    test('Non-existent links return not found response', async () => {
+        const deleteLink = await testUtils.agent.delete('/links/made-up-link').query({
+            apiKey: '000000005'
+        });
+        expect(deleteLink.statusCode).toBe(404);
+        expect(deleteLink.body.message).toBe('Link not found.');
+    });
 });

--- a/api/src/components/link/__tests__/markForDeletion.test.ts
+++ b/api/src/components/link/__tests__/markForDeletion.test.ts
@@ -1,0 +1,107 @@
+import * as client from 'lib/client';
+import * as testUtils from 'lib/testUtils';
+
+describe('Mark links for deletion', () => {
+    beforeAll(async () => {
+        await testUtils.clearDB();
+        await testUtils.testSeed();
+    });
+
+    test('Links can be marked for deletion by the publication author', async () => {
+        // Confirm state before change.
+        const linkBefore = await client.prisma.links.findUnique({
+            where: {
+                id: 'multiversion-hypothesis-link-to-live'
+            }
+        });
+        expect(linkBefore?.pendingDeletion).toBe(false);
+
+        const markForDeletion = await testUtils.agent
+            .post('/links/multiversion-hypothesis-link-to-live/mark-for-deletion')
+            .query({
+                apiKey: '000000005'
+            })
+            .send({
+                toDelete: true
+            });
+
+        expect(markForDeletion.statusCode).toBe(200);
+        expect(markForDeletion.body.message).toBe('Link marked for deletion.');
+
+        // Confirm effect is as intended.
+        const linkAfter = await client.prisma.links.findUnique({
+            where: {
+                id: 'multiversion-hypothesis-link-to-live'
+            }
+        });
+        expect(linkAfter?.pendingDeletion).toBe(true);
+    });
+
+    test('Anonymous user cannot mark a link for deletion', async () => {
+        const markForDeletion = await testUtils.agent
+            .post('/links/multiversion-hypothesis-link-to-live/mark-for-deletion')
+            .send({
+                toDelete: true
+            });
+
+        expect(markForDeletion.statusCode).toBe(401);
+    });
+
+    test('Non-existent links cannot be marked for deletion', async () => {
+        const markForDeletion = await testUtils.agent
+            .post('/links/made-up-link/mark-for-deletion')
+            .query({
+                apiKey: '000000005'
+            })
+            .send({
+                toDelete: true
+            });
+
+        expect(markForDeletion.statusCode).toBe(404);
+        expect(markForDeletion.body.message).toBe('Link not found.');
+    });
+
+    test('User other than corresponding author cannot mark a link for deletion', async () => {
+        const markForDeletion = await testUtils.agent
+            .post('/links/multiversion-hypothesis-link-to-live/mark-for-deletion')
+            .query({
+                apiKey: '987654321'
+            })
+            .send({
+                toDelete: true
+            });
+
+        expect(markForDeletion.statusCode).toBe(403);
+        expect(markForDeletion.body.message).toBe('You do not have permission to mark this link for deletion.');
+    });
+
+    test('Draft links cannot be marked for deletion', async () => {
+        const markForDeletion = await testUtils.agent
+            .post('/links/multiversion-hypothesis-draft-link/mark-for-deletion')
+            .query({
+                apiKey: '000000005'
+            })
+            .send({
+                toDelete: true
+            });
+
+        expect(markForDeletion.statusCode).toBe(400);
+        expect(markForDeletion.body.message).toBe(
+            'Draft links cannot be marked for deletion. You can simply delete them instead.'
+        );
+    });
+
+    test('Link cannot be marked for deletion if there is no current draft', async () => {
+        const markForDeletion = await testUtils.agent
+            .post('/links/hypothesis-live-to-problem-live/mark-for-deletion')
+            .query({
+                apiKey: '123456789'
+            })
+            .send({
+                toDelete: true
+            });
+
+        expect(markForDeletion.statusCode).toBe(400);
+        expect(markForDeletion.body.message).toBe('This publication has no active draft. Please make one first.');
+    });
+});

--- a/api/src/components/link/routes.ts
+++ b/api/src/components/link/routes.ts
@@ -15,3 +15,9 @@ export const deleteLink = middy(linkController.deleteLink)
     .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))
     .use(middleware.httpJsonBodyParser())
     .use(middleware.authentication());
+
+export const markForDeletion = middy(linkController.markForDeletion)
+    .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))
+    .use(middleware.httpJsonBodyParser())
+    .use(middleware.authentication())
+    .use(middleware.validator(linkSchema.markForDeletion, 'body'));

--- a/api/src/components/link/schema/index.ts
+++ b/api/src/components/link/schema/index.ts
@@ -1,1 +1,2 @@
 export { default as create } from './create';
+export { default as markForDeletion } from './markForDeletion';

--- a/api/src/components/link/schema/markForDeletion.ts
+++ b/api/src/components/link/schema/markForDeletion.ts
@@ -1,0 +1,14 @@
+import * as I from 'interface';
+
+const markForDeletion: I.JSONSchemaType<I.MarkLinkForDeletionBody> = {
+    type: 'object',
+    properties: {
+        toDelete: {
+            type: 'boolean'
+        }
+    },
+    required: ['toDelete'],
+    additionalProperties: false
+};
+
+export default markForDeletion;

--- a/api/src/components/link/service.ts
+++ b/api/src/components/link/service.ts
@@ -306,3 +306,13 @@ export const removeInvalidLinksForPublication = async (publicationId: string, di
 
     await deleteInvalidLinks(flattenDraftLinkData(draftLinksForPublication));
 };
+
+export const markForDeletion = (linkId: string, toDelete: boolean) =>
+    client.prisma.links.update({
+        where: {
+            id: linkId
+        },
+        data: {
+            pendingDeletion: toDelete
+        }
+    });

--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -1225,6 +1225,7 @@ export const getDirectLinksForPublication = async (
                 select: {
                     id: true,
                     draft: true,
+                    pendingDeletion: requesterIsAuthor || undefined,
                     versionTo: {
                         select: {
                             id: true,
@@ -1285,6 +1286,7 @@ export const getDirectLinksForPublication = async (
                 select: {
                     id: true,
                     draft: true,
+                    pendingDeletion: requesterIsAuthor || undefined,
                     versionTo: {
                         select: {
                             id: true,
@@ -1366,7 +1368,7 @@ export const getDirectLinksForPublication = async (
     }
 
     const linkedTo: I.LinkedToPublication[] = publication.linkedTo.map((link) => {
-        const { id: linkId, publicationTo, versionTo, draft } = link;
+        const { id: linkId, publicationTo, versionTo, draft, pendingDeletion } = link;
         const { id, type, versions, doi: publicationDoi, publicationFlags, linkedFrom, externalSource } = publicationTo;
         const initialDraftVersion = versions.find(
             (version) => version.versionNumber === 1 && version.currentStatus !== 'LIVE'
@@ -1403,6 +1405,7 @@ export const getDirectLinksForPublication = async (
         return {
             id,
             draft,
+            pendingDeletion,
             linkId,
             type,
             doi: publicationDoi,
@@ -1423,7 +1426,7 @@ export const getDirectLinksForPublication = async (
     });
 
     const linkedFrom: I.LinkedFromPublication[] = publication.linkedFrom.map((link) => {
-        const { id: linkId, publicationFrom, versionTo, draft } = link;
+        const { id: linkId, publicationFrom, versionTo, draft, pendingDeletion } = link;
         const { id, type, versions, doi: publicationDoi, publicationFlags, linkedFrom } = publicationFrom;
         const initialDraftVersion = versions.find(
             (version) => version.versionNumber === 1 && version.currentStatus !== 'LIVE'
@@ -1460,6 +1463,7 @@ export const getDirectLinksForPublication = async (
         return {
             id,
             draft,
+            pendingDeletion,
             linkId,
             type,
             doi: publicationDoi,
@@ -1508,3 +1512,11 @@ export const getDirectLinksForPublication = async (
         linkedFrom
     };
 };
+
+export const deleteLinksPendingDeletion = (publicationId: string) =>
+    client.prisma.links.deleteMany({
+        where: {
+            publicationFromId: publicationId,
+            pendingDeletion: true
+        }
+    });

--- a/api/src/components/publicationVersion/__tests__/getAll.test.ts
+++ b/api/src/components/publicationVersion/__tests__/getAll.test.ts
@@ -42,7 +42,7 @@ describe('Get many publication versions', () => {
             offset: 10
         });
         // This will change if we add more live seed publications.
-        expect(getPublications.body.data.length).toEqual(6);
+        expect(getPublications.body.data.length).toEqual(7);
     });
 
     test('Can order by publication date, descending', async () => {
@@ -144,7 +144,7 @@ describe('Get many publication versions', () => {
 
         expect(getPublications.status).toEqual(200);
         // Includes everything.
-        expect(getPublications.body.metadata.total).toEqual(16);
+        expect(getPublications.body.metadata.total).toEqual(17);
     });
 
     test('Author filtering rejects invalid types', async () => {

--- a/api/src/components/publicationVersion/controller.ts
+++ b/api/src/components/publicationVersion/controller.ts
@@ -301,9 +301,11 @@ export const updateStatus = async (
                 }
 
                 // check if publication version is ready to be LOCKED
-                if (!(await publicationVersionService.checkIsReadyToLock(publicationVersion))) {
-                    return response.json(403, {
-                        message: 'Publication is not ready to be LOCKED. Make sure all fields are filled in.'
+                const isReadyToLock = await publicationVersionService.checkIsReadyToLock(publicationVersion);
+
+                if (!isReadyToLock.ready) {
+                    return response.json(400, {
+                        message: isReadyToLock.message
                     });
                 }
 
@@ -317,8 +319,8 @@ export const updateStatus = async (
                 const isReadyToPublish = await publicationVersionService.checkIsReadyToPublish(publicationVersion);
 
                 if (!isReadyToPublish.ready) {
-                    return response.json(403, {
-                        message: isReadyToPublish.reason
+                    return response.json(400, {
+                        message: isReadyToPublish.message
                     });
                 }
             }
@@ -341,8 +343,8 @@ export const updateStatus = async (
                 const isReadyToPublish = await publicationVersionService.checkIsReadyToPublish(publicationVersion);
 
                 if (!isReadyToPublish.ready) {
-                    return response.json(403, {
-                        message: isReadyToPublish.reason
+                    return response.json(400, {
+                        message: isReadyToPublish.message
                     });
                 }
             }

--- a/api/src/components/publicationVersion/service.ts
+++ b/api/src/components/publicationVersion/service.ts
@@ -353,14 +353,14 @@ export const validateConflictOfInterest = <
     return true;
 };
 
-export const checkIsReadyToPublish = async (
-    publicationVersion: I.PublicationVersion
-): Promise<{
+type ReadyCheckResult = {
     ready: boolean;
-    reason: string;
-}> => {
+    message: string;
+};
+
+export const checkIsReadyToPublish = async (publicationVersion: I.PublicationVersion): Promise<ReadyCheckResult> => {
     if (!publicationVersion) {
-        return { ready: false, reason: 'Publication version not found' };
+        return { ready: false, message: 'Publication version not found' };
     }
 
     const { linkedTo } = await publicationService.getDirectLinksForPublication(
@@ -369,9 +369,37 @@ export const checkIsReadyToPublish = async (
         true
     );
 
-    const hasAtLeastOneLiveLinkOrTopic =
-        (linkedTo.length !== 0 && linkedTo.every((linkedPublication) => linkedPublication.currentStatus === 'LIVE')) ||
-        (publicationVersion.publication.type === 'PROBLEM' && publicationVersion.topics.length !== 0);
+    // Are any linked publications not live?
+    if (!linkedTo.every((linkedPublication) => linkedPublication.currentStatus === 'LIVE')) {
+        return {
+            ready: false,
+            message:
+                'One or more linked publications are still in draft. Please ensure all linked publications are live before publishing this one.'
+        };
+    }
+
+    // Are there any links (to publications, or topics if publication is a problem)?
+    const isProblem = publicationVersion.publication.type === 'PROBLEM';
+    const isProblemWithTopics = isProblem && publicationVersion.topics.length !== 0;
+
+    if (!linkedTo.length && !isProblemWithTopics) {
+        return {
+            ready: false,
+            message: `This publication must be linked to a live publication ${
+                isProblem ? 'or topic ' : ''
+            } in order to publish.`
+        };
+    }
+
+    // Would publishing leave any valid links (if some are pending deletion)?
+    if (linkedTo.length && linkedTo.every((linkedPublication) => linkedPublication.pendingDeletion === true)) {
+        return {
+            ready: false,
+            message:
+                'This publication would be left with no valid links if it was published. Please ensure there is at least one link to a live publication that is not marked for deletion before publishing this publication.'
+        };
+    }
+
     const hasFilledRequiredFields =
         ['title', 'licence'].every((field) => publicationVersion[field]) &&
         !Helpers.isEmptyContent(publicationVersion.content || '');
@@ -387,7 +415,6 @@ export const checkIsReadyToPublish = async (
     );
 
     const ready =
-        hasAtLeastOneLiveLinkOrTopic &&
         hasFilledRequiredFields &&
         conflictOfInterest &&
         !hasPublishDate &&
@@ -395,23 +422,30 @@ export const checkIsReadyToPublish = async (
         isDataAndHasPermissionsStatement &&
         coAuthorsAreVerified &&
         publicationVersion.isLatestVersion;
-    const reason = !hasAtLeastOneLiveLinkOrTopic
-        ? 'One or more linked publications are still in draft. Please ensure all linked publications are live before publishing this one.'
-        : 'Publication is not ready to be made LIVE. Make sure all fields are filled in.';
 
     return {
         ready,
-        reason
+        message: ready
+            ? 'Publication is ready to publish.'
+            : 'Publication is not ready to be made LIVE. Make sure all fields are filled in.'
     };
 };
 
-export const checkIsReadyToRequestApprovals = async (publicationVersion: I.PublicationVersion): Promise<boolean> => {
+export const checkIsReadyToRequestApprovals = async (
+    publicationVersion: I.PublicationVersion
+): Promise<ReadyCheckResult> => {
     if (!publicationVersion) {
-        return false;
+        return {
+            ready: false,
+            message: 'Publication version not found.'
+        };
     }
 
     if (!publicationVersion.isLatestVersion || publicationVersion.currentStatus !== 'DRAFT') {
-        return false;
+        return {
+            ready: false,
+            message: 'Publication is not an active draft.'
+        };
     }
 
     const { linkedTo } = await publicationService.getDirectLinksForPublication(
@@ -436,30 +470,44 @@ export const checkIsReadyToRequestApprovals = async (publicationVersion: I.Publi
             author.linkedUser === publicationVersion.createdBy && (author.isIndependent || author.affiliations.length)
     );
 
-    return (
+    const ready =
         hasAtLeastOneLinkOrTopic &&
         hasFilledRequiredFields &&
         conflictOfInterest &&
         isDataAndHasEthicalStatement &&
         isDataAndHasPermissionsStatement &&
         hasConfirmedAffiliations &&
-        publicationVersion.isLatestVersion
-    );
+        publicationVersion.isLatestVersion;
+
+    return {
+        ready,
+        message: ready ? 'Publication is ready to request approvals' : 'Make sure all fields are filled in.'
+    };
 };
 
-export const checkIsReadyToLock = async (publicationVersion: I.PublicationVersion): Promise<boolean> => {
-    if (!publicationVersion) {
-        return false;
-    }
-
-    if (publicationVersion.currentStatus !== 'DRAFT') {
-        return false;
-    }
-
+export const checkIsReadyToLock = async (publicationVersion: I.PublicationVersion): Promise<ReadyCheckResult> => {
     const isReadyToRequestApprovals = await checkIsReadyToRequestApprovals(publicationVersion);
+
+    if (isReadyToRequestApprovals.ready === false) {
+        return {
+            ready: false,
+            message: 'Publication is not ready to be LOCKED. ' + isReadyToRequestApprovals.message
+        };
+    }
+
     const hasRequestedApprovals = !!publicationVersion.coAuthors.some((author) => author.approvalRequested);
 
-    return isReadyToRequestApprovals && hasRequestedApprovals;
+    if (!hasRequestedApprovals) {
+        return {
+            ready: false,
+            message: 'Please request approval before locking the publication.'
+        };
+    }
+
+    return {
+        ready: true,
+        message: 'Publication is ready to be locked.'
+    };
 };
 
 export const deleteVersion = async (publicationVersion: I.PublicationVersion) => {
@@ -654,6 +702,9 @@ export const transferOwnership = (publicationVersionId: string, requesterId: str
 // published immediately (i.e. not going through full drafting workflow) and bypasses the updateStatus function.
 export const postPublishHook = async (publicationVersion: I.PublicationVersion, skipPdfGeneration?: boolean) => {
     try {
+        // Delete links pending deletion.
+        await publicationService.deleteLinksPendingDeletion(publicationVersion.versionOf);
+
         // Tasks specific to peer reviews.
         if (publicationVersion.publication.type === 'PEER_REVIEW') {
             // Ensure links made from a PEER_REVIEW version point to the latest live version of the target publication.
@@ -765,38 +816,55 @@ export const postPublishHook = async (publicationVersion: I.PublicationVersion, 
         // If we have a version with a DOI, pass that, but if not just pass one without.
         await doi.updateCanonicalDOI(publicationVersion.publication.doi, versionWithDOI || publicationVersion);
 
-        // (Re)index publication in opensearch.
-        // TODO: remove this extra logging if we don't observe ARI imports stalling here for some time.
-        console.log(`Indexing publication ${publicationVersion.versionOf} in opensearch.`);
-        await publicationService.upsertOpenSearchRecord({
-            id: publicationVersion.versionOf,
-            type: publicationVersion.publication.type,
-            title: publicationVersion.title,
-            organisationalAuthor: publicationVersion.user.role === 'ORGANISATION',
-            description: publicationVersion.description,
-            keywords: publicationVersion.keywords,
-            content: publicationVersion.content,
-            publishedDate: publicationVersion.publishedDate,
-            cleanContent: convert(publicationVersion.content)
-        });
-        console.log(`Indexing complete.`);
+        // Complete remaining tasks in parallel.
+        const postDBUpdatePromises: Array<Promise<unknown>> = [];
+
+        postDBUpdatePromises.push(
+            new Promise((resolve) => {
+                // TODO: remove this extra logging if we don't observe ARI imports stalling here for some time.
+                console.log(`Indexing publication ${publicationVersion.versionOf} in opensearch.`);
+                publicationService
+                    .upsertOpenSearchRecord({
+                        id: publicationVersion.versionOf,
+                        type: publicationVersion.publication.type,
+                        title: publicationVersion.title,
+                        organisationalAuthor: publicationVersion.user.role === 'ORGANISATION',
+                        description: publicationVersion.description,
+                        keywords: publicationVersion.keywords,
+                        content: publicationVersion.content,
+                        publishedDate: publicationVersion.publishedDate,
+                        cleanContent: convert(publicationVersion.content)
+                    })
+                    .then((result) => {
+                        console.log(`Indexing complete.`);
+                        resolve(result);
+                    })
+                    .catch((error) => console.log(error));
+            })
+        );
 
         // Delete all pending request control events for this publication version.
-        await eventService.deleteMany({
-            type: 'REQUEST_CONTROL',
-            data: {
-                path: ['publicationVersion', 'id'],
-                equals: publicationVersion.id
-            }
-        });
+        postDBUpdatePromises.push(
+            eventService.deleteMany({
+                type: 'REQUEST_CONTROL',
+                data: {
+                    path: ['publicationVersion', 'id'],
+                    equals: publicationVersion.id
+                }
+            })
+        );
 
-        // Send message to the pdf generation queue.
-        // Skipped locally, as there is not an SQS que in localstack.
-        // Option to skip, e.g. in bulk import scripts, where instant pdf generation is not a priority.
-        // In both cases, the pdf will still be generated the first time it's requested.
-        if (process.env.STAGE !== 'local' && !skipPdfGeneration) {
-            await sqs.sendMessage(publicationVersion.versionOf);
+        if (process.env.STAGE !== 'local') {
+            if (!skipPdfGeneration) {
+                // Send message to the pdf generation queue.
+                // Skipped locally, as there is not an SQS queue in localstack.
+                // Option to skip, e.g. in bulk import scripts, where instant pdf generation is not a priority.
+                // In both cases, the pdf will still be generated the first time it's requested.
+                postDBUpdatePromises.push(sqs.sendMessage(publicationVersion.versionOf));
+            }
         }
+
+        await Promise.all(postDBUpdatePromises);
     } catch (err) {
         console.log('Error in post-publish hook: ', err);
     }

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -266,6 +266,7 @@ export interface LinkedToPublication extends LinkedPublication {
     draft: boolean;
     externalSource: PublicationImportSource | null;
     linkId: string;
+    pendingDeletion?: boolean;
 }
 
 export interface LinkedFromPublication extends LinkedPublication {
@@ -273,6 +274,7 @@ export interface LinkedFromPublication extends LinkedPublication {
     linkId: string;
     parentPublicationId: string;
     parentPublicationType: PublicationType;
+    pendingDeletion?: boolean;
 }
 
 export interface PublicationWithLinks {

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -281,6 +281,18 @@ export interface PublicationWithLinks {
     linkedFrom: LinkedFromPublication[];
 }
 
+export interface DeleteLinkPathParams {
+    id: string;
+}
+
+export interface MarkLinkForDeletionBody {
+    toDelete: boolean;
+}
+
+export interface MarkLinkForDeletionPathParams {
+    id: string;
+}
+
 /**
  * @description Users
  */
@@ -461,10 +473,6 @@ export interface ApproveControlRequestPathParams {
 export interface ApproveControlRequestBody {
     approve: 'true' | 'false';
     eventId: string;
-}
-
-export interface DeleteLinkPathParams {
-    id: string;
 }
 
 export type ValidStatuses = 'DRAFT' | 'LIVE' | 'LOCKED';

--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -427,7 +427,7 @@ test.describe('Publication flow', () => {
         const page = await Helpers.users.getPageAsUser(browser);
         await Helpers.publicationCreation.createPublication(page, 'problem to link to topic', 'PROBLEM');
         // Go to Linked Items tab
-        await (await page.waitForSelector("aside button:has-text('Linked items')")).click();
+        await (await page.waitForSelector(PageModel.publish.tabs.linkedItems)).click();
         // Link a topic and expect it to appear below with a delete button
         await page.locator(PageModel.publish.linkedItems.entityTypeSelect).selectOption('Research topics');
         await page.locator(PageModel.publish.linkedItems.topicInput).click();
@@ -446,7 +446,7 @@ test.describe('Publication flow', () => {
             'HYPOTHESIS'
         );
         // Go to Linked Items tab
-        await (await page.waitForSelector("aside button:has-text('Linked items')")).click();
+        await (await page.waitForSelector(PageModel.publish.tabs.linkedItems)).click();
         // Topic option should not be visible
         const options = await page.getByRole('option').all();
         await expect(options.length).toBe(2);
@@ -472,8 +472,67 @@ test.describe('Publication flow', () => {
         await page.waitForResponse(
             (response) => response.url().includes('/publications') && response.request().method() === 'POST'
         );
-        await (await page.waitForSelector("aside button:has-text('Linked items')")).click();
+        await (await page.waitForSelector(PageModel.publish.tabs.linkedItems)).click();
         await expect(page.locator(PageModel.publish.linkedItems.deleteNewTopicLink)).toBeVisible();
+    });
+
+    test('Links inherited from a previous version can be marked for deletion upon publish', async ({ browser }) => {
+        // Create v1 of a publication with one link
+        const page = await Helpers.users.getPageAsUser(browser);
+        await Helpers.publicationCreation.createPublication(page, 'pending deletion link test', 'PROBLEM');
+        await Helpers.publicationCreation.completeKeyInformationTab(page);
+        await Helpers.publicationCreation.completeAffiliationsTab(page, true);
+        await Helpers.publicationCreation.completeLinkedItemsTab(
+            page,
+            'living organisms',
+            'How do living organisms function, survive, reproduce and evolve?'
+        );
+        await Helpers.publicationCreation.completeMainTextTabMinimally(
+            page,
+            'a link on this publication should be flagged for deletion and deleted on publish'
+        );
+        await Helpers.publicationCreation.completeConflictOfInterestTab(page, false);
+        await page.locator(PageModel.publish.publishButton).click();
+        await Promise.all([
+            page.waitForURL('/publications/**/versions/latest'),
+            page.locator(PageModel.publish.confirmPublishButton).click()
+        ]);
+
+        // Create v2
+        await page.locator(PageModel.livePublication.versionsDropdown.createNewVersionButton).click();
+        await Promise.all([
+            page.locator('button[title="Confirm"]').click(),
+            page.waitForURL('/publications/**/edit?step=0')
+        ]);
+        await (await page.waitForSelector(PageModel.publish.tabs.linkedItems)).click();
+
+        // Mark the existing link for deletion
+        await Promise.all([
+            page.locator(PageModel.publish.linkedItems.markPublicationLinkForDeletionButton).click(),
+            page.waitForResponse(
+                (response) => response.url().includes('/mark-for-deletion') && response.request().method() === 'POST'
+            )
+        ]);
+        await expect(page.locator(PageModel.publish.linkedItems.cancelPublicationPendingDeletionButton)).toBeVisible();
+        // Publish should be disabled because there are no valid links remaining that aren't pending deletion
+        await expect(page.locator(PageModel.publish.publishButton)).toBeDisabled();
+
+        // Add a new link
+        await page.locator(PageModel.publish.linkedItems.publicationInput).click();
+        await page.keyboard.type('organisational');
+        await page.locator(`[role="option"]:has-text("Organisational account publication 1")`).click();
+        await Promise.all([
+            page.waitForResponse((response) => response.url().includes('/links') && response.ok()),
+            page.locator(PageModel.publish.linkedItems.addLink).click()
+        ]);
+        await expect(page.locator(PageModel.publish.linkedItems.deleteNewPublicationLink)).toBeVisible();
+
+        // Attempt to publish
+        await page.locator(PageModel.publish.publishButton).click();
+        await expect(page.getByText('Links to the following publications will be deleted upon publish:')).toBeVisible();
+        await expect(
+            page.locator('li:has-text("How do living organisms function, survive, reproduce and evolve?")')
+        ).toBeVisible();
     });
 });
 
@@ -1496,7 +1555,7 @@ test.describe('Publication flow + co-authors', () => {
         await page.locator(PageModel.publish.previewButton).click();
         await page.locator(`h1:has-text("${newTitle}")`).first().waitFor({ state: 'visible' });
 
-        await page.locator(PageModel.publish.versionsAccordionButton).waitFor();
+        await page.locator(PageModel.livePublication.versionsDropdown.toggleButton).waitFor();
 
         // switch between versions
         await expect(
@@ -1665,20 +1724,20 @@ test.describe('Publication flow + co-authors', () => {
         await page.reload();
         await page.locator(PageModel.publish.publishButtonTracker).click();
         await page.locator(PageModel.publish.confirmPublishButtonTracker).click();
-        await page.locator('aside a:has-text("Create New Version")').waitFor();
-        await expect(page.locator('aside a:has-text("Create New Version")')).toBeVisible();
+        await page.locator(PageModel.livePublication.versionsDropdown.createNewVersionButton).waitFor();
+        await expect(page.locator(PageModel.livePublication.versionsDropdown.createNewVersionButton)).toBeVisible();
 
         const publicationUrl = page.url();
 
         // login as co-author
         const page2 = await Helpers.users.getPageAsUser(browser, Helpers.users.user2);
         await page2.goto(publicationUrl);
-        await page2.locator('aside button[title="Versions"]').waitFor();
+        await page2.locator(PageModel.livePublication.versionsDropdown.toggleButton).waitFor();
 
         // create v2 from 'Versions' dropdown
-        await expect(page2.locator('aside button[title="Versions"]')).toBeVisible();
-        await expect(page2.locator('aside a:has-text("Create New Version")')).toBeVisible();
-        await page2.locator('aside a:has-text("Create New Version")').click();
+        await expect(page2.locator(PageModel.livePublication.versionsDropdown.toggleButton)).toBeVisible();
+        await expect(page2.locator(PageModel.livePublication.versionsDropdown.createNewVersionButton)).toBeVisible();
+        await page2.locator(PageModel.livePublication.versionsDropdown.createNewVersionButton).click();
         await page2.locator('button[title="Confirm"]').click();
 
         // wait to be redirected to the edit page
@@ -1694,11 +1753,11 @@ test.describe('Publication flow + co-authors', () => {
 
         // check previous corresponding author can 'Take over editing' from the 'Versions' dropdown
         await page.reload();
-        await page.locator('aside button[title="Versions"]').waitFor();
-        await expect(page.locator('aside button[title="Versions"]')).toBeVisible();
-        await expect(page.locator('aside a:has-text("Take over editing")')).toBeVisible();
+        await page.locator(PageModel.livePublication.versionsDropdown.toggleButton).waitFor();
+        await expect(page.locator(PageModel.livePublication.versionsDropdown.toggleButton)).toBeVisible();
+        await expect(page.locator(PageModel.livePublication.versionsDropdown.takeOverEditingButton)).toBeVisible();
 
-        await page.locator('aside a:has-text("Take over editing")').click();
+        await page.locator(PageModel.livePublication.versionsDropdown.takeOverEditingButton).click();
         await page.locator('button[title="Request Control"]').click();
         await page.waitForResponse(
             (response) => response.url().includes('/publication-versions/latest/request-control') && response.ok()

--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -435,7 +435,7 @@ test.describe('Publication flow', () => {
         await page.locator(`[role="option"]:has-text("Computer science")`).click();
         await page.locator(PageModel.publish.linkedItems.addLink).click();
         await page.waitForResponse((response) => response.url().includes('/topics') && response.ok());
-        await expect(page.locator(PageModel.publish.linkedItems.deleteTopicLink)).toBeVisible();
+        await expect(page.locator(PageModel.publish.linkedItems.deleteNewTopicLink)).toBeVisible();
     });
 
     test('Cannot link a non-problem publication to a topic', async ({ browser }) => {
@@ -473,7 +473,7 @@ test.describe('Publication flow', () => {
             (response) => response.url().includes('/publications') && response.request().method() === 'POST'
         );
         await (await page.waitForSelector("aside button:has-text('Linked items')")).click();
-        await expect(page.locator(PageModel.publish.linkedItems.deleteTopicLink)).toBeVisible();
+        await expect(page.locator(PageModel.publish.linkedItems.deleteNewTopicLink)).toBeVisible();
     });
 });
 

--- a/e2e/tests/PageModel.ts
+++ b/e2e/tests/PageModel.ts
@@ -192,8 +192,8 @@ export const PageModel = {
             publicationInput: 'input[placeholder="Search for publications"]',
             topicInput: 'input[placeholder="Search for topics"]',
             addLink: 'button[aria-label="Add link"]',
-            deletePublicationLink: '#linked-publication-table > tbody > tr > td > button[title="Delete"]',
-            deleteTopicLink: '#linked-topic-table > tbody > tr > td > button[title="Delete"]'
+            deleteNewPublicationLink: '#new-linked-publication-table > tbody > tr > td >> button[title="Delete"]',
+            deleteNewTopicLink: '#new-linked-topic-table > tbody > tr > td >> button[title="Delete"]'
         },
         text: {
             editor: '.ProseMirror >> nth=0',

--- a/e2e/tests/PageModel.ts
+++ b/e2e/tests/PageModel.ts
@@ -106,7 +106,12 @@ export const PageModel = {
         redFlagLink: '[aria-label="View red flags"]',
         redFlagPreview: '#red-flags > div > div > div > a[title="View  comment thread"]',
         resolveFlag: 'text=Resolve flag',
-        confirmResolve: 'button[aria-label="Resolve"]'
+        confirmResolve: 'button[aria-label="Resolve"]',
+        versionsDropdown: {
+            createNewVersionButton: 'aside a:has-text("Create New Version")',
+            takeOverEditingButton: 'aside a:has-text("Take over editing")',
+            toggleButton: 'aside button[title="Versions"]'
+        }
     },
     organisationalUserInfo: {
         name: 'text=Octopus',
@@ -156,6 +161,9 @@ export const PageModel = {
         removeTopicBookmark: 'a[href="/topics/cly468yyb00177ryzsvccai51"] + button[aria-label="Remove bookmark"]'
     },
     publish: {
+        tabs: {
+            linkedItems: "aside button:has-text('Linked items')"
+        },
         title: 'input[type="text"]',
         publicationType: 'select#publicationType',
         confirmPublicationType: 'input[type="checkbox"]',
@@ -188,12 +196,16 @@ export const PageModel = {
             affiliationDetails: 'textarea[placeholder="Enter any details"]'
         },
         linkedItems: {
-            entityTypeSelect: 'select#linked-entity-type',
-            publicationInput: 'input[placeholder="Search for publications"]',
-            topicInput: 'input[placeholder="Search for topics"]',
             addLink: 'button[aria-label="Add link"]',
+            cancelPublicationPendingDeletionButton:
+                '#inherited-linked-publication-table > tbody > tr > td >> button[title="Cancel pending deletion"]',
             deleteNewPublicationLink: '#new-linked-publication-table > tbody > tr > td >> button[title="Delete"]',
-            deleteNewTopicLink: '#new-linked-topic-table > tbody > tr > td >> button[title="Delete"]'
+            deleteNewTopicLink: '#new-linked-topic-table > tbody > tr > td >> button[title="Delete"]',
+            entityTypeSelect: 'select#linked-entity-type',
+            markPublicationLinkForDeletionButton:
+                '#inherited-linked-publication-table > tbody > tr > td >> button[title="Mark for deletion"]',
+            publicationInput: 'input[placeholder="Search for publications"]',
+            topicInput: 'input[placeholder="Search for topics"]'
         },
         text: {
             editor: '.ProseMirror >> nth=0',
@@ -244,9 +256,7 @@ export const PageModel = {
             dataCollectionApprover: 'textarea#dataPermissionsStatementProvidedBy',
             dataAccessStatementOther: 'input#other',
             dataAccessStatementFreeText: '#dataAccessStatementfreeText'
-        },
-        versionsAccordion: 'aside >> #versions-accordion',
-        versionsAccordionButton: 'aside button[title="Versions"]'
+        }
     },
     coauthorApprove: {},
     coauthorDeny: {},

--- a/e2e/tests/helpers/publicationCreation.ts
+++ b/e2e/tests/helpers/publicationCreation.ts
@@ -44,7 +44,7 @@ export const completeLinkedItemsTab = async (page: Page, linkedPubSearchTerm: st
         page.waitForResponse((response) => response.url().includes('/links') && response.ok()),
         page.locator(PageModel.publish.linkedItems.addLink).click()
     ]);
-    await expect(page.locator(PageModel.publish.linkedItems.deletePublicationLink)).toBeVisible();
+    await expect(page.locator(PageModel.publish.linkedItems.deleteNewPublicationLink)).toBeVisible();
 
     await page.locator(PageModel.publish.nextButton).click();
 };

--- a/ui/src/__tests__/components/Publication/Creation/LinkedItems/LinkedItemTable.test.tsx
+++ b/ui/src/__tests__/components/Publication/Creation/LinkedItems/LinkedItemTable.test.tsx
@@ -1,57 +1,130 @@
 import * as Components from '@/components';
-import * as Config from '@/config';
 import { render, screen } from '@testing-library/react';
 
-describe('Linked item table', () => {
-    const component = (
-        <Components.LinkedItemTable
-            deleteLink={jest.fn(() => Promise.resolve())}
-            entities={[]}
-            entityType={'LIVE_PUBLICATION'}
-        />
-    );
-
+describe('Inherited linked publications table', () => {
     beforeEach(() => {
-        render(component);
+        render(
+            <Components.LinkedItemTable
+                entityType={'PUBLICATION'}
+                inherited={true}
+                rows={
+                    <tr>
+                        <td>Sample content</td>
+                    </tr>
+                }
+            />
+        );
     });
 
     it('Renders a table', () => {
-        const table = screen.getByRole('table');
-        expect(table).toBeInTheDocument();
+        expect(screen.getByRole('table')).toBeInTheDocument();
     });
 
     it('Renders a header row', () => {
-        const headerRow = screen.getByRole('row');
-        expect(headerRow).toBeInTheDocument();
+        expect(screen.getAllByRole('row')[0]).toBeInTheDocument();
     });
 
-    it('Renders a column heading with the entity type label', () => {
-        const columnHeading = screen.getByRole('columnheader', {
-            name: Config.values.linkedEntityTypeLabels.LIVE_PUBLICATION
-        });
-        expect(columnHeading).toBeInTheDocument();
+    it('Renders a column heading named "Publications"', () => {
+        expect(
+            screen.getByRole('columnheader', {
+                name: 'Publications'
+            })
+        ).toBeInTheDocument();
     });
 
-    it('Renders a column heading named "Delete"', () => {
-        const columnHeading = screen.getByRole('columnheader', {
-            name: 'Delete'
-        });
-        expect(columnHeading).toBeInTheDocument();
+    it('Renders a column heading named "Status"', () => {
+        expect(
+            screen.getByRole('columnheader', {
+                name: 'Status'
+            })
+        ).toBeInTheDocument();
+    });
+
+    it('Renders a column heading named "View"', () => {
+        expect(
+            screen.getByRole('columnheader', {
+                name: 'View'
+            })
+        ).toBeInTheDocument();
+    });
+
+    it('Renders a column heading named "Actions"', () => {
+        expect(
+            screen.getByRole('columnheader', {
+                name: 'Actions'
+            })
+        ).toBeInTheDocument();
+    });
+
+    it('Renders jsx passed to "rows" prop', () => {
+        expect(screen.getByText('Sample content')).toBeInTheDocument();
+    });
+});
+
+describe('New linked publications table', () => {
+    beforeEach(() => {
+        render(<Components.LinkedItemTable entityType={'PUBLICATION'} inherited={false} rows={null} />);
+    });
+
+    it('Does not render a column heading named "Status"', () => {
+        expect(
+            screen.queryByRole('columnheader', {
+                name: 'Status'
+            })
+        ).not.toBeInTheDocument();
+    });
+
+    it('Renders a column heading named "View"', () => {
+        expect(
+            screen.getByRole('columnheader', {
+                name: 'View'
+            })
+        ).toBeInTheDocument();
+    });
+
+    it('Renders a column heading named "Actions"', () => {
+        expect(
+            screen.getByRole('columnheader', {
+                name: 'Actions'
+            })
+        ).toBeInTheDocument();
     });
 });
 
 describe('Linked item table for topics', () => {
-    it('Renders a column heading with the correct entity type label', () => {
-        render(
-            <Components.LinkedItemTable
-                deleteLink={jest.fn(() => Promise.resolve())}
-                entities={[]}
-                entityType={'TOPIC'}
-            />
-        );
-        const columnHeading = screen.getByRole('columnheader', {
-            name: Config.values.linkedEntityTypeLabels.TOPIC
-        });
-        expect(columnHeading).toBeInTheDocument();
+    beforeEach(() => {
+        render(<Components.LinkedItemTable entityType={'TOPIC'} inherited={true} rows={null} />);
+    });
+
+    it('Renders a column heading named "Topics"', () => {
+        expect(
+            screen.getByRole('columnheader', {
+                name: 'Topics'
+            })
+        ).toBeInTheDocument();
+    });
+
+    it('Does not render a column heading named "Status"', () => {
+        expect(
+            screen.queryByRole('columnheader', {
+                name: 'Status'
+            })
+        ).not.toBeInTheDocument();
+    });
+
+    it('Does not render a column heading named "View"', () => {
+        expect(
+            screen.queryByRole('columnheader', {
+                name: 'View'
+            })
+        ).not.toBeInTheDocument();
+    });
+
+    it('Renders a column heading named "Actions"', () => {
+        expect(
+            screen.getByRole('columnheader', {
+                name: 'Actions'
+            })
+        ).toBeInTheDocument();
     });
 });

--- a/ui/src/components/Publication/Creation/LinkedItems/LinkedItemTable.tsx
+++ b/ui/src/components/Publication/Creation/LinkedItems/LinkedItemTable.tsx
@@ -1,52 +1,45 @@
 import React from 'react';
 import * as Framer from 'framer-motion';
 
-import * as Components from '@/components';
-import * as Config from '@/config';
-import * as Interfaces from '@/interfaces';
-import * as Types from '@/types';
-
 type LinkedItemTableProps = {
-    deleteLink: (id: string) => Promise<void>;
-    entities: Interfaces.LinkedToPublication[] | Interfaces.BaseTopic[];
-    entityType: Types.LinkedEntityType;
+    entityType: 'PUBLICATION' | 'TOPIC';
+    inherited: boolean;
+    rows: React.ReactNode;
 };
 
 const LinkedItemTable: React.FC<LinkedItemTableProps> = (props): React.ReactElement => {
+    const thClasses =
+        'whitespace-pre py-3.5 px-3 sm:px-6 text-sm font-semibold text-grey-900 transition-colors duration-500 dark:text-grey-50';
     return (
-        <Framer.motion.div initial={{ opacity: 0.5 }} animate={{ opacity: 1 }} className="mt-8 flex flex-col">
-            <div className="inline-block min-w-full py-2 align-middle">
+        <Framer.motion.div initial={{ opacity: 0.5 }} animate={{ opacity: 1 }} className="mt-4 flex flex-col">
+            <div className="inline-block w-full py-2 align-middle">
                 <div className="overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 dark:ring-transparent">
                     <table
-                        className="min-w-full table-fixed divide-y divide-grey-100 dark:divide-teal-300"
-                        id={`linked-${props.entityType === 'TOPIC' ? 'topic' : 'publication'}-table`}
+                        className="w-full table-fixed divide-y divide-grey-100 dark:divide-teal-300"
+                        id={`${props.inherited ? 'inherited' : 'new'}-linked-${props.entityType === 'TOPIC' ? 'topic' : 'publication'}-table`}
                     >
                         <thead className="bg-grey-50 transition-colors duration-500 dark:bg-grey-700">
                             <tr>
-                                <th className="w-4/5 whitespace-pre py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-grey-900 transition-colors duration-500 dark:text-grey-50 sm:pl-6">
-                                    {Config.values.linkedEntityTypeLabels[props.entityType]}
+                                <th
+                                    className={`${props.entityType === 'PUBLICATION' ? (props.inherited ? 'w-1/2' : 'w-2/3') : 'w-5/6'} text-left ${thClasses}`}
+                                >
+                                    {props.entityType.charAt(0).toUpperCase() +
+                                        props.entityType.slice(1).toLowerCase() +
+                                        's'}
                                 </th>
-                                <th className="whitespace-pre py-3.5 pl-4 pr-3 text-center text-sm font-semibold text-grey-900 transition-colors duration-500 dark:text-grey-50 sm:pl-6 ">
-                                    Delete
-                                </th>
+                                {props.entityType === 'PUBLICATION' && (
+                                    <>
+                                        {props.inherited && (
+                                            <th className={`w-1/6 text-center ${thClasses}`}>Status</th>
+                                        )}
+                                        <th className={`w-1/6 text-center ${thClasses}`}>View</th>
+                                    </>
+                                )}
+                                <th className={`w-1/6 text-center ${thClasses}`}>Actions</th>
                             </tr>
                         </thead>
                         <tbody className="my-4 divide-grey-100 bg-white-50 transition-colors duration-500 dark:divide-teal-300 dark:bg-grey-600">
-                            {props.entities.map((entity) =>
-                                'type' in entity ? (
-                                    <Components.LinkedPublicationRow
-                                        key={entity.id}
-                                        linkedPublication={entity}
-                                        deleteLink={props.deleteLink}
-                                    />
-                                ) : (
-                                    <Components.LinkedTopicRow
-                                        key={entity.id}
-                                        topic={entity}
-                                        deleteTopic={props.deleteLink}
-                                    />
-                                )
-                            )}
+                            {props.rows}
                         </tbody>
                     </table>
                 </div>

--- a/ui/src/components/Publication/Creation/LinkedItems/LinkedPublicationRow.tsx
+++ b/ui/src/components/Publication/Creation/LinkedItems/LinkedPublicationRow.tsx
@@ -7,13 +7,14 @@ import * as OutlineIcons from '@heroicons/react/24/outline';
 
 type Props = {
     deleteLink: (id: string) => Promise<void>;
-    inherited: boolean;
     linkedPublication: Interfaces.LinkedToPublication;
     markLinkForDeletion: (id: string, toDelete: boolean) => Promise<void>;
 };
 
 const LinkedPublicationRow: React.FC<Props> = (props): React.ReactElement => {
     const [loading, setLoading] = React.useState(false);
+    const inherited = !props.linkedPublication.draft;
+
     const handleDelete = async () => {
         setLoading(true);
         await props.deleteLink(props.linkedPublication.linkId);
@@ -29,7 +30,7 @@ const LinkedPublicationRow: React.FC<Props> = (props): React.ReactElement => {
 
     return (
         <tr key={props.linkedPublication.id}>
-            <td className={`${props.inherited ? 'w-1/2' : 'w-2/3'} ${tdClasses}`}>
+            <td className={`${inherited ? 'w-1/2' : 'w-2/3'} ${tdClasses}`}>
                 <div className="space-y-2">
                     <span className="font-montserrat text-sm font-medium text-teal-600 transition-colors duration-500 dark:text-teal-100">
                         {Helpers.formatPublicationType(props.linkedPublication.type)}
@@ -57,7 +58,7 @@ const LinkedPublicationRow: React.FC<Props> = (props): React.ReactElement => {
                     </div>
                 </div>
             </td>
-            {props.inherited && (
+            {inherited && (
                 <td className={`w-1/6 font-medium ${tdClasses}`}>
                     {props.linkedPublication.pendingDeletion
                         ? 'To be deleted when published'

--- a/ui/src/components/Publication/Creation/LinkedItems/LinkedPublicationRow.tsx
+++ b/ui/src/components/Publication/Creation/LinkedItems/LinkedPublicationRow.tsx
@@ -1,25 +1,35 @@
 import React from 'react';
-import * as OutlineIcons from '@heroicons/react/24/outline';
-import * as Interfaces from '@/interfaces';
-import * as Helpers from '@/helpers';
 import * as Components from '@/components';
+import * as Config from '@/config';
+import * as Helpers from '@/helpers';
+import * as Interfaces from '@/interfaces';
+import * as OutlineIcons from '@heroicons/react/24/outline';
 
 type Props = {
-    linkedPublication: Interfaces.LinkedToPublication;
     deleteLink: (id: string) => Promise<void>;
+    inherited: boolean;
+    linkedPublication: Interfaces.LinkedToPublication;
+    markLinkForDeletion: (id: string, toDelete: boolean) => Promise<void>;
 };
 
 const LinkedPublicationRow: React.FC<Props> = (props): React.ReactElement => {
     const [loading, setLoading] = React.useState(false);
-    const handleClick = async () => {
+    const handleDelete = async () => {
         setLoading(true);
         await props.deleteLink(props.linkedPublication.linkId);
         setLoading(false);
     };
+    const handleMarkForDeletion = async (toDelete: boolean) => {
+        setLoading(true);
+        await props.markLinkForDeletion(props.linkedPublication.linkId, toDelete);
+        setLoading(false);
+    };
+    const iconClasses = 'h-6 w-6 text-teal-600 transition-colors duration-500 dark:text-teal-400';
+    const tdClasses = 'py-4 px-3 sm:px-6 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50';
 
     return (
         <tr key={props.linkedPublication.id}>
-            <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
+            <td className={`${props.inherited ? 'w-1/2' : 'w-2/3'} ${tdClasses}`}>
                 <div className="space-y-2">
                     <span className="font-montserrat text-sm font-medium text-teal-600 transition-colors duration-500 dark:text-teal-100">
                         {Helpers.formatPublicationType(props.linkedPublication.type)}
@@ -47,46 +57,80 @@ const LinkedPublicationRow: React.FC<Props> = (props): React.ReactElement => {
                     </div>
                 </div>
             </td>
-            <td className="whitespace-nowrap px-8 py-4 text-center text-sm font-medium text-grey-900 transition-colors duration-500 dark:text-white-50">
-                {props.linkedPublication.draft ? (
-                    loading ? (
-                        <Components.IconButton
-                            className="p-2"
-                            title="Refresh"
-                            icon={
-                                <OutlineIcons.ArrowPathIcon
-                                    className="h-6 w-6 animate-reverse-spin text-teal-600 transition-colors duration-500 dark:text-teal-400"
-                                    aria-hidden="true"
-                                />
-                            }
-                            onClick={handleClick}
-                        />
-                    ) : (
+            {props.inherited && (
+                <td className={`w-1/6 font-medium ${tdClasses}`}>
+                    {props.linkedPublication.pendingDeletion
+                        ? 'To be deleted when published'
+                        : 'To be retained when published'}
+                </td>
+            )}
+            <td className={`w-1/6 text-center font-medium ${tdClasses}`}>
+                <div className="flex items-center justify-center">
+                    <Components.Link
+                        href={`${Config.urls.viewPublication.path}/${props.linkedPublication.id}`}
+                        openNew={true}
+                        ariaLabel={'Visit publication'}
+                        className="p-2"
+                    >
+                        <OutlineIcons.ArrowTopRightOnSquareIcon className={iconClasses} />
+                    </Components.Link>
+                </div>
+            </td>
+            <td className={`w-1/6 text-center font-medium ${tdClasses}`}>
+                <div className="flex items-center justify-center">
+                    {props.linkedPublication.draft ? (
                         <Components.IconButton
                             className="p-2"
                             title="Delete"
                             icon={
-                                <OutlineIcons.TrashIcon
-                                    className="h-6 w-6 text-teal-600 transition-colors duration-500 dark:text-teal-400"
-                                    aria-hidden="true"
-                                />
+                                loading ? (
+                                    <OutlineIcons.ArrowPathIcon
+                                        className={iconClasses + ' animate-spin'}
+                                        aria-hidden="true"
+                                    />
+                                ) : (
+                                    <OutlineIcons.TrashIcon className={iconClasses} aria-hidden="true" />
+                                )
                             }
-                            onClick={handleClick}
+                            onClick={handleDelete}
+                            disabled={loading}
                         />
-                    )
-                ) : (
-                    <Components.IconButton
-                        className="p-2"
-                        disabled
-                        title="Deletion forbidden as link is inherited from previous version"
-                        icon={
-                            <OutlineIcons.NoSymbolIcon
-                                className="h-6 w-6 text-teal-600 transition-colors duration-500 dark:text-teal-400"
-                                aria-hidden="true"
-                            />
-                        }
-                    />
-                )}
+                    ) : props.linkedPublication.pendingDeletion ? (
+                        <Components.IconButton
+                            className="p-2"
+                            title="Cancel pending deletion"
+                            icon={
+                                loading ? (
+                                    <OutlineIcons.ArrowPathIcon
+                                        className={iconClasses + ' animate-spin'}
+                                        aria-hidden="true"
+                                    />
+                                ) : (
+                                    <OutlineIcons.ArrowUturnLeftIcon className={iconClasses} aria-hidden="true" />
+                                )
+                            }
+                            onClick={() => handleMarkForDeletion(false)}
+                            disabled={loading}
+                        />
+                    ) : (
+                        <Components.IconButton
+                            className="p-2"
+                            title="Mark for deletion"
+                            icon={
+                                loading ? (
+                                    <OutlineIcons.ArrowPathIcon
+                                        className={iconClasses + ' animate-spin'}
+                                        aria-hidden="true"
+                                    />
+                                ) : (
+                                    <OutlineIcons.TrashIcon className={iconClasses} aria-hidden="true" />
+                                )
+                            }
+                            onClick={() => handleMarkForDeletion(true)}
+                            disabled={loading}
+                        />
+                    )}
+                </div>
             </td>
         </tr>
     );

--- a/ui/src/components/Publication/Creation/LinkedItems/LinkedTopicRow.tsx
+++ b/ui/src/components/Publication/Creation/LinkedItems/LinkedTopicRow.tsx
@@ -11,57 +11,49 @@ type Props = {
 
 const LinkedTopicRow: React.FC<Props> = (props): React.ReactElement => {
     const [loading, setLoading] = React.useState(false);
-    const handleClick = async () => {
+    const handleDelete = async () => {
         setLoading(true);
         await props.deleteTopic(props.topic.id);
         setLoading(false);
     };
 
+    const iconClasses = 'h-6 w-6 text-teal-600 transition-colors duration-500 dark:text-teal-400';
+    const tdClasses =
+        'whitespace-nowrap py-4 px-3 sm:px-6 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50';
+
     return (
         <tr key={props.topic.id}>
-            <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50 sm:pl-6">
+            <td className={`w-4/5 ${tdClasses}`}>
                 <p className="text-grey-800 transition-colors duration-500 dark:text-white-50">{props.topic.title}</p>
             </td>
-            <td className="whitespace-nowrap px-8 py-4 text-center text-sm font-medium text-grey-900 transition-colors duration-500 dark:text-white-50">
-                {props.topic.draft ? (
-                    loading ? (
-                        <Components.IconButton
-                            className="p-2"
-                            title="Refresh"
-                            icon={
-                                <OutlineIcons.ArrowPathIcon
-                                    className="h-6 w-6 animate-reverse-spin text-teal-600 transition-colors duration-500 dark:text-teal-400"
-                                    aria-hidden="true"
-                                />
-                            }
-                            onClick={handleClick}
-                        />
-                    ) : (
+            <td className={`w-1/5 text-center ${tdClasses}`}>
+                <div className="flex items-center justify-center">
+                    {props.topic.draft ? (
                         <Components.IconButton
                             className="p-2"
                             title="Delete"
                             icon={
-                                <OutlineIcons.TrashIcon
-                                    className="h-6 w-6 text-teal-600 transition-colors duration-500 dark:text-teal-400"
-                                    aria-hidden="true"
-                                />
+                                loading ? (
+                                    <OutlineIcons.ArrowPathIcon
+                                        className={iconClasses + ' animate-spin'}
+                                        aria-hidden="true"
+                                    />
+                                ) : (
+                                    <OutlineIcons.TrashIcon className={iconClasses} aria-hidden="true" />
+                                )
                             }
-                            onClick={handleClick}
+                            onClick={handleDelete}
+                            disabled={loading}
                         />
-                    )
-                ) : (
-                    <Components.IconButton
-                        className="p-2"
-                        disabled
-                        title="Deletion forbidden as topic is inherited from previous version"
-                        icon={
-                            <OutlineIcons.NoSymbolIcon
-                                className="h-6 w-6 text-teal-600 transition-colors duration-500 dark:text-teal-400"
-                                aria-hidden="true"
-                            />
-                        }
-                    />
-                )}
+                    ) : (
+                        <Components.IconButton
+                            className="p-2"
+                            disabled
+                            title="Deletion forbidden as topic is inherited from previous version"
+                            icon={<OutlineIcons.NoSymbolIcon className={iconClasses} aria-hidden="true" />}
+                        />
+                    )}
+                </div>
             </td>
         </tr>
     );

--- a/ui/src/components/Publication/Creation/LinkedItems/LinksPendingDeletionMessage.tsx
+++ b/ui/src/components/Publication/Creation/LinkedItems/LinksPendingDeletionMessage.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+const LinksPendingDeletionMessage: React.FC<{ publicationTitles: string[] }> = (props): React.ReactElement => {
+    const hasPublications = props.publicationTitles.length > 0;
+
+    return (
+        <>
+            {hasPublications ? (
+                <>
+                    <p className="mt-2 text-sm font-semibold text-grey-700">
+                        Links to the following publications will be deleted upon publish:
+                    </p>
+                    <ul className="mt-2 mx-auto w-min text-sm text-grey-700 list-disc">
+                        {props.publicationTitles.map((title) => (
+                            <li key={title} className="whitespace-nowrap text-left">
+                                {title}
+                            </li>
+                        ))}
+                    </ul>
+                </>
+            ) : null}
+        </>
+    );
+};
+
+export default LinksPendingDeletionMessage;

--- a/ui/src/components/Publication/Creation/LinkedItems/LinksPendingDeletionMessage.tsx
+++ b/ui/src/components/Publication/Creation/LinkedItems/LinksPendingDeletionMessage.tsx
@@ -10,9 +10,9 @@ const LinksPendingDeletionMessage: React.FC<{ publicationTitles: string[] }> = (
                     <p className="mt-2 text-sm font-semibold text-grey-700">
                         Links to the following publications will be deleted upon publish:
                     </p>
-                    <ul className="mt-2 mx-auto w-min text-sm text-grey-700 list-disc">
+                    <ul className="mt-2 mx-auto w-full text-sm text-grey-700 list-disc">
                         {props.publicationTitles.map((title) => (
-                            <li key={title} className="whitespace-nowrap text-left">
+                            <li key={title} className="text-left">
                                 {title}
                             </li>
                         ))}

--- a/ui/src/components/Publication/Creation/LinkedItems/index.tsx
+++ b/ui/src/components/Publication/Creation/LinkedItems/index.tsx
@@ -122,7 +122,6 @@ const Links: React.FC = (): React.ReactElement => {
             <Components.LinkedPublicationRow
                 key={linkedPublication.id}
                 deleteLink={deletePublicationLink}
-                inherited={!linkedPublication.draft}
                 linkedPublication={linkedPublication}
                 markLinkForDeletion={markPublicationLinkForDeletion}
             />

--- a/ui/src/components/Publication/Creation/LinkedItems/index.tsx
+++ b/ui/src/components/Publication/Creation/LinkedItems/index.tsx
@@ -48,6 +48,28 @@ const Links: React.FC = (): React.ReactElement => {
         [linkedTo, setError, updateLinkedTo, user]
     );
 
+    const markPublicationLinkForDeletion = useCallback(
+        async (linkId: string, toDelete: boolean) => {
+            setError(null);
+            if (user) {
+                try {
+                    await api.post(`/links/${linkId}/mark-for-deletion`, { toDelete }, user.token);
+
+                    // update linked publications in the UI
+                    const newLinkedTo = structuredClone(linkedTo);
+                    const changedLinkIndex = newLinkedTo.findIndex(
+                        (linkedPublication) => linkedPublication.linkId === linkId
+                    );
+                    newLinkedTo[changedLinkIndex].pendingDeletion = toDelete;
+                    updateLinkedTo(newLinkedTo);
+                } catch (err) {
+                    setError('There was a problem marking the link for deletion.');
+                }
+            }
+        },
+        [linkedTo, setError, updateLinkedTo, user]
+    );
+
     const deleteTopicLink = useCallback(
         async (topicId: string) => {
             setError(null);
@@ -82,7 +104,7 @@ const Links: React.FC = (): React.ReactElement => {
 
     // Problems can link to all entity types.
     if (isProblem) {
-        linkableEntityTypes = Object.keys(Config.values.linkedEntityTypeLabels) as Types.LinkedEntityType[];
+        linkableEntityTypes = ['DRAFT_PUBLICATION', 'LIVE_PUBLICATION', 'TOPIC'];
     } else {
         // Peer reviews can't link to drafts.
         if (type === 'PEER_REVIEW') {
@@ -92,6 +114,48 @@ const Links: React.FC = (): React.ReactElement => {
         }
     }
 
+    const inheritedLinkRows: React.ReactNode[] = [];
+    const newLinkRows: React.ReactNode[] = [];
+
+    for (const linkedPublication of linkedTo) {
+        const row = (
+            <Components.LinkedPublicationRow
+                key={linkedPublication.id}
+                deleteLink={deletePublicationLink}
+                inherited={!linkedPublication.draft}
+                linkedPublication={linkedPublication}
+                markLinkForDeletion={markPublicationLinkForDeletion}
+            />
+        );
+        if (linkedPublication.draft) {
+            newLinkRows.push(row);
+        } else {
+            inheritedLinkRows.push(row);
+        }
+    }
+
+    const inheritedTopicRows: React.ReactNode[] = [];
+    const newTopicRows: React.ReactNode[] = [];
+
+    for (const topic of topics) {
+        const row = <Components.LinkedTopicRow key={topic.id} topic={topic} deleteTopic={deleteTopicLink} />;
+        if (topic.draft) {
+            newTopicRows.push(row);
+        } else {
+            inheritedTopicRows.push(row);
+        }
+    }
+
+    const h3Classes =
+        'mb-4 font-montserrat text-lg font-semibold text-grey-800 transition-colors duration-500 dark:text-white-100';
+    const paragraphClasses = 'text-sm text-grey-800 transition-colors duration-500 dark:text-white-50';
+
+    const linkedEntityTypeLabels: Record<Types.LinkedEntityType, string> = {
+        LIVE_PUBLICATION: 'Publications',
+        TOPIC: 'Research topics',
+        DRAFT_PUBLICATION: 'Drafts'
+    };
+
     return (
         <div className="space-y-6 lg:space-y-10 2xl:w-10/12">
             <div>
@@ -99,14 +163,14 @@ const Links: React.FC = (): React.ReactElement => {
                     text={`What ${linkableEntityLabel}s should this publication be linked from?`}
                     required
                 />
-                <p className="mb-6 block text-sm text-grey-800 transition-colors duration-500 dark:text-white-50">
+                <p className={`mb-6 ${paragraphClasses}`}>
                     All publications in Octopus are linked to each other to form research chains, branching down from
                     research problems to real world implementations.{' '}
                     {isProblem &&
                         ' For research problems, if there is no existing publication on the system that yours relates to, you can link to a research topic instead.'}
                 </p>
 
-                <p className="mb-6 block text-sm text-grey-800 transition-colors duration-500 dark:text-white-50">
+                <p className={`mb-6 ${paragraphClasses}`}>
                     Your {Helpers.formatPublicationType(type)} must be linked from at least one other{' '}
                     {linkableEntityLabel} on Octopus. {Helpers.formatPublicationType(type)} can be linked from{' '}
                     {linkablePublicationTypes.map((type, index) => {
@@ -124,7 +188,7 @@ const Links: React.FC = (): React.ReactElement => {
                     {isProblem && ' Use the dropdown to switch between searching for publications or research topics.'}
                 </p>
 
-                <p className="mb-6 block text-sm text-grey-800 transition-colors duration-500 dark:text-white-50">
+                <p className={paragraphClasses}>
                     This approach structures the content of the platform and makes your work more discoverable. It also
                     helps you avoid repeating work, as there is no need to keep re-writing descriptions of well-known
                     Research Problems, or Methods etc.
@@ -132,7 +196,7 @@ const Links: React.FC = (): React.ReactElement => {
             </div>
 
             <div className="relative">
-                <Components.PublicationCreationStepTitle text="Add links" required />
+                <Components.PublicationCreationStepTitle text="Add new links" required />
                 <div className="flex flex-col flex-wrap gap-4 sm:flex-row sm:items-center">
                     {type !== 'PEER_REVIEW' && (
                         <select
@@ -147,7 +211,7 @@ const Links: React.FC = (): React.ReactElement => {
                         >
                             {linkableEntityTypes.map((type) => (
                                 <option key={type} value={type}>
-                                    {Config.values.linkedEntityTypeLabels[type]}
+                                    {linkedEntityTypeLabels[type]}
                                 </option>
                             ))}
                         </select>
@@ -172,15 +236,37 @@ const Links: React.FC = (): React.ReactElement => {
                 </div>
             </div>
 
-            {!!linkedTo.length && (
-                <Components.LinkedItemTable
-                    deleteLink={deletePublicationLink}
-                    entities={linkedTo}
-                    entityType="LIVE_PUBLICATION"
-                />
+            {(!!inheritedLinkRows.length || !!inheritedTopicRows.length) && (
+                <div>
+                    <h3 className={h3Classes}>Links on published version</h3>
+                    {!!inheritedLinkRows.length && (
+                        <>
+                            <p className={paragraphClasses}>
+                                Links that were added on the previously published version can be marked to be deleted
+                                when this new version is published.
+                            </p>
+                            <Components.LinkedItemTable
+                                entityType="PUBLICATION"
+                                inherited={true}
+                                rows={inheritedLinkRows}
+                            />
+                        </>
+                    )}
+                    {!!inheritedTopicRows.length && (
+                        <Components.LinkedItemTable entityType="TOPIC" inherited={true} rows={inheritedTopicRows} />
+                    )}
+                </div>
             )}
-            {!!topics?.length && (
-                <Components.LinkedItemTable deleteLink={deleteTopicLink} entities={topics} entityType="TOPIC" />
+            {(!!newLinkRows.length || !!newTopicRows.length) && (
+                <div>
+                    <h3 className={h3Classes}>Links added in this version</h3>
+                    {!!newLinkRows.length && (
+                        <Components.LinkedItemTable entityType="PUBLICATION" inherited={false} rows={newLinkRows} />
+                    )}
+                    {!!newTopicRows.length && (
+                        <Components.LinkedItemTable entityType="TOPIC" inherited={false} rows={newTopicRows} />
+                    )}
+                </div>
             )}
             {!error && !linkedTo.length && !topics?.length && (
                 <Components.Alert

--- a/ui/src/components/index.tsx
+++ b/ui/src/components/index.tsx
@@ -44,6 +44,7 @@ export { default as LinkedPublicationsCombobox } from './Publication/Creation/Li
 export { default as LinkedPublicationsComboboxOption } from './Publication/Creation/LinkedItems/LinkedPublicationCombobox/Option';
 export { default as LinkedTopicRow } from './Publication/Creation/LinkedItems/LinkedTopicRow';
 export { default as LinkedTopicsCombobox } from './Publication/Creation/LinkedItems/LinkedTopicsCombobox';
+export { default as LinksPendingDeletionMessage } from './Publication/Creation/LinkedItems/LinksPendingDeletionMessage';
 export { default as List } from './List';
 export { default as ListItem } from './List/Item';
 export { default as Maintenance } from './Maintenance';

--- a/ui/src/config/values.ts
+++ b/ui/src/config/values.ts
@@ -957,9 +957,3 @@ export const doiBaseUrl = `https://${process.env.NEXT_PUBLIC_STAGE === 'prod' ? 
 
 // Defines the boundaries for LaTeX expressions in publication content. Expressions are enclosed on both ends by "$$".
 export const latexRegex = /\$\$([^$]*)\$\$/gi;
-
-export const linkedEntityTypeLabels: Record<Types.LinkedEntityType, string> = {
-    LIVE_PUBLICATION: 'Publications',
-    TOPIC: 'Research topics',
-    DRAFT_PUBLICATION: 'Drafts'
-};

--- a/ui/src/layouts/BuildPublication.tsx
+++ b/ui/src/layouts/BuildPublication.tsx
@@ -73,9 +73,10 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
             if (!publicationVersion.content) ready = { ready: false, message: 'You must provide main text' };
             const hasLiveLinks =
                 linkedTo.length && linkedTo.every((linkedPublication) => linkedPublication.currentStatus === 'LIVE');
+            const hasLinkNotPendingDeletion = linkedTo.some((link) => link.pendingDeletion === false);
             if (
                 (publicationVersion.publication.type === 'PROBLEM' &&
-                    !hasLiveLinks &&
+                    (!hasLiveLinks || !hasLinkNotPendingDeletion) &&
                     !publicationVersion.topics.length) ||
                 (publicationVersion.publication.type !== 'PROBLEM' && !hasLiveLinks)
             )
@@ -488,6 +489,7 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
     const topNextButtonSmallId = 'top-next-button-small-displays';
 
     const linkedToARI = store.linkedTo.some((linkedTo) => linkedTo.externalSource === 'ARI' && linkedTo.draft);
+    const linksPendingDeletion = store.linkedTo.filter((link) => link.pendingDeletion);
 
     return (
         <>
@@ -517,6 +519,18 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
                 icon={<OutlineIcons.CloudArrowUpIcon className="h-10 w-10 text-grey-600" aria-hidden="true" />}
             >
                 <p className="text-sm text-grey-700">It is not possible to make any changes post-publication.</p>
+                {!!linksPendingDeletion.length && (
+                    <>
+                        <p className="mt-2 text-sm font-semibold text-grey-700">
+                            Links to the following publications will be deleted upon publish:
+                        </p>
+                        <ul className="mt-2 mx-auto w-min text-sm text-grey-700 list-disc">
+                            {linksPendingDeletion.map((link) => (
+                                <li className="whitespace-nowrap">{link.title}</li>
+                            ))}
+                        </ul>
+                    </>
+                )}
                 {linkedToARI && (
                     <>
                         <p className="text-sm text-grey-700 my-4">

--- a/ui/src/layouts/BuildPublication.tsx
+++ b/ui/src/layouts/BuildPublication.tsx
@@ -520,16 +520,9 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
             >
                 <p className="text-sm text-grey-700">It is not possible to make any changes post-publication.</p>
                 {!!linksPendingDeletion.length && (
-                    <>
-                        <p className="mt-2 text-sm font-semibold text-grey-700">
-                            Links to the following publications will be deleted upon publish:
-                        </p>
-                        <ul className="mt-2 mx-auto w-min text-sm text-grey-700 list-disc">
-                            {linksPendingDeletion.map((link) => (
-                                <li className="whitespace-nowrap">{link.title}</li>
-                            ))}
-                        </ul>
-                    </>
+                    <Components.LinksPendingDeletionMessage
+                        publicationTitles={linksPendingDeletion.flatMap((link) => (link.title ? [link.title] : []))}
+                    />
                 )}
                 {linkedToARI && (
                     <>

--- a/ui/src/lib/helpers.tsx
+++ b/ui/src/lib/helpers.tsx
@@ -392,11 +392,12 @@ export const getTabCompleteness = (
                 const hasCoauthors = publicationVersion?.coAuthors.length > 1;
                 const hasLink = linkedTo.length > 0 || publicationVersion.topics.length > 0;
                 const allLinkedPublicationsAreLive = linkedTo.every((link) => link.currentStatus === 'LIVE');
+                const hasLinkNotPendingDeletion = linkedTo.some((link) => link.pendingDeletion === false);
                 if (
                     // When coauthors are added, any link is fine to request approval, even to a draft publication.
                     (hasCoauthors && hasLink) ||
                     // When no coauthors are added, all linked publications need to be live.
-                    (!hasCoauthors && hasLink && allLinkedPublicationsAreLive)
+                    (!hasCoauthors && hasLink && allLinkedPublicationsAreLive && hasLinkNotPendingDeletion)
                 ) {
                     stepsWithCompleteness.push({ status: 'COMPLETE', ...step });
                 } else {

--- a/ui/src/lib/interfaces.ts
+++ b/ui/src/lib/interfaces.ts
@@ -141,6 +141,7 @@ export interface LinkedToPublication extends LinkedPublication {
     draft: boolean;
     externalSource: Types.PublicationImportSource | null;
     linkId: string;
+    pendingDeletion?: boolean;
 }
 
 export interface LinkedFromPublication extends LinkedPublication {
@@ -148,6 +149,7 @@ export interface LinkedFromPublication extends LinkedPublication {
     linkId: string;
     parentPublicationId: string;
     parentPublicationType: Types.PublicationType;
+    pendingDeletion?: boolean;
 }
 
 export interface PublicationWithLinks {

--- a/ui/src/pages/publications/[id]/versions/[versionId].tsx
+++ b/ui/src/pages/publications/[id]/versions/[versionId].tsx
@@ -364,9 +364,30 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
     };
 
     const handlePublish = React.useCallback(async () => {
+        let modalDescription: React.ReactNode[] = [];
+        modalDescription.push(
+            <p key="no-changes-post-publication">It is not possible to make any changes post-publication.</p>
+        );
+
+        const linksPendingDeletion = linkedTo.filter((link) => link.pendingDeletion);
+        if (linksPendingDeletion.length) {
+            modalDescription.push(
+                <React.Fragment key="links-pending-deletion">
+                    <p className="mt-2 font-semibold">
+                        Links to the following publications will be deleted upon publish:
+                    </p>
+                    <ul className="mt-2 mx-auto w-min list-disc">
+                        {linksPendingDeletion.map((link) => (
+                            <li className="whitespace-nowrap">{link.title}</li>
+                        ))}
+                    </ul>
+                </React.Fragment>
+            );
+        }
+
         const confirmed = await confirmation(
             'Are you sure you want to publish?',
-            'It is not possible to make any changes post-publication.',
+            modalDescription,
             <OutlineIcons.CloudArrowUpIcon className="h-10 w-10 text-grey-600" aria-hidden="true" />,
             'Yes',
             'No'
@@ -392,7 +413,7 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
                 setPublishing(false);
             }
         }
-    }, [confirmation, publicationVersion?.id, router]);
+    }, [confirmation, linkedTo, publicationVersion?.id, router]);
 
     const handleUnlock = async () => {
         if (isUnlocking) {

--- a/ui/src/pages/publications/[id]/versions/[versionId].tsx
+++ b/ui/src/pages/publications/[id]/versions/[versionId].tsx
@@ -372,16 +372,10 @@ const Publication: Types.NextPage<Props> = (props): React.ReactElement => {
         const linksPendingDeletion = linkedTo.filter((link) => link.pendingDeletion);
         if (linksPendingDeletion.length) {
             modalDescription.push(
-                <React.Fragment key="links-pending-deletion">
-                    <p className="mt-2 font-semibold">
-                        Links to the following publications will be deleted upon publish:
-                    </p>
-                    <ul className="mt-2 mx-auto w-min list-disc">
-                        {linksPendingDeletion.map((link) => (
-                            <li className="whitespace-nowrap">{link.title}</li>
-                        ))}
-                    </ul>
-                </React.Fragment>
+                <Components.LinksPendingDeletionMessage
+                    key="links-pending-deletion"
+                    publicationTitles={linksPendingDeletion.flatMap((link) => (link.title ? [link.title] : []))}
+                />
             );
         }
 


### PR DESCRIPTION
The purpose of this PR was to allow users to remove existing links when they reversion a publication in case they have added one incorrectly, or the linked publication has been edited to make it no longer relevant.

---

### Acceptance Criteria:

- When re-versioning a publication, the existing “Add links” area now titled “Add new links”  
- When re-versioning a publication, a new table is present in the linked publications tab, above the “Add new links” area, titled “Links on published version”
    - Below the “Links on published version” title, above the new table, text is present reading “Links that were added on the previously published version can be marked to be deleted when this new version is published.
    - The “Delete” column in this table now reads “Actions”
        - If a link in this column is not pending deletion, this column includes a “Delete” button that will mark the link as pending deletion
        - If a link in this column is pending deletion, this column includes a “Cancel Deletion” button that will remove the pending deletion
    - The new table includes a “Status” column to the left of the actions column
        - If a link is marked as pending deletion, this column reads “To be deleted when published” in red text
        - If a link is not marked as pending deletion, this column reads “To be retained when published” 
- Upon attempting to publish a new version, at least one link must be present and NOT marked as “Pending deletion”
- Upon publishing the new version, any links that are marked as “Pending deletion” are deleted

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

API
![Screenshot 2025-05-13 132751](https://github.com/user-attachments/assets/d6bed334-ce46-49d7-800c-3777ea6a28f3)

UI
![Screenshot 2025-05-13 133032](https://github.com/user-attachments/assets/e5f8fa62-7b08-453f-809b-f73ea63a996e)

E2E
![Screenshot 2025-05-13 120023](https://github.com/user-attachments/assets/93f070b4-4c75-43df-a7e0-97c8655998bc)

---

### Screenshots:

![Screenshot 2025-05-13 133656](https://github.com/user-attachments/assets/f5da37f1-b3f7-446d-a370-4c7ab71c4fe3)
