### PR TITLE
show "Write a linked Research Problem" button on peer reviews

### DIFF
--- a/ui/src/components/Publication/PublicationPage/HeaderActions/index.tsx
+++ b/ui/src/components/Publication/PublicationPage/HeaderActions/index.tsx
@@ -14,7 +14,7 @@ type Props = {
 const HeaderActions: React.FC<Props> = (props) => {
     const { user } = Stores.useAuthStore();
 
-    if (!user || props.publicationType === 'PEER_REVIEW') {
+    if (!user) {
         return null;
     }
 
@@ -31,7 +31,7 @@ const HeaderActions: React.FC<Props> = (props) => {
                     />
                 );
             })}
-            {!props.authorIds.includes(user.id) && (
+            {!props.authorIds.includes(user.id) && props.publicationType !== 'PEER_REVIEW' && (
                 <Components.Button
                     title="Write a review"
                     variant="block"

--- a/ui/src/lib/helpers.tsx
+++ b/ui/src/lib/helpers.tsx
@@ -278,7 +278,8 @@ export const linkedPublicationTypes = {
     DATA: ['PROBLEM', 'ANALYSIS'],
     ANALYSIS: ['PROBLEM', 'INTERPRETATION'],
     INTERPRETATION: ['PROBLEM', 'REAL_WORLD_APPLICATION'],
-    REAL_WORLD_APPLICATION: ['PROBLEM']
+    REAL_WORLD_APPLICATION: ['PROBLEM'],
+    PEER_REVIEW: ['PROBLEM']
 };
 
 // original URL regex: /(http|ftp|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:\/~+#-]*[\w@?^=%&\/~+#-])/


### PR DESCRIPTION
The purpose of this PR was to show a "Write a linked Research Problem" button when viewing a peer review publication. We have these types of buttons when viewing other publication types, covering the types of links that are possible to create, but peer reviews were missing them.

---

### Acceptance Criteria:

- The “Write a research problem” button is available against peer reviews

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

UI
![Screenshot 2025-06-23 153724](https://github.com/user-attachments/assets/7a883250-2a34-4b19-add4-31845870dceb)

E2E
![Screenshot 2025-06-24 083751](https://github.com/user-attachments/assets/6ac9feae-2ea4-48ab-b5e4-8cd56d8a2d42)

---

### Screenshots:

![Screenshot 2025-06-24 084925](https://github.com/user-attachments/assets/e41314eb-4ffd-47a3-b1e3-0f24ad5979c2)
