### PR TITLE
OC-1049 fix: Deployment policy amendment and import reorganising

### DIFF
--- a/api/src/components/pdf/service.ts
+++ b/api/src/components/pdf/service.ts
@@ -694,11 +694,3 @@ export const generatePublicationVersionPDF = async (
         }
     }
 };
-
-export const getPDFURL = (publicationId: string): string => {
-    const objectKey = `${publicationId}.pdf`;
-
-    return process.env.STAGE === 'local'
-        ? Helpers.checkEnvVariable('LOCALSTACK_SERVER') + s3.buckets.pdfs + `/${objectKey}`
-        : `https://${s3.buckets.pdfs}.s3.amazonaws.com/${objectKey}`;
-};

--- a/api/src/components/pubRouter/service.ts
+++ b/api/src/components/pubRouter/service.ts
@@ -1,7 +1,7 @@
 import * as email from 'lib/email';
 import * as Helpers from 'lib/helpers';
 import * as I from 'interface';
-import * as pdfService from 'pdf/service';
+import * as s3 from 'lib/s3';
 
 const pubRouterPublicationTypePrefix = 'Octopus article; ';
 
@@ -58,7 +58,7 @@ const getPubRouterMetadata = (publicationVersion: I.PublicationVersion) => {
     const formattedPublicationDate = publicationVersion.createdAt.toISOString().split('T')[0];
     const publication = publicationVersion.publication;
     const formattedCoAuthors = publicationVersion.coAuthors?.map((coAuthor) => formatCoAuthor(coAuthor));
-    const pdfUrl = pdfService.getPDFURL(publication.id);
+    const pdfUrl = s3.getPDFURL(publication.id);
 
     return {
         provider: {

--- a/api/src/lib/s3.ts
+++ b/api/src/lib/s3.ts
@@ -1,4 +1,5 @@
 import { S3Client, S3ClientConfig } from '@aws-sdk/client-s3';
+import * as Helpers from 'lib/helpers';
 
 export const endpoint =
     process.env.STAGE === 'local' ? process.env.LOCALSTACK_SERVER : 'https://s3.eu-west-1.amazonaws.com';
@@ -24,3 +25,11 @@ export const buckets = {
 };
 
 export const client = new S3Client(config);
+
+export const getPDFURL = (publicationId: string): string => {
+    const objectKey = `${publicationId}.pdf`;
+
+    return process.env.STAGE === 'local'
+        ? Helpers.checkEnvVariable('LOCALSTACK_SERVER') + buckets.pdfs + `/${objectKey}`
+        : `https://${buckets.pdfs}.s3.amazonaws.com/${objectKey}`;
+};

--- a/infra/modules/oidc/main.tf
+++ b/infra/modules/oidc/main.tf
@@ -55,6 +55,7 @@ data "aws_iam_policy_document" "deploy_backend_policy" {
       "events:ListTargetsByRule",
       "events:DescribeRule",
       "iam:CreateRole",
+      "iam:DeleteRole",
       "iam:DeleteRolePolicy",
       "iam:ListRolePolicies",
       "iam:ListAttachedRolePolicies",


### PR DESCRIPTION
The purpose of this PR was to fix two issues arising from the deployment to int of #801:
- The automated deploy failed because serverless needed to delete an old automatically generated IAM role but the relevant policy lacked this permission
    - This policy has been added in this change
        - This has already been deployed in order to test it
- Import errors were occurring because `api/src/components/publicationVersion/service.ts` was trying to import `@sparticuz/chromium` through an import chain via the pubrouter service and pdf service files. Because PDF generation functions are packaged separately, and the deployment package for the rest of the code doesn't include this library, it threw an error because it couldn't find the library.
    - Moved the `getPDFURL` function out of the pdf service file (which imports this library) into an alternative home in the s3 lib file.
