### PR TITLE
OC-1082: Add security.txt file - compliance with IT-POL-14

### DIFF
--- a/ui/public/security.txt
+++ b/ui/public/security.txt
@@ -1,0 +1,3 @@
+# If you would like to report a security issue or actively test for one please visit the URL below
+
+Contact: https://www.jisc.ac.uk/contact/vulnerability-disclosure-policy


### PR DESCRIPTION
The purpose of this PR was to comply with IT-POL-14, so we need to serve at `/security.txt` the vulnerability disclosure policy URL.

---

### Acceptance Criteria:
Visiting https://octopus.ac/security.txt  serves the following content:
```md
# If you would like to report a security issue or actively test for one please visit the URL below

Contact: https://www.jisc.ac.uk/contact/vulnerability-disclosure-policy
```

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated