### PR TITLE
OC-1057: Endpoints for publication bundles

### DIFF
--- a/api/.swcrc
+++ b/api/.swcrc
@@ -72,6 +72,9 @@
             "publication/*": [
                 "src/components/publication/*"
             ],
+            "publicationBundle/*": [
+                "src/components/publicationBundle/*"
+            ],
             "publicationVersion/*": [
                 "src/components/publicationVersion/*"
             ],

--- a/api/prisma/migrations/20250513140607_publication_bundles/migration.sql
+++ b/api/prisma/migrations/20250513140607_publication_bundles/migration.sql
@@ -1,0 +1,31 @@
+-- CreateTable
+CREATE TABLE "PublicationBundle" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "name" TEXT NOT NULL,
+    "createdBy" TEXT NOT NULL,
+
+    CONSTRAINT "PublicationBundle_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_PublicationToPublicationBundle" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_PublicationToPublicationBundle_AB_unique" ON "_PublicationToPublicationBundle"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_PublicationToPublicationBundle_B_index" ON "_PublicationToPublicationBundle"("B");
+
+-- AddForeignKey
+ALTER TABLE "PublicationBundle" ADD CONSTRAINT "PublicationBundle_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicationToPublicationBundle" ADD CONSTRAINT "_PublicationToPublicationBundle_A_fkey" FOREIGN KEY ("A") REFERENCES "Publication"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PublicationToPublicationBundle" ADD CONSTRAINT "_PublicationToPublicationBundle_B_fkey" FOREIGN KEY ("B") REFERENCES "PublicationBundle"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -37,6 +37,7 @@ model User {
     defaultTopicId      String?
     defaultTopic        Topic?               @relation(fields: [defaultTopicId], references: [id])
     mappings            UserMapping[]
