### PR TITLE
OC-1077: Fix Improper Link Resolution Before File Access ('Link Following')

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -22562,9 +22562,9 @@
             }
         },
         "node_modules/tar-fs": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
-            "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
+            "integrity": "sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==",
             "license": "MIT",
             "dependencies": {
                 "pump": "^3.0.0",


### PR DESCRIPTION
The purpose of this PR was to fix a vulnerability flagged by Snyk with the tar-fs package, introduced as a subdependency of  @sparticuz/chromium and puppeteer-core.

---

### Acceptance Criteria:

- tar-fs is installed at 3.0.9 or newer
- PDF generation still works as previously

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

API
![Screenshot 2025-06-11 112611](https://github.com/user-attachments/assets/37c78ac5-d7f7-4b36-a4ea-4421bacccea8)

E2E
![Screenshot 2025-06-11 125252](https://github.com/user-attachments/assets/b4a24e5e-5313-4851-98f2-4c3248ba4a8e)

