### PR TITLE
OC-1074: Fix Regular Expression Denial of Service (ReDoS)

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -622,12 +622,10 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.24.0",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.0.tgz",
-            "integrity": "sha512-Chk32uHMg6TnQdvw2e9IlqPpFX/6NLuK0Ys2PqLb7/gL5uFn9mXvK715FGLlOLQrcO4qIkNHkvPGktzzXexsFw==",
-            "dependencies": {
-                "regenerator-runtime": "^0.14.0"
-            },
+            "version": "7.27.4",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.4.tgz",
+            "integrity": "sha512-t3yaEOuGu9NlIZ+hIeGbBjFtZT7j2cb2tg0fuaJKeGotchRjjLfrBA9Kwf8quhpP1EUuxModQg04q/mBwyg8uA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -13211,11 +13209,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-        },
         "node_modules/regexp.prototype.flags": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
@@ -15766,12 +15759,9 @@
             }
         },
         "@babel/runtime": {
-            "version": "7.24.0",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.0.tgz",
-            "integrity": "sha512-Chk32uHMg6TnQdvw2e9IlqPpFX/6NLuK0Ys2PqLb7/gL5uFn9mXvK715FGLlOLQrcO4qIkNHkvPGktzzXexsFw==",
-            "requires": {
-                "regenerator-runtime": "^0.14.0"
-            }
+            "version": "7.27.4",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.4.tgz",
+            "integrity": "sha512-t3yaEOuGu9NlIZ+hIeGbBjFtZT7j2cb2tg0fuaJKeGotchRjjLfrBA9Kwf8quhpP1EUuxModQg04q/mBwyg8uA=="
         },
         "@babel/template": {
             "version": "7.22.5",
@@ -17005,7 +16995,7 @@
             "integrity": "sha512-ZR4aihtnnT9lMbhh5DEbsriJRlukRXmLZe7HmM+6ufJNNUDoazc75UX26xbgQlNUqgAqMcUdGFAnPc1JwgAdLQ==",
             "peer": true,
             "requires": {
-                "@babel/runtime": "^7.21.0"
+                "@babel/runtime": "^7.27.4"
             }
         },
         "@remirror/core-helpers": {
@@ -17014,7 +17004,7 @@
             "integrity": "sha512-LqIPF4stGG69l9qu/FFicv9d9B+YaItzgDMC5A0CEvDQfKkGD3BfabLmfpnuWbsc06oKGdTduilgWcALLZoYLg==",
             "peer": true,
             "requires": {
-                "@babel/runtime": "^7.21.0",
+                "@babel/runtime": "^7.27.4",
                 "@linaria/core": "4.2.9",
                 "@remirror/core-constants": "^2.0.1",
                 "@remirror/types": "^1.0.1",
@@ -17246,7 +17236,7 @@
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.10.4",
-                "@babel/runtime": "^7.12.5",
+                "@babel/runtime": "^7.27.4",
                 "@types/aria-query": "^5.0.1",
                 "aria-query": "5.1.3",
                 "chalk": "^4.1.0",
@@ -17347,7 +17337,7 @@
             "dev": true,
             "requires": {
                 "@adobe/css-tools": "^4.3.2",
-                "@babel/runtime": "^7.9.2",
+                "@babel/runtime": "^7.27.4",
                 "aria-query": "^5.0.0",
                 "chalk": "^3.0.0",
                 "css.escape": "^1.5.1",
@@ -17419,7 +17409,7 @@
             "integrity": "sha512-sGdjws32ai5TLerhvzThYFbpnF9XtL65Cjf+gB0Dhr29BGqK+mAeN7SURSdu+eqgET4ANcWoC7FQpkaiGvBr+A==",
             "dev": true,
             "requires": {
-                "@babel/runtime": "^7.12.5",
+                "@babel/runtime": "^7.27.4",
                 "@testing-library/dom": "^9.0.0",
                 "@types/react-dom": "^18.0.0"
             }
@@ -19406,7 +19396,7 @@
             "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
             "dev": true,
             "requires": {
-                "@babel/runtime": "^7.21.0"
+                "@babel/runtime": "^7.27.4"
             }
         },
         "debug": {
@@ -20198,7 +20188,7 @@
             "integrity": "sha512-Hdh937BS3KdwwbBaKd5+PLCOmYY6U4f2h9Z2ktwtNKvIdIEu137rjYbcb9ApSbVJfWxANNuiKTD/9tOKjK9qOA==",
             "dev": true,
             "requires": {
-                "@babel/runtime": "^7.23.2",
+                "@babel/runtime": "^7.27.4",
                 "aria-query": "^5.3.0",
                 "array-includes": "^3.1.7",
                 "array.prototype.flatmap": "^1.3.2",
@@ -24576,7 +24566,7 @@
             "integrity": "sha512-0Yl9w7IdHkaCdqR+NE3FOucePME4OmiGcybnF1iasarEILP5U8+4xTnl53yafULjmwcg1SrSG65Hg7Zk2H2v3g==",
             "peer": true,
             "requires": {
-                "@babel/runtime": "^7.21.0",
+                "@babel/runtime": "^7.27.4",
                 "@remirror/core-constants": "^2.0.1",
                 "@remirror/core-helpers": "^2.0.2",
                 "escape-string-regexp": "^4.0.0"
@@ -24811,7 +24801,7 @@
             "resolved": "https://registry.npmjs.org/react-beautiful-dnd/-/react-beautiful-dnd-13.1.1.tgz",
             "integrity": "sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==",
             "requires": {
-                "@babel/runtime": "^7.9.2",
+                "@babel/runtime": "^7.27.4",
                 "css-box-model": "^1.2.0",
                 "memoize-one": "^5.1.1",
                 "raf-schd": "^4.0.2",
@@ -24873,7 +24863,7 @@
             "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
             "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
             "requires": {
-                "@babel/runtime": "^7.15.4",
+                "@babel/runtime": "^7.27.4",
                 "@types/react-redux": "^7.1.20",
                 "hoist-non-react-statics": "^3.3.2",
                 "loose-envify": "^1.4.0",
@@ -24951,7 +24941,7 @@
             "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
             "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
             "requires": {
-                "@babel/runtime": "^7.9.2"
+                "@babel/runtime": "^7.27.4"
             }
         },
         "reflect.getprototypeof": {
@@ -24967,11 +24957,6 @@
                 "globalthis": "^1.0.3",
                 "which-builtin-type": "^1.1.3"
             }
-        },
-        "regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
         },
         "regexp.prototype.flags": {
             "version": "1.5.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -101,5 +101,8 @@
         "tailwindcss": "^3.4.2",
         "ts-jest": "^29.1.2",
         "typescript": "^5.4.2"
+    },
+    "overrides": {
+        "@babel/runtime": "^7.27.4"
     }
 }


### PR DESCRIPTION
The purpose of this PR was to fix a ReDoS vulnerability in [@babel/runtime](https://www.npmjs.com/package/@babel/runtime), which is a subdependency of [react-beautiful-dnd](https://www.npmjs.com/package/react-beautiful-dnd).

For now I have addressed this using an override as react-beautiful-dnd is unmaintained, but the better solution would be to replace it with a different drag + drop solution that is better maintained. I have added ticket OC-1075 in the backlog for this.

---

### Acceptance Criteria:

- @babel/runtime is installed at 7.26.10 or higher and drag and drop functionality still works.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
![Screenshot 2025-06-02 131230](https://github.com/user-attachments/assets/ca560151-7e1d-4aee-8a2a-7944dc9c4aca)

E2E
![Screenshot 2025-06-02 125806](https://github.com/user-attachments/assets/222d8a91-3421-438f-ae6b-0b4b89a3faf6)