+    publicationBundles  PublicationBundle[]
 }
 
 model Verification {
@@ -59,23 +60,24 @@ model Images {
 }
 
 model Publication {
-    id               String                   @id @default(cuid())
-    url_slug         String                   @unique @default(cuid())
-    type             PublicationType
-    doi              String
-    publicationFlags PublicationFlags[]
-    linkedTo         Links[]                  @relation("from")
-    linkedFrom       Links[]                  @relation("to")
-    versions         PublicationVersion[]
+    id                 String                   @id @default(cuid())
+    url_slug           String                   @unique @default(cuid())
+    type               PublicationType
+    doi                String
+    publicationFlags   PublicationFlags[]
+    linkedTo           Links[]                  @relation("from")
+    linkedFrom         Links[]                  @relation("to")
+    versions           PublicationVersion[]
+    publicationBundles PublicationBundle[]
     // These reverse relations are needed by prisma, but we shouldn't use them in the application.
     // Prisma doesn't allow symmetrical many-to-many self relations.
     // There must be an "asymmetrical" relationship (e.g. from and to) in the schema. In practice, we will treat
     // crosslink entities as having a pair of publications associated that are of equal importance.
-    crosslinksFrom   Crosslink[]              @relation("crosslinkFrom")
-    crosslinksTo     Crosslink[]              @relation("crosslinkTo")
+    crosslinksFrom     Crosslink[]              @relation("crosslinkFrom")
+    crosslinksTo       Crosslink[]              @relation("crosslinkTo")
     // Populated when a publication has been imported from an external source.
-    externalId       String?
-    externalSource   PublicationImportSource?
+    externalId         String?
+    externalSource     PublicationImportSource?
 }
 
 model PublicationVersion {
@@ -308,6 +310,16 @@ model IngestLog {
     source PublicationImportSource
     start  DateTime                @default(now())
     end    DateTime?
+}
+
+model PublicationBundle {
+    id           String        @id @default(cuid())
+    createdAt    DateTime      @default(now())
+    updatedAt    DateTime      @updatedAt
+    name         String
+    createdBy    String
+    user         User          @relation(fields: [createdBy], references: [id], onDelete: Cascade)
+    publications Publication[]
 }
 
 enum EventType {

--- a/api/prisma/seeds/index.ts
+++ b/api/prisma/seeds/index.ts
@@ -10,6 +10,7 @@ export { default as prodUsers } from './prod/users';
 export { default as testBookmarks } from './local/unitTesting/bookmarks';
 export { default as testEvents } from './local/unitTesting/events';
 export { default as testIngestLogs } from './local/unitTesting/ingestLogs';
+export { default as testPublicationBundles } from './local/unitTesting/publicationBundles';
 export { default as testPublications } from './local/unitTesting/publications';
 export { default as testReferences } from './local/unitTesting/references';
 export { default as testTopicMappings } from './local/unitTesting/topicMappings';

--- a/api/prisma/seeds/local/unitTesting/publicationBundles.ts
+++ b/api/prisma/seeds/local/unitTesting/publicationBundles.ts
@@ -1,0 +1,14 @@
+import { Prisma } from '@prisma/client';
+
+const publicationBundleSeeds: Prisma.PublicationBundleUncheckedCreateInput[] = [
+    {
+        id: 'test-bundle',
+        name: 'Test Bundle',
+        publications: {
+            connect: [{ id: 'publication-problem-live' }, { id: 'publication-problem-live-2' }]
+        },
+        createdBy: 'test-user-1'
+    }
+];
+
+export default publicationBundleSeeds;

--- a/api/prisma/seeds/local/unitTesting/publicationBundles.ts
+++ b/api/prisma/seeds/local/unitTesting/publicationBundles.ts
@@ -7,7 +7,17 @@ const publicationBundleSeeds: Prisma.PublicationBundleUncheckedCreateInput[] = [
         publications: {
             connect: [{ id: 'publication-problem-live' }, { id: 'publication-problem-live-2' }]
         },
-        createdBy: 'test-user-1'
+        createdBy: 'test-user-1',
+        createdAt: new Date('2023-01-01T00:00:00Z')
+    },
+    {
+        id: 'test-bundle-2',
+        name: 'Test Bundle 2',
+        publications: {
+            connect: [{ id: 'publication-hypothesis-live' }, { id: 'publication-protocol-live' }]
+        },
+        createdBy: 'test-user-1',
+        createdAt: new Date('2022-12-31T00:00:00Z')
     }
 ];
 

--- a/api/serverless-config-default.yml
+++ b/api/serverless-config-default.yml
@@ -526,6 +526,13 @@ functions:
                 path: ${self:custom.versions.v1}/publication-bundles/{publicationBundleId}
                 method: GET
                 cors: true
+    getPublicationBundlesByUser:
+        handler: dist/src/components/publicationBundle/routes.getByUser
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publication-bundles
+                method: GET
+                cors: true
 
 package:
     defaultPatterns:

--- a/api/serverless-config-default.yml
+++ b/api/serverless-config-default.yml
@@ -512,6 +512,13 @@ functions:
                 path: ${self:custom.versions.v1}/publication-bundles/{publicationBundleId}
                 method: PATCH
                 cors: true
+    deletePublicationBundle:
+        handler: dist/src/components/publicationBundle/routes.deletePublicationBundle
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publication-bundles/{publicationBundleId}
+                method: DELETE
+                cors: true
 
 package:
     defaultPatterns:

--- a/api/serverless-config-default.yml
+++ b/api/serverless-config-default.yml
@@ -519,6 +519,13 @@ functions:
                 path: ${self:custom.versions.v1}/publication-bundles/{publicationBundleId}
                 method: DELETE
                 cors: true
+    getPublicationBundle:
+        handler: dist/src/components/publicationBundle/routes.get
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publication-bundles/{publicationBundleId}
+                method: GET
+                cors: true
 
 package:
     defaultPatterns:

--- a/api/serverless-config-default.yml
+++ b/api/serverless-config-default.yml
@@ -505,6 +505,13 @@ functions:
                 path: ${self:custom.versions.v1}/publication-bundles
                 method: POST
                 cors: true
+    editPublicationBundle:
+        handler: dist/src/components/publicationBundle/routes.edit
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publication-bundles/{publicationBundleId}
+                method: PATCH
+                cors: true
 
 package:
     defaultPatterns:

--- a/api/serverless-config-default.yml
+++ b/api/serverless-config-default.yml
@@ -497,6 +497,14 @@ functions:
                 path: ${self:custom.versions.v1}/integrations/ari/incremental
                 method: POST
                 cors: true
+    # Publication bundles
+    createPublicationBundle:
+        handler: dist/src/components/publicationBundle/routes.create
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/publication-bundles
+                method: POST
+                cors: true
 
 package:
     defaultPatterns:

--- a/api/src/components/publication/__tests__/miscFunctions.test.ts
+++ b/api/src/components/publication/__tests__/miscFunctions.test.ts
@@ -1,0 +1,24 @@
+import * as publicationService from 'publication/service';
+import * as testUtils from 'lib/testUtils';
+
+describe('Check if a publication is live', () => {
+    beforeAll(async () => {
+        await testUtils.clearDB();
+        await testUtils.testSeed();
+    });
+
+    test('Returns true for a publication with a live version', async () => {
+        const isLive = await publicationService.isLive('publication-problem-live');
+        expect(isLive).toBe(true);
+    });
+
+    test('Returns false for a publication without a live version', async () => {
+        const isLive = await publicationService.isLive('publication-problem-draft');
+        expect(isLive).toBe(false);
+    });
+
+    test('Returns false for a non-existent publication', async () => {
+        const isLive = await publicationService.isLive('non-existent-publication');
+        expect(isLive).toBe(false);
+    });
+});

--- a/api/src/components/publication/service.ts
+++ b/api/src/components/publication/service.ts
@@ -1508,3 +1508,11 @@ export const getDirectLinksForPublication = async (
         linkedFrom
     };
 };
+
+export const isLive = async (id: string) => {
+    const livePublication = await client.prisma.publication.findFirst({
+        where: { id, versions: { some: { currentStatus: 'LIVE' } } }
+    });
+
+    return !!livePublication;
+};

--- a/api/src/components/publicationBundle/__tests__/createPublicationBundle.test.ts
+++ b/api/src/components/publicationBundle/__tests__/createPublicationBundle.test.ts
@@ -1,0 +1,169 @@
+import * as client from 'lib/client';
+import * as testUtils from 'lib/testUtils';
+
+describe('Create a publication bundle', () => {
+    beforeAll(async () => {
+        await testUtils.clearDB();
+        await testUtils.testSeed();
+    });
+
+    test('Authenticated user can create a publication bundle', async () => {
+        const createRequest = await testUtils.agent
+            .post('/publication-bundles')
+            .query({
+                apiKey: '123456789'
+            })
+            .send({
+                name: 'Test Bundle',
+                publicationIds: ['publication-problem-live', 'publication-problem-live-2']
+            });
+
+        expect(createRequest.status).toBe(201);
+        const expectedBundle = {
+            id: expect.any(String),
+            createdAt: expect.any(String),
+            updatedAt: expect.any(String),
+            createdBy: 'test-user-1',
+            name: 'Test Bundle',
+            publications: [{ id: 'publication-problem-live' }, { id: 'publication-problem-live-2' }]
+        };
+        expect(createRequest.body).toMatchObject(expectedBundle);
+
+        // Check presence of bundle in DB
+        const bundle = await client.prisma.publicationBundle.findUnique({
+            where: { id: createRequest.body.id },
+            include: { publications: true }
+        });
+        expect(bundle).toMatchObject({ ...expectedBundle, createdAt: expect.any(Date), updatedAt: expect.any(Date) });
+    });
+
+    test('Unauthenticated user cannot create a publication bundle', async () => {
+        const createRequest = await testUtils.agent.post('/publication-bundles').send({
+            name: 'Test Bundle',
+            publicationIds: ['publication-problem-live', 'publication-problem-live-2']
+        });
+        expect(createRequest.status).toBe(401);
+        expect(createRequest.body.message).toBe('Please enter either a valid apiKey or bearer token.');
+    });
+
+    test('Name is mandatory', async () => {
+        const createRequest = await testUtils.agent
+            .post('/publication-bundles')
+            .query({
+                apiKey: '123456789'
+            })
+            .send({
+                publicationIds: ['publication-problem-live', 'publication-problem-live-2']
+            });
+        expect(createRequest.status).toBe(400);
+        expect(createRequest.body.message[0].message).toBe("must have required property 'name'");
+    });
+
+    test('Name must not be empty', async () => {
+        const createRequest = await testUtils.agent
+            .post('/publication-bundles')
+            .query({
+                apiKey: '123456789'
+            })
+            .send({
+                name: '',
+                publicationIds: ['publication-problem-live', 'publication-problem-live-2']
+            });
+        expect(createRequest.status).toBe(400);
+        expect(createRequest.body.message[0]).toMatchObject({
+            instancePath: '/name',
+            message: 'must NOT have fewer than 1 characters'
+        });
+    });
+
+    test('Publication IDs are mandatory', async () => {
+        const createRequest = await testUtils.agent
+            .post('/publication-bundles')
+            .query({
+                apiKey: '123456789'
+            })
+            .send({
+                name: 'Test Bundle'
+            });
+        expect(createRequest.status).toBe(400);
+        expect(createRequest.body.message[0].message).toBe("must have required property 'publicationIds'");
+    });
+
+    test('Cannot supply fewer than 2 publication IDs', async () => {
+        const createRequest = await testUtils.agent
+            .post('/publication-bundles')
+            .query({
+                apiKey: '123456789'
+            })
+            .send({
+                name: 'Test Bundle',
+                publicationIds: ['publication-problem-live']
+            });
+        expect(createRequest.status).toBe(400);
+        expect(createRequest.body.message[0]).toMatchObject({
+            instancePath: '/publicationIds',
+            message: 'must NOT have fewer than 2 items'
+        });
+    });
+
+    test('Cannot supply more than 30 publication IDs', async () => {
+        const createRequest = await testUtils.agent
+            .post('/publication-bundles')
+            .query({
+                apiKey: '123456789'
+            })
+            .send({
+                name: 'Test Bundle',
+                publicationIds: [...Array(31).map((_, i) => `publication-problem-live-${i}`)]
+            });
+        expect(createRequest.status).toBe(400);
+        expect(createRequest.body.message[0]).toMatchObject({
+            instancePath: '/publicationIds',
+            message: 'must NOT have more than 30 items'
+        });
+    });
+
+    test('Publication IDs must be unique', async () => {
+        const createRequest = await testUtils.agent
+            .post('/publication-bundles')
+            .query({
+                apiKey: '123456789'
+            })
+            .send({
+                name: 'Test Bundle',
+                publicationIds: ['duplicate-id', 'duplicate-id']
+            });
+        expect(createRequest.status).toBe(400);
+        expect(createRequest.body.message).toBe('Publication IDs must be unique.');
+    });
+
+    test('Non-existent publication IDs are rejected', async () => {
+        const createRequest = await testUtils.agent
+            .post('/publication-bundles')
+            .query({
+                apiKey: '123456789'
+            })
+            .send({
+                name: 'Test Bundle',
+                publicationIds: ['publication-problem-live', 'non-existent-id']
+            });
+        expect(createRequest.status).toBe(400);
+        expect(createRequest.body.message).toBe('No live publications exist with the following IDs: non-existent-id');
+    });
+
+    test('All publication IDs must refer to live publications', async () => {
+        const createRequest = await testUtils.agent
+            .post('/publication-bundles')
+            .query({
+                apiKey: '123456789'
+            })
+            .send({
+                name: 'Test Bundle',
+                publicationIds: ['publication-problem-live', 'publication-problem-draft']
+            });
+        expect(createRequest.status).toBe(400);
+        expect(createRequest.body.message).toBe(
+            'No live publications exist with the following IDs: publication-problem-draft'
+        );
+    });
+});

--- a/api/src/components/publicationBundle/__tests__/deletePublicationBundle.test.ts
+++ b/api/src/components/publicationBundle/__tests__/deletePublicationBundle.test.ts
@@ -1,0 +1,47 @@
+import * as client from 'lib/client';
+import * as testUtils from 'lib/testUtils';
+
+describe('Delete a publication bundle', () => {
+    beforeEach(async () => {
+        await testUtils.clearDB();
+        await testUtils.testSeed();
+    });
+
+    test('Authenticated user can delete a publication bundle', async () => {
+        const bundleId = 'test-bundle';
+        const deleteRequest = await testUtils.agent.delete(`/publication-bundles/${bundleId}`).query({
+            apiKey: '123456789'
+        });
+
+        expect(deleteRequest.status).toBe(200);
+        expect(deleteRequest.body.message).toBe('Publication bundle deleted.');
+
+        // Confirm bundle is deleted from DB
+        const bundle = await client.prisma.publicationBundle.findUnique({
+            where: { id: bundleId }
+        });
+        expect(bundle).toBeNull();
+    });
+
+    test('Unauthenticated user cannot create a publication bundle', async () => {
+        const deleteRequest = await testUtils.agent.delete('/publication-bundles/test-bundle');
+        expect(deleteRequest.status).toBe(401);
+        expect(deleteRequest.body.message).toBe('Please enter either a valid apiKey or bearer token.');
+    });
+
+    test('Authenticated user cannot delete a non-existent publication bundle', async () => {
+        const deleteRequest = await testUtils.agent.delete('/publication-bundles/made-up-bundle').query({
+            apiKey: '123456789'
+        });
+        expect(deleteRequest.status).toBe(404);
+        expect(deleteRequest.body.message).toBe('Publication bundle not found.');
+    });
+
+    test("Authenticated user cannot delete another user's publication bundle", async () => {
+        const deleteRequest = await testUtils.agent.delete('/publication-bundles/test-bundle').query({
+            apiKey: '987654321'
+        });
+        expect(deleteRequest.status).toBe(403);
+        expect(deleteRequest.body.message).toBe('You do not have permission to delete this publication bundle.');
+    });
+});

--- a/api/src/components/publicationBundle/__tests__/editPublicationBundle.test.ts
+++ b/api/src/components/publicationBundle/__tests__/editPublicationBundle.test.ts
@@ -1,0 +1,195 @@
+import * as client from 'lib/client';
+import * as testUtils from 'lib/testUtils';
+
+describe('Edit a publication bundle', () => {
+    beforeEach(async () => {
+        await testUtils.clearDB();
+        await testUtils.testSeed();
+    });
+
+    test('Authenticated user can edit a publication bundle', async () => {
+        const editRequest = await testUtils.agent
+            .patch('/publication-bundles/test-bundle')
+            .query({
+                apiKey: '123456789'
+            })
+            .send({
+                name: 'Edited name',
+                publicationIds: ['publication-hypothesis-live', 'publication-protocol-live', 'publication-data-live']
+            });
+
+        expect(editRequest.status).toBe(200);
+        const expectedBundle = {
+            id: expect.any(String),
+            createdAt: expect.any(String),
+            updatedAt: expect.any(String),
+            createdBy: 'test-user-1',
+            name: 'Edited name',
+            publications: [
+                { id: 'publication-hypothesis-live' },
+                { id: 'publication-protocol-live' },
+                { id: 'publication-data-live' }
+            ]
+        };
+        expect(editRequest.body).toMatchObject(expectedBundle);
+
+        // Check data of bundle in DB
+        const bundle = await client.prisma.publicationBundle.findUnique({
+            where: { id: editRequest.body.id },
+            include: { publications: true }
+        });
+        expect(bundle).toMatchObject({ ...expectedBundle, createdAt: expect.any(Date), updatedAt: expect.any(Date) });
+    });
+
+    test('Unauthenticated user cannot create a publication bundle', async () => {
+        const editRequest = await testUtils.agent.patch('/publication-bundles/test-bundle').send({
+            name: 'Test Bundle',
+            publicationIds: ['publication-problem-live', 'publication-problem-live-2']
+        });
+        expect(editRequest.status).toBe(401);
+        expect(editRequest.body.message).toBe('Please enter either a valid apiKey or bearer token.');
+    });
+
+    test('Authenticated user cannot edit a non-existent publication bundle', async () => {
+        const editRequest = await testUtils.agent
+            .patch('/publication-bundles/made-up-bundle')
+            .query({
+                apiKey: '123456789'
+            })
+            .send({
+                name: 'Edited name',
+                publicationIds: ['publication-hypothesis-live', 'publication-protocol-live', 'publication-data-live']
+            });
+        expect(editRequest.status).toBe(404);
+        expect(editRequest.body.message).toBe('Publication bundle not found.');
+    });
+
+    test("Authenticated user cannot edit another user's publication bundle", async () => {
+        const editRequest = await testUtils.agent
+            .patch('/publication-bundles/test-bundle')
+            .query({
+                apiKey: '987654321'
+            })
+            .send({
+                name: 'Edited name',
+                publicationIds: ['publication-hypothesis-live', 'publication-protocol-live', 'publication-data-live']
+            });
+        expect(editRequest.status).toBe(403);
+        expect(editRequest.body.message).toBe('You do not have permission to edit this publication bundle.');
+    });
+
+    test('Fields are not mandatory', async () => {
+        const editRequest = await testUtils.agent
+            .patch('/publication-bundles/test-bundle')
+            .query({
+                apiKey: '123456789'
+            })
+            .send({});
+        expect(editRequest.status).toBe(200);
+        // Expect unchanged bundle
+        const expectedBundle = {
+            id: expect.any(String),
+            createdAt: expect.any(String),
+            updatedAt: expect.any(String),
+            createdBy: 'test-user-1',
+            name: 'Test Bundle',
+            publications: [{ id: 'publication-problem-live' }, { id: 'publication-problem-live-2' }]
+        };
+        expect(editRequest.body).toMatchObject(expectedBundle);
+    });
+
+    test('Name must not be empty if supplied', async () => {
+        const editRequest = await testUtils.agent
+            .patch('/publication-bundles/test-bundle')
+            .query({
+                apiKey: '123456789'
+            })
+            .send({
+                name: '',
+                publicationIds: ['publication-problem-live', 'publication-problem-live-2']
+            });
+        expect(editRequest.status).toBe(400);
+        expect(editRequest.body.message[0]).toMatchObject({
+            instancePath: '/name',
+            message: 'must NOT have fewer than 1 characters'
+        });
+    });
+
+    test('Cannot supply fewer than 2 publication IDs if any supplied', async () => {
+        const editRequest = await testUtils.agent
+            .patch('/publication-bundles/test-bundle')
+            .query({
+                apiKey: '123456789'
+            })
+            .send({
+                name: 'Test Bundle',
+                publicationIds: ['publication-problem-live']
+            });
+        expect(editRequest.status).toBe(400);
+        expect(editRequest.body.message[0]).toMatchObject({
+            instancePath: '/publicationIds',
+            message: 'must NOT have fewer than 2 items'
+        });
+    });
+
+    test('Cannot supply more than 30 publication IDs if any supplied', async () => {
+        const editRequest = await testUtils.agent
+            .patch('/publication-bundles/test-bundle')
+            .query({
+                apiKey: '123456789'
+            })
+            .send({
+                name: 'Test Bundle',
+                publicationIds: [...Array(31).map((_, i) => `publication-problem-live-${i}`)]
+            });
+        expect(editRequest.status).toBe(400);
+        expect(editRequest.body.message[0]).toMatchObject({
+            instancePath: '/publicationIds',
+            message: 'must NOT have more than 30 items'
+        });
+    });
+
+    test('Publication IDs must be unique', async () => {
+        const editRequest = await testUtils.agent
+            .patch('/publication-bundles/test-bundle')
+            .query({
+                apiKey: '123456789'
+            })
+            .send({
+                name: 'Test Bundle',
+                publicationIds: ['duplicate-id', 'duplicate-id']
+            });
+        expect(editRequest.status).toBe(400);
+        expect(editRequest.body.message).toBe('Publication IDs must be unique.');
+    });
+
+    test('Non-existent publication IDs are rejected', async () => {
+        const editRequest = await testUtils.agent
+            .patch('/publication-bundles/test-bundle')
+            .query({
+                apiKey: '123456789'
+            })
+            .send({
+                name: 'Test Bundle',
+                publicationIds: ['publication-problem-live', 'non-existent-id']
+            });
+        expect(editRequest.status).toBe(400);
+        expect(editRequest.body.message).toBe('No live publications exist with the following IDs: non-existent-id');
+    });
+
+    test('All publication IDs must refer to live publications', async () => {
+        const editRequest = await testUtils.agent
+            .patch('/publication-bundles/test-bundle')
+            .query({
+                apiKey: '123456789'
+            })
+            .send({
+                name: 'Test Bundle',
+                publicationIds: ['publication-problem-live', 'publication-problem-draft']
+            });
+        expect(editRequest.status).toBe(400);
+        expect(editRequest.body.message).toBe(
+            'No live publications exist with the following IDs: publication-problem-draft'
+        );
+    });
+});

--- a/api/src/components/publicationBundle/__tests__/getByUserId.test.ts
+++ b/api/src/components/publicationBundle/__tests__/getByUserId.test.ts
@@ -1,0 +1,75 @@
+import * as testUtils from 'lib/testUtils';
+
+describe('Get your own publication bundles', () => {
+    beforeAll(async () => {
+        await testUtils.clearDB();
+        await testUtils.testSeed();
+    });
+
+    test('Authenticated user can get their own publication bundles', async () => {
+        const getRequest = await testUtils.agent.get('/publication-bundles').query({
+            apiKey: '123456789'
+        });
+        expect(getRequest.status).toBe(200);
+        expect(getRequest.body).toMatchObject({
+            metadata: {
+                total: 2,
+                limit: 10,
+                offset: 0
+            },
+            data: [
+                {
+                    id: expect.any(String),
+                    createdAt: expect.any(String),
+                    updatedAt: expect.any(String),
+                    createdBy: 'test-user-1',
+                    name: 'Test Bundle',
+                    publications: [{ id: 'publication-problem-live' }, { id: 'publication-problem-live-2' }]
+                },
+                {
+                    id: expect.any(String),
+                    createdAt: expect.any(String),
+                    updatedAt: expect.any(String),
+                    createdBy: 'test-user-1',
+                    name: 'Test Bundle 2',
+                    publications: [{ id: 'publication-hypothesis-live' }, { id: 'publication-protocol-live' }]
+                }
+            ]
+        });
+    });
+
+    test('Non-authenticated user cannot get publication bundles', async () => {
+        const getRequest = await testUtils.agent.get('/publication-bundles');
+        expect(getRequest.status).toBe(401);
+        expect(getRequest.body.message).toBe('Please enter either a valid apiKey or bearer token.');
+    });
+
+    test('Results can be limited', async () => {
+        const getRequest = await testUtils.agent.get('/publication-bundles').query({
+            apiKey: '123456789',
+            limit: 1
+        });
+        expect(getRequest.status).toBe(200);
+        expect(getRequest.body.metadata).toMatchObject({
+            total: 2,
+            limit: 1,
+            offset: 0
+        });
+        expect(getRequest.body.data).toHaveLength(1);
+    });
+
+    test('Results can be offset', async () => {
+        const getRequest = await testUtils.agent.get('/publication-bundles').query({
+            apiKey: '123456789',
+            offset: 1
+        });
+        expect(getRequest.status).toBe(200);
+        expect(getRequest.body.metadata).toMatchObject({
+            total: 2,
+            limit: 10,
+            offset: 1
+        });
+        expect(getRequest.body.data).toHaveLength(1);
+        expect(getRequest.body.data[0].name).toBe('Test Bundle 2');
+    });
+});

--- a/api/src/components/publicationBundle/__tests__/getPublicationBundle.test.ts
+++ b/api/src/components/publicationBundle/__tests__/getPublicationBundle.test.ts
@@ -1,0 +1,29 @@
+import * as testUtils from 'lib/testUtils';
+
+describe('Get a publication bundle', () => {
+    beforeAll(async () => {
+        await testUtils.clearDB();
+        await testUtils.testSeed();
+    });
+
+    test('Anonymous user can get a publication bundle', async () => {
+        const getRequest = await testUtils.agent.get('/publication-bundles/test-bundle');
+
+        expect(getRequest.status).toBe(200);
+        const expectedBundle = {
+            id: expect.any(String),
+            createdAt: expect.any(String),
+            updatedAt: expect.any(String),
+            createdBy: 'test-user-1',
+            name: 'Test Bundle',
+            publications: [{ id: 'publication-problem-live' }, { id: 'publication-problem-live-2' }]
+        };
+        expect(getRequest.body).toMatchObject(expectedBundle);
+    });
+
+    test('Non-existent bundle returns 404', async () => {
+        const getRequest = await testUtils.agent.get('/publication-bundles/non-existent-bundle');
+        expect(getRequest.status).toBe(404);
+        expect(getRequest.body.message).toBe('Publication bundle not found.');
+    });
+});

--- a/api/src/components/publicationBundle/__tests__/getPublicationBundle.test.ts
+++ b/api/src/components/publicationBundle/__tests__/getPublicationBundle.test.ts
@@ -10,15 +10,14 @@ describe('Get a publication bundle', () => {
         const getRequest = await testUtils.agent.get('/publication-bundles/test-bundle');
 
         expect(getRequest.status).toBe(200);
-        const expectedBundle = {
+        expect(getRequest.body).toMatchObject({
             id: expect.any(String),
             createdAt: expect.any(String),
             updatedAt: expect.any(String),
             createdBy: 'test-user-1',
             name: 'Test Bundle',
             publications: [{ id: 'publication-problem-live' }, { id: 'publication-problem-live-2' }]
-        };
-        expect(getRequest.body).toMatchObject(expectedBundle);
+        });
     });
 
     test('Non-existent bundle returns 404', async () => {

--- a/api/src/components/publicationBundle/controller.ts
+++ b/api/src/components/publicationBundle/controller.ts
@@ -101,3 +101,15 @@ export const deletePublicationBundle = async (
 
     return response.json(200, { message: 'Publication bundle deleted.' });
 };
+
+export const get = async (
+    event: I.APIRequest<undefined, undefined, I.SinglePublicationBundleOperationPathParams>
+): Promise<I.JSONResponse> => {
+    const bundle = await publicationBundleService.get(event.pathParameters.publicationBundleId);
+
+    if (!bundle) {
+        return response.json(404, { message: 'Publication bundle not found.' });
+    }
+
+    return response.json(200, bundle);
+};

--- a/api/src/components/publicationBundle/controller.ts
+++ b/api/src/components/publicationBundle/controller.ts
@@ -1,0 +1,39 @@
+import * as I from 'interface';
+import * as publicationBundleService from 'publicationBundle/service';
+import * as publicationService from 'publication/service';
+import * as response from 'lib/response';
+
+export const create = async (
+    event: I.AuthenticatedAPIRequest<I.CreatePublicationBundleRequestBody, undefined, undefined>
+): Promise<I.JSONResponse> => {
+    // Check that publication IDs are unique.
+    const hasDuplicates = new Set(event.body.publicationIds).size !== event.body.publicationIds.length;
+
+    if (hasDuplicates) {
+        return response.json(400, {
+            message: 'Publication IDs must be unique.'
+        });
+    }
+
+    // Check that publication IDs refer to a live publication.
+    const notFoundIds: string[] = [];
+    await Promise.all(
+        event.body.publicationIds.map(async (id) => {
+            const existsLive = await publicationService.isLive(id);
+
+            if (!existsLive) {
+                notFoundIds.push(id);
+            }
+        })
+    );
+
+    if (notFoundIds.length) {
+        return response.json(400, {
+            message: `No live publications exist with the following IDs: ${notFoundIds.join(', ')}`
+        });
+    }
+
+    const bundle = await publicationBundleService.create({ ...event.body, userId: event.user.id });
+
+    return response.json(201, bundle);
+};

--- a/api/src/components/publicationBundle/controller.ts
+++ b/api/src/components/publicationBundle/controller.ts
@@ -113,3 +113,11 @@ export const get = async (
 
     return response.json(200, bundle);
 };
+
+export const getByUser = async (
+    event: I.AuthenticatedAPIRequest<undefined, I.GetPublicationBundlesByUserQueryParams, undefined>
+): Promise<I.JSONResponse> => {
+    const bundles = await publicationBundleService.getByUser(event.user.id, event.queryStringParameters);
+
+    return response.json(200, bundles);
+};

--- a/api/src/components/publicationBundle/controller.ts
+++ b/api/src/components/publicationBundle/controller.ts
@@ -54,7 +54,11 @@ export const create = async (
 };
 
 export const edit = async (
-    event: I.AuthenticatedAPIRequest<I.EditPublicationBundleRequestBody, undefined, I.EditPublicationBundlePathParams>
+    event: I.AuthenticatedAPIRequest<
+        I.EditPublicationBundleRequestBody,
+        undefined,
+        I.SinglePublicationBundleOperationPathParams
+    >
 ): Promise<I.JSONResponse> => {
     if (event.body.publicationIds?.length) {
         const validationCheck = await validatePublicationIds(event.body.publicationIds);
@@ -78,4 +82,22 @@ export const edit = async (
     const editBundle = await publicationBundleService.edit(event.pathParameters.publicationBundleId, event.body);
 
     return response.json(200, editBundle);
+};
+
+export const deletePublicationBundle = async (
+    event: I.AuthenticatedAPIRequest<undefined, undefined, I.SinglePublicationBundleOperationPathParams>
+): Promise<I.JSONResponse> => {
+    const bundle = await publicationBundleService.get(event.pathParameters.publicationBundleId);
+
+    if (!bundle) {
+        return response.json(404, { message: 'Publication bundle not found.' });
+    }
+
+    if (bundle.createdBy !== event.user.id) {
+        return response.json(403, { message: 'You do not have permission to delete this publication bundle.' });
+    }
+
+    await publicationBundleService.deletePublicationBundle(event.pathParameters.publicationBundleId);
+
+    return response.json(200, { message: 'Publication bundle deleted.' });
 };

--- a/api/src/components/publicationBundle/routes.ts
+++ b/api/src/components/publicationBundle/routes.ts
@@ -9,3 +9,9 @@ export const create = middy(publicationBundleController.create)
     .use(middleware.httpJsonBodyParser())
     .use(middleware.authentication())
     .use(middleware.validator(publicationBundleSchema.create, 'body'));
+
+export const edit = middy(publicationBundleController.edit)
+    .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))
+    .use(middleware.httpJsonBodyParser())
+    .use(middleware.authentication())
+    .use(middleware.validator(publicationBundleSchema.edit, 'body'));

--- a/api/src/components/publicationBundle/routes.ts
+++ b/api/src/components/publicationBundle/routes.ts
@@ -15,3 +15,7 @@ export const edit = middy(publicationBundleController.edit)
     .use(middleware.httpJsonBodyParser())
     .use(middleware.authentication())
     .use(middleware.validator(publicationBundleSchema.edit, 'body'));
+
+export const deletePublicationBundle = middy(publicationBundleController.deletePublicationBundle)
+    .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))
+    .use(middleware.authentication());

--- a/api/src/components/publicationBundle/routes.ts
+++ b/api/src/components/publicationBundle/routes.ts
@@ -1,0 +1,11 @@
+import middy from '@middy/core';
+
+import * as middleware from 'middleware';
+import * as publicationBundleController from 'publicationBundle/controller';
+import * as publicationBundleSchema from 'publicationBundle/schema';
+
+export const create = middy(publicationBundleController.create)
+    .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))
+    .use(middleware.httpJsonBodyParser())
+    .use(middleware.authentication())
+    .use(middleware.validator(publicationBundleSchema.create, 'body'));

--- a/api/src/components/publicationBundle/routes.ts
+++ b/api/src/components/publicationBundle/routes.ts
@@ -23,3 +23,8 @@ export const deletePublicationBundle = middy(publicationBundleController.deleteP
 export const get = middy(publicationBundleController.get).use(
     middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true })
 );
+
+export const getByUser = middy(publicationBundleController.getByUser)
+    .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))
+    .use(middleware.authentication())
+    .use(middleware.validator(publicationBundleSchema.getByUser, 'queryStringParameters'));

--- a/api/src/components/publicationBundle/routes.ts
+++ b/api/src/components/publicationBundle/routes.ts
@@ -19,3 +19,7 @@ export const edit = middy(publicationBundleController.edit)
 export const deletePublicationBundle = middy(publicationBundleController.deletePublicationBundle)
     .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))
     .use(middleware.authentication());
+
+export const get = middy(publicationBundleController.get).use(
+    middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true })
+);

--- a/api/src/components/publicationBundle/schema/create.ts
+++ b/api/src/components/publicationBundle/schema/create.ts
@@ -1,0 +1,21 @@
+import * as I from 'interface';
+
+const createPublicationBundleBody: I.JSONSchemaType<I.CreatePublicationBundleRequestBody> = {
+    type: 'object',
+    properties: {
+        name: {
+            type: 'string',
+            minLength: 1
+        },
+        publicationIds: {
+            type: 'array',
+            items: { type: 'string' },
+            minItems: 2,
+            maxItems: 30
+        }
+    },
+    required: ['name', 'publicationIds'],
+    additionalProperties: false
+};
+
+export default createPublicationBundleBody;

--- a/api/src/components/publicationBundle/schema/edit.ts
+++ b/api/src/components/publicationBundle/schema/edit.ts
@@ -1,19 +1,23 @@
 import * as I from 'interface';
-import createSchema from './create';
 
 const editPublicationBundleBody: I.JSONSchemaType<I.EditPublicationBundleRequestBody> = {
-    ...createSchema,
+    type: 'object',
     properties: {
         name: {
-            ...createSchema.properties.name,
+            type: 'string',
+            minLength: 1,
             nullable: true
         },
         publicationIds: {
-            ...createSchema.properties.publicationIds,
+            type: 'array',
+            items: { type: 'string' },
+            minItems: 2,
+            maxItems: 30,
             nullable: true
         }
     },
-    required: []
+    required: [],
+    additionalProperties: false
 };
 
 export default editPublicationBundleBody;

--- a/api/src/components/publicationBundle/schema/edit.ts
+++ b/api/src/components/publicationBundle/schema/edit.ts
@@ -1,0 +1,19 @@
+import * as I from 'interface';
+import createSchema from './create';
+
+const editPublicationBundleBody: I.JSONSchemaType<I.EditPublicationBundleRequestBody> = {
+    ...createSchema,
+    properties: {
+        name: {
+            ...createSchema.properties.name,
+            nullable: true
+        },
+        publicationIds: {
+            ...createSchema.properties.publicationIds,
+            nullable: true
+        }
+    },
+    required: []
+};
+
+export default editPublicationBundleBody;

