### PR TITLE
OC-1070: Co-author cancelled approval emails being sent erroneously

### DIFF
--- a/api/src/components/coauthor/__tests__/updateCoAuthor.test.ts
+++ b/api/src/components/coauthor/__tests__/updateCoAuthor.test.ts
@@ -235,6 +235,19 @@ describe('Update co-author', () => {
         expect(coAuthor?.retainApproval).toEqual(false);
     });
 
+    test('Email is sent when co-author retracts their approval', async () => {
+        const retractConfirmation = await testUtils.agent
+            .patch('/publication-versions/locked-publication-problem-confirmed-co-authors-v1/coauthors/test-user-2')
+            .query({ apiKey: '987654321' })
+            .send({ confirm: false });
+
+        expect(retractConfirmation.status).toEqual(200);
+
+        // Cancellation email should have been sent to corresponding author
+        const findMail = await testUtils.getEmails('test-user-1@jisc.ac.uk');
+        expect(findMail.messages[0].Subject).toContain('A co-author has cancelled their approval');
+    });
+
     test('Cannot be independent and have affiliations at the same time', async () => {
         const updateAffiliationsResponse = await testUtils.agent
             .patch('/publication-versions/publication-problem-draft-v1/coauthors/coauthor-test-user-5-problem-draft')


### PR DESCRIPTION
The purpose of this PR was to correct the logic that dictates when the "A co-author has cancelled their approval" email is sent because it was broken when the update co-author endpoint was reworked recently.

---

### Acceptance Criteria:

The "A co-author has cancelled their approval" email is sent to the corresponding author only when a co-author retracts their previously given approval.

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

API
![Screenshot 2025-05-29 102830](https://github.com/user-attachments/assets/fc2e3ac0-7086-4057-89e5-b1bf33f33c90)
