### PR TITLE
OC-1036: Display issue with resolved red flags on author page

### DIFF
--- a/ui/src/pages/authors/[id]/index.tsx
+++ b/ui/src/pages/authors/[id]/index.tsx
@@ -184,7 +184,7 @@ const Author: Types.NextPage<Props> = (props): React.ReactElement => {
 
                 return (
                     <Components.PublicationSearchResult
-                        key={publication.id}
+                        key={flag.id}
                         className={classes}
                         coAuthors={coAuthors}
                         content={content}


### PR DESCRIPTION
The purpose of this PR was to fix an issue where red flag results on the author page are staying in the list when they should be removed in response to changing filters or page. The key was using the publication ID which is not necessarily unique, so changed this to the flag ID which will be unique for each result.

---

### Acceptance Criteria:

Outdated results don't appear in user's flag results pagination.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