--- a/api/src/components/publicationBundle/schema/getByUser.ts
+++ b/api/src/components/publicationBundle/schema/getByUser.ts
@@ -1,0 +1,25 @@
+import * as I from 'interface';
+
+const getPublicationsByUserIdQueryParams: I.JSONSchemaType<I.GetPublicationBundlesByUserQueryParams> = {
+    type: 'object',
+    properties: {
+        apiKey: {
+            type: 'string',
+            nullable: true
+        },
+        limit: {
+            type: 'integer',
+            nullable: true,
+            default: null
+        },
+        offset: {
+            type: 'number',
+            nullable: true,
+            default: null
+        }
+    },
+    required: [],
+    additionalProperties: false
+};
+
+export default getPublicationsByUserIdQueryParams;

--- a/api/src/components/publicationBundle/schema/index.ts
+++ b/api/src/components/publicationBundle/schema/index.ts
@@ -1,0 +1,1 @@
+export { default as create } from './create';

--- a/api/src/components/publicationBundle/schema/index.ts
+++ b/api/src/components/publicationBundle/schema/index.ts
@@ -1,1 +1,2 @@
 export { default as create } from './create';
+export { default as edit } from './edit';

--- a/api/src/components/publicationBundle/schema/index.ts
+++ b/api/src/components/publicationBundle/schema/index.ts
@@ -1,2 +1,3 @@
 export { default as create } from './create';
 export { default as edit } from './edit';
+export { default as getByUser } from './getByUser';

--- a/api/src/components/publicationBundle/service.ts
+++ b/api/src/components/publicationBundle/service.ts
@@ -1,4 +1,5 @@
 import * as client from 'lib/client';
+import * as I from 'interface';
 
 export const create = (data: { name: string; publicationIds: string[]; userId: string }) =>
     client.prisma.publicationBundle.create({
@@ -9,6 +10,30 @@ export const create = (data: { name: string; publicationIds: string[]; userId: s
                 connect: data.publicationIds.map((id) => ({ id }))
             }
         },
+        include: {
+            publications: true
+        }
+    });
+
+export const edit = (id: string, data: I.EditPublicationBundleRequestBody) =>
+    client.prisma.publicationBundle.update({
+        where: { id },
+        data: {
+            name: data.name ?? undefined,
+            publications: data.publicationIds
+                ? {
+                      set: data.publicationIds.map((id) => ({ id }))
+                  }
+                : undefined
+        },
+        include: {
+            publications: true
+        }
+    });
+
+export const get = (id: string) =>
+    client.prisma.publicationBundle.findUnique({
+        where: { id },
         include: {
             publications: true
         }

--- a/api/src/components/publicationBundle/service.ts
+++ b/api/src/components/publicationBundle/service.ts
@@ -1,0 +1,15 @@
+import * as client from 'lib/client';
+
+export const create = (data: { name: string; publicationIds: string[]; userId: string }) =>
+    client.prisma.publicationBundle.create({
+        data: {
+            name: data.name,
+            createdBy: data.userId,
+            publications: {
+                connect: data.publicationIds.map((id) => ({ id }))
+            }
+        },
+        include: {
+            publications: true
+        }
+    });

--- a/api/src/components/publicationBundle/service.ts
+++ b/api/src/components/publicationBundle/service.ts
@@ -38,3 +38,8 @@ export const get = (id: string) =>
             publications: true
         }
     });
