### PR TITLE
OC-1069: Difficulty finding drafts to link

### DIFF
--- a/api/src/components/user/__tests__/getUserPublications.test.ts
+++ b/api/src/components/user/__tests__/getUserPublications.test.ts
@@ -1,4 +1,5 @@
 import { Prisma } from '@prisma/client';
+import * as enums from 'lib/enum';
 import * as testUtils from 'lib/testUtils';
 import * as userService from 'user/service';
 
@@ -57,8 +58,23 @@ describe("Get a given user's publications", () => {
         expect(publications.status).toEqual(400);
     });
 
-    test('Results can be filtered by a query term', async () => {
+    test('Results can be filtered by a whole word query term', async () => {
         const queryTerm = 'interpretation';
+        const publications = await testUtils.agent.get('/users/test-user-1/publications').query({ query: queryTerm });
+
+        expect(publications.status).toEqual(200);
+        expect(publications.body.data.length).toEqual(1);
+        expect(
+            (publications.body as UserPublications).data.every((publication) =>
+                publication.versions.some(
+                    (version) => version.isLatestLiveVersion && version.title?.toLowerCase().includes(queryTerm)
+                )
+            )
+        ).toEqual(true);
+    });
+
+    test('Results can be filtered by a partial word query term', async () => {
+        const queryTerm = 'interp';
         const publications = await testUtils.agent.get('/users/test-user-1/publications').query({ query: queryTerm });
 
         expect(publications.status).toEqual(200);
@@ -166,5 +182,33 @@ describe("Get a given user's publications", () => {
                 (publication) => !publicationIdsToExclude.includes(publication.id)
             )
         ).toEqual(true);
+    });
+
+    test('Can filter by publication type', async () => {
+        await Promise.all(
+            enums.publicationTypes.map(async (type) => {
+                const getPublications = await testUtils.agent.get(`/users/test-user-1/publications?type=${type}`);
+
+                expect(getPublications.status).toEqual(200);
+                expect(getPublications.body.data.every((publication) => publication.type === type)).toEqual(true);
+            })
+        );
+    });
+
+    test('Can filter by multiple publication types at once', async () => {
+        const getPublications = await testUtils.agent.get('/users/test-user-1/publications?type=PROBLEM,PROTOCOL');
+
+        expect(getPublications.status).toEqual(200);
+        expect(
+            getPublications.body.data.every((publication) => ['PROBLEM', 'PROTOCOL'].includes(publication.type))
+        ).toEqual(true);
+    });
+
+    test('Type filtering rejects invalid types', async () => {
+        const getPublications = await testUtils.agent.get('/users/test-user-1/publications?type=DINOSAUR');
+
+        expect(getPublications.status).toEqual(400);
+        expect(getPublications.body.message).toHaveLength(1);
+        expect(getPublications.body.message[0].keyword).toEqual('pattern');
     });
 });

--- a/api/src/components/user/schema/getPublications.ts
+++ b/api/src/components/user/schema/getPublications.ts
@@ -1,3 +1,4 @@
+import * as Enum from 'enum';
 import * as I from 'interface';
 
 const getPublicationsSchema: I.JSONSchemaType<I.UserPublicationsFilters> = {
@@ -28,6 +29,11 @@ const getPublicationsSchema: I.JSONSchemaType<I.UserPublicationsFilters> = {
         },
         exclude: {
             type: 'string',
+            nullable: true
+        },
+        type: {
+            type: 'string',
+            pattern: `^((${Enum.publicationTypes.join('|')})(,)?)+$`,
             nullable: true
         }
     },

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -746,6 +746,7 @@ export interface UserPublicationsFilters {
     versionStatus?: string;
     initialDraftsOnly?: boolean;
     exclude?: string;
+    type?: string;
 }
 
 export interface SendApprovalReminderPathParams {

--- a/ui/src/components/Publication/Creation/LinkedItems/LinkedPublicationCombobox/index.tsx
+++ b/ui/src/components/Publication/Creation/LinkedItems/LinkedPublicationCombobox/index.tsx
@@ -38,7 +38,7 @@ const LinkedPublicationsCombobox: React.FC<LinkedPublicationsComboboxProps> = (p
 
     const minimumQueryEntered = search.length > 2;
     const swrKey = props.draftsOnly
-        ? `${Config.endpoints.users}/${user?.id}/publications?initialDraftsOnly=true&limit=10${minimumQueryEntered ? `&query=${search}` : ''}&exclude=${excludedIds.join(',')}`
+        ? `${Config.endpoints.users}/${user?.id}/publications?initialDraftsOnly=true&limit=10${minimumQueryEntered ? `&query=${search}` : ''}&exclude=${excludedIds.join(',')}&type=${formattedAsString}`
         : `/publication-versions?type=${formattedAsString}&limit=10${
               minimumQueryEntered ? `&search=${search}` : ''
           }&exclude=${excludedIds.join(',')}`;


### PR DESCRIPTION
The purpose of this PR was to fix 2 issues with the draft linking experience:

- Filtering by a query term above 3 characters causes no results to appear
- Hypotheses can have peer reviews linked as drafts, which should not be possible

---

### Acceptance Criteria:

- Query terms above 3 characters can be used to match drafts to link to
- Only publication types that are possible to link to should be returned in the combobox

---

### Checklist:

- [x] Local manual testing conducted
- [x] Automated tests added
- [ ] Documentation updated

---

### Tests:

API
![Screenshot 2025-05-29 120450](https://github.com/user-attachments/assets/31a2d1fe-4acd-4aac-bd24-59d3b2a7325b)

UI
![Screenshot 2025-05-29 133546](https://github.com/user-attachments/assets/b3356277-fdae-4076-b88a-e0660f70675a)

E2E
![Screenshot 2025-05-29 132153](https://github.com/user-attachments/assets/a2b21f40-f28b-450c-b5f6-9d8257182b37)

