### PR TITLE
OC-1102: DndContext custom modifier to disable page scroll on keyboard dnd

### DIFF
--- a/ui/src/components/Publication/Creation/CoAuthor.tsx
+++ b/ui/src/components/Publication/Creation/CoAuthor.tsx
@@ -71,7 +71,6 @@ const CoAuthor: React.FC = (): React.ReactElement => {
             return context.transform;
         }
 
-
         if (context.scrollableAncestors.at(-1) === window.document.documentElement) {
             context.scrollableAncestors.pop();
         }

--- a/ui/src/components/Publication/Creation/CoAuthor.tsx
+++ b/ui/src/components/Publication/Creation/CoAuthor.tsx
@@ -11,6 +11,7 @@ import {
     DndContext,
     DragEndEvent,
     KeyboardSensor,
+    Modifier,
     PointerSensor,
     useSensor,
     useSensors
@@ -54,6 +55,28 @@ const CoAuthor: React.FC = (): React.ReactElement => {
             const newCoAuthors = arrayMove(coAuthors, oldIndex, newIndex);
             updateCoAuthors(newCoAuthors);
         }
+    };
+
+    const disablePageScrollModifier: Modifier = (context) => {
+        if (!context.activatorEvent || context.activatorEvent.type !== 'keydown') {
+            return context.transform;
+        }
+
+        if (typeof window === 'undefined' || !window.document.documentElement) {
+            return context.transform;
+        }
+
+        const docIndex = context.scrollableAncestors.indexOf(window.document.documentElement);
+        if (docIndex === -1) {
+            return context.transform;
+        }
+
+
+        if (context.scrollableAncestors.at(-1) === window.document.documentElement) {
+            context.scrollableAncestors.pop();
+        }
+
+        return context.transform;
     };
 
     const handleEmailChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
@@ -194,7 +217,12 @@ const CoAuthor: React.FC = (): React.ReactElement => {
                 <div className="overflow-x-auto rounded-lg shadow ring-1 ring-black ring-opacity-5 dark:ring-transparent">
                     <div className="inline-block min-w-full align-middle">
                         <div className="overflow-hidden">
-                            <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+                            <DndContext
+                                sensors={sensors}
+                                collisionDetection={closestCenter}
+                                onDragEnd={handleDragEnd}
+                                modifiers={[disablePageScrollModifier]}
+                            >
                                 <SortableContext
                                     items={coAuthors.map((coAuthor) => coAuthor.id)}
                                     strategy={verticalListSortingStrategy}


### PR DESCRIPTION


The purpose of this PR was to disable the page scrolling up and down when sorting elements in the page using the keyboard: https://docs.dndkit.com/api-documentation/sensors/keyboard

There is no configuration exposed to disable page scrolling for keyboard specifically, `autoScroll` property is managed internally by the keyboard sensor: https://docs.dndkit.com/api-documentation/context-provider#autoscroll

So the only working solution I've found is to remove the top (document element) scrollable ancestor from the `context.scrollableAncestors` list. This way it will no longer scroll the top most scrollable container.

---

### Acceptance Criteria:
- The list is sortable as normal (using the mouse and keyboard)
- The page doesn't scroll when sorting using the keyboard
---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated
