### PR TITLE
OC-1062 fix: List padding and on-publish validation

### DIFF
--- a/api/src/components/publicationVersion/service.ts
+++ b/api/src/components/publicationVersion/service.ts
@@ -383,22 +383,24 @@ export const checkIsReadyToPublish = async (publicationVersion: I.PublicationVer
     const isProblem = publicationVersion.publication.type === 'PROBLEM';
     const isProblemWithTopics = isProblem && publicationVersion.topics.length !== 0;
 
-    if (!linkedTo.length && !isProblemWithTopics) {
-        return {
-            ready: false,
-            message: `This publication must be linked to a live publication ${
-                isProblem ? 'or topic ' : ''
-            } in order to publish.`
-        };
-    }
+    if (!isProblemWithTopics) {
+        if (!linkedTo.length) {
+            return {
+                ready: false,
+                message: `This publication must be linked to a live publication ${
+                    isProblem ? 'or topic ' : ''
+                } in order to publish.`
+            };
+        }
 
-    // Would publishing leave any valid links (if some are pending deletion)?
-    if (linkedTo.length && linkedTo.every((linkedPublication) => linkedPublication.pendingDeletion === true)) {
-        return {
-            ready: false,
-            message:
-                'This publication would be left with no valid links if it was published. Please ensure there is at least one link to a live publication that is not marked for deletion before publishing this publication.'
-        };
+        // Would publishing leave any valid links (if some are pending deletion)?
+        if (linkedTo.length && linkedTo.every((linkedPublication) => linkedPublication.pendingDeletion === true)) {
+            return {
+                ready: false,
+                message:
+                    'This publication would be left with no valid links if it was published. Please ensure there is at least one link to a live publication that is not marked for deletion before publishing this publication.'
+            };
+        }
     }
 
     const hasFilledRequiredFields =

--- a/ui/src/components/Publication/Creation/LinkedItems/LinksPendingDeletionMessage.tsx
+++ b/ui/src/components/Publication/Creation/LinkedItems/LinksPendingDeletionMessage.tsx
@@ -10,7 +10,7 @@ const LinksPendingDeletionMessage: React.FC<{ publicationTitles: string[] }> = (
                     <p className="mt-2 text-sm font-semibold text-grey-700">
                         Links to the following publications will be deleted upon publish:
                     </p>
-                    <ul className="mt-2 mx-auto w-full text-sm text-grey-700 list-disc">
+                    <ul className="mt-2 mx-auto pl-6 w-full text-sm text-grey-700 list-disc">
                         {props.publicationTitles.map((title) => (
                             <li key={title} className="text-left">
                                 {title}


### PR DESCRIPTION
The purpose of this PR was to fix 2 issues found when testing #803.

- The list of links pending deletion should be indented a bit.
- A publication linked to a topic can't be published if it has links to publications which are all pending deletion.

---

### Acceptance Criteria:

The two issues described above no longer apply.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

API
![Screenshot 2025-06-24 153442](https://github.com/user-attachments/assets/886239a4-eeca-40e8-8b69-623b6d224a76)