+
+export const deletePublicationBundle = (id: string) =>
+    client.prisma.publicationBundle.delete({
+        where: { id }
+    });

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -1113,6 +1113,6 @@ export interface EditPublicationBundleRequestBody {
     publicationIds?: string[];
 }
 
-export interface EditPublicationBundlePathParams {
+export interface SinglePublicationBundleOperationPathParams {
     publicationBundleId: string;
 }

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -1116,3 +1116,8 @@ export interface EditPublicationBundleRequestBody {
 export interface SinglePublicationBundleOperationPathParams {
     publicationBundleId: string;
 }
+
+export interface GetPublicationBundlesByUserQueryParams {
+    limit?: number;
+    offset?: number;
+}

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -1102,3 +1102,8 @@ export interface TriggerAriIngestQueryParams {
 export interface LocalNotifyPubRouterPathParams {
     publicationId: string;
 }
+
+export interface CreatePublicationBundleRequestBody {
+    name: string;
+    publicationIds: string[];
+}

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -1107,3 +1107,12 @@ export interface CreatePublicationBundleRequestBody {
     name: string;
     publicationIds: string[];
 }
+
+export interface EditPublicationBundleRequestBody {
+    name?: string;
+    publicationIds?: string[];
+}
+
+export interface EditPublicationBundlePathParams {
+    publicationBundleId: string;
+}

--- a/api/src/lib/testUtils.ts
+++ b/api/src/lib/testUtils.ts
@@ -33,6 +33,14 @@ const createUsers = async (): Promise<void> => {
     }
 };
 
+const createPublicationBundles = async (): Promise<void> => {
+    for (const publicationBundle of seeds.testPublicationBundles) {
+        await client.prisma.publicationBundle.create({
+            data: publicationBundle
+        });
+    }
+};
+
 // Seed the database with a smaller set of data, just enough to run the automated tests.
 export const testSeed = async (): Promise<void> => {
     // These don't depend on anything.
@@ -57,7 +65,8 @@ export const testSeed = async (): Promise<void> => {
         }),
         client.prisma.event.createMany({
             data: seeds.testEvents
-        })
+        }),
+        createPublicationBundles()
     ]);
     // These depend on topics.
     await Promise.all([

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -87,6 +87,9 @@
             "publication/*": [
                 "src/components/publication/*"
             ],
+            "publicationBundle/*": [
+                "src/components/publicationBundle/*"
+            ],
             "publicationVersion/*": [
                 "src/components/publicationVersion/*"
             ],


### PR DESCRIPTION
The purpose of this PR was to prepare for the bundled publications feature by adding publication bundles to the schema and writing various endpoints for creating and managing them.

---

### Acceptance Criteria:

- An endpoint is present that allows for the creation of a bundle, including:
    - Name
    - ID
    - Publications list
        - Where the publications list must have at least 2 live publications, and less than 30 publications added in total
    - Date created (not specified by user)
    - Creator user ID (not specified by user)
- An endpoint is present that allows for the editing of an existing bundle, including changing the:
    - Name
    - Publications list
        - Where the publications list must have at least 2 live publications, and less than 30 publications added in total
- An endpoint is present that fetches a list of bundles created by the user who made the request, paginated to 10 at a time, including:
    - Name
    - Publications list
    - ID
    - Created date
- An endpoint is present that allows for the deletion of an existing bundle by the user who created it
- An endpoint is present that gets the details of an existing bundle, including the:
    - Name
    - Publications list
    - ID
    - Creator User ID
    - Date Created
    - This endpoint can be accessed by any user, regardless of whether they created it 

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

API
![Screenshot 2025-05-15 135855](https://github.com/user-attachments/assets/05ef1540-2c4b-4174-9f55-8a2baf3c61f6)

E2E
![Screenshot 2025-05-15 145617](https://github.com/user-attachments/assets/a18d00c9-3a44-4080-bc5b-e3c76cf3ac3a)

