### PR TITLE
OC-1051-fix: Test data not fitting type

### DIFF
--- a/ui/src/__tests__/components/Publication/Card.test.tsx
+++ b/ui/src/__tests__/components/Publication/Card.test.tsx
@@ -64,6 +64,7 @@ describe('Individual cases', () => {
                             linkedUser: 'test-2',
                             affiliations: [],
                             isIndependent: true,
+                            retainApproval: true,
                             user: {
                                 firstName: 'Test',
                                 lastName: 'User',

--- a/ui/src/__tests__/testUtils/index.tsx
+++ b/ui/src/__tests__/testUtils/index.tsx
@@ -62,6 +62,7 @@ export const testPublicationVersion: Interfaces.PublicationVersion = {
             publicationVersionId: 'test-v1',
             affiliations: [],
             isIndependent: true,
+            retainApproval: true,
             user: {
                 firstName: testCoreUser.firstName,
                 lastName: testCoreUser.lastName,


### PR DESCRIPTION
The purpose of this PR was to update some test data to match the type it was assigned and prevent typescript errors that had made their way onto main branch.

