### PR TITLE
OC-1045: Publication edit page

### DIFF
--- a/ui/src/components/PublicationBundle/PublicationBundleForm.tsx
+++ b/ui/src/components/PublicationBundle/PublicationBundleForm.tsx
@@ -1,0 +1,207 @@
+import React from 'react';
+import * as Framer from 'framer-motion';
+import type { AxiosResponse } from 'axios';
+import * as OutlineIcons from '@heroicons/react/24/outline';
+
+import * as api from '@/api';
+import * as Components from '@/components';
+import * as Config from '@/config';
+import * as Contexts from '@/contexts';
+import * as Helpers from '@/helpers';
+import * as Interfaces from '@/interfaces';
+import * as Stores from '@/stores';
+
+type Props = {
+    bundle?: Interfaces.PublicationBundle | null;
+    isSaving?: boolean;
+    onSave: (bundle: Pick<Interfaces.PublicationBundle, 'name' | 'publications'>) => void;
+};
+
+const PublicationBundleForm = (props: Props): JSX.Element => {
+    const { bundle, isSaving: isLoading, onSave } = props;
+    const { setError } = Stores.usePublicationCreationStore((state) => ({ setError: state.setError }));
+
+    const [bundleName, setBundleName] = React.useState<string>(bundle?.name || '');
+    const [deletionUpdate, setDeletionUpdate] = React.useState('');
+    const [deleting, setDeleting] = React.useState(false);
+    const [publications, setPublications] = React.useState<Interfaces.PublicationBundle['publications']>(
+        bundle?.publications || []
+    );
+
+    const confirmation = Contexts.useConfirmationModal();
+
+    const addPublication = async (publicationId: string) => {
+        const getPublication: AxiosResponse<Interfaces.Publication> = await api.get(
+            `${Config.endpoints.publications}/${publicationId}`
+        );
+        const publication = getPublication.data;
+        const latestLiveVersion = publication.versions.find((version) => version.isLatestLiveVersion);
+        if (latestLiveVersion) {
+            setPublications((prev) => [
+                ...prev,
+                {
+                    authorFirstName: latestLiveVersion.user.firstName,
+                    authorLastName: latestLiveVersion.user.lastName,
+                    id: publication.id,
+                    publishedDate: latestLiveVersion.publishedDate || '',
+                    title: latestLiveVersion.title,
+                    type: publication.type
+                }
+            ]);
+        }
+    };
+
+    const deletePublication = async (publicationId: string) => {
+        const publication = publications.find((publication) => publication.id === publicationId);
+        const confirmed = await confirmation(
+            'Remove publication from bundle',
+            <p>
+                Are you sure you want to remove the publication{' '}
+                <span className="font-semibold">{publication?.title}</span> from the bundle?
+            </p>,
+            <OutlineIcons.TrashIcon className="h-8 w-8 text-grey-600" aria-hidden="true" />,
+            'Confirm'
+        );
+        if (confirmed) {
+            setDeleting(true);
+            setPublications((prev) => prev.filter((publication) => publication.id !== publicationId));
+            setDeleting(false);
+            setDeletionUpdate(`Publication ${publicationId} has been removed from the bundle.`);
+        }
+    };
+
+    const iconClasses = 'h-6 w-6 text-teal-600 transition-colors duration-500 dark:text-teal-400';
+    const thClasses =
+        'whitespace-pre py-3.5 px-3 sm:px-6 text-sm font-semibold text-grey-900 transition-colors duration-500 dark:text-grey-50';
+    const tdClasses = 'py-4 px-3 sm:px-6 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50';
+
+    return (
+        <div className="w-full xl:w-2/3 2xl:w-1/2 flex flex-col gap-8">
+            <form className="flex flex-col gap-4">
+                <label
+                    className="font-montserrat text-xl font-semibold text-grey-800 transition-colors duration-500 dark:text-white-100"
+                    htmlFor="bundle-name"
+                >
+                    Name <Components.RequiredIndicator />
+                </label>
+                <input
+                    id="bundle-name"
+                    required
+                    type="text"
+                    value={bundleName}
+                    onChange={(e) => setBundleName(e.target.value)}
+                    className="block rounded-md border border-grey-100 bg-white-50 text-grey-800 shadow outline-0 focus:ring-2 focus:ring-yellow-400"
+                />
+                <label
+                    className="mt-4 font-montserrat text-xl font-semibold text-grey-800 transition-colors duration-500 dark:text-white-100"
+                    htmlFor="add-publications"
+                >
+                    Add publications <Components.RequiredIndicator />
+                </label>
+                <Components.PublicationCombobox
+                    buttonText="Add to bundle"
+                    buttonCallback={async (publicationId) => addPublication(publicationId)}
+                    draftsOnly={false}
+                    excludedIds={publications.map((publication) => publication.id)}
+                    setError={setError}
+                />
+            </form>
+            <div className="sr-only" aria-live="polite">
+                {deletionUpdate}
+            </div>
+            {!!publications.length && (
+                <Framer.motion.div
+                    initial={{ opacity: 0.5 }}
+                    animate={{ opacity: 1 }}
+                    className="flex flex-col overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 dark:ring-transparent"
+                >
+                    <table
+                        className="min-w-full table-fixed divide-y divide-grey-100 dark:divide-teal-300"
+                        aria-label="Bundled publications table"
+                    >
+                        <thead className="bg-grey-50 transition-colors duration-500 dark:bg-grey-700">
+                            <tr>
+                                <th className={`text-left ${thClasses}`}>Publication</th>
+                                <th className={thClasses}>View</th>
+                                <th className={thClasses}>Delete</th>
+                            </tr>
+                        </thead>
+                        <tbody className="my-4 bg-white-50 transition-colors duration-500 dark:bg-grey-600">
+                            {publications.map((publication) => (
+                                <tr key={publication.id}>
+                                    <td className={`w-3/5 ${tdClasses}`}>
+                                        <div className="space-y-2">
+                                            <span className="font-montserrat text-sm font-medium text-teal-600 transition-colors duration-500 dark:text-teal-100">
+                                                {Helpers.formatPublicationType(publication.type)}
+                                            </span>
+                                            <p className="text-grey-800 transition-colors duration-500 dark:text-white-50">
+                                                {publication.title}
+                                            </p>
+                                            <div className="flex items-center space-x-2">
+                                                <span className="text-xs text-grey-700 transition-colors duration-500 dark:text-white-100">
+                                                    <time suppressHydrationWarning>
+                                                        {Helpers.formatDate(publication.publishedDate)}
+                                                    </time>
+                                                    ,
+                                                </span>
+                                                <span className="text-sm text-grey-700 transition-colors duration-500 dark:text-white-100">
+                                                    {Helpers.abbreviateUserName({
+                                                        firstName: publication.authorFirstName,
+                                                        lastName: publication.authorLastName
+                                                    })}
+                                                </span>
+                                            </div>
+                                        </div>
+                                    </td>
+                                    <td className={`w-1/5 text-center font-medium ${tdClasses}`}>
+                                        <div className="flex items-center justify-center">
+                                            <Components.Link
+                                                href={`${Config.urls.viewPublication.path}/${publication.id}`}
+                                                openNew={true}
+                                                ariaLabel={'Visit publication'}
+                                                className="p-2"
+                                            >
+                                                <OutlineIcons.ArrowTopRightOnSquareIcon className={iconClasses} />
+                                            </Components.Link>
+                                        </div>
+                                    </td>
+                                    <td className={`w-1/5 text-center font-medium ${tdClasses}`}>
+                                        <div className="flex items-center justify-center">
+                                            <Components.IconButton
+                                                className="p-2"
+                                                title="Delete"
+                                                icon={
+                                                    deleting ? (
+                                                        <OutlineIcons.ArrowPathIcon
+                                                            className={iconClasses + ' animate-spin'}
+                                                            aria-hidden="true"
+                                                        />
+                                                    ) : (
+                                                        <OutlineIcons.TrashIcon
+                                                            className={iconClasses}
+                                                            aria-hidden="true"
+                                                        />
+                                                    )
+                                                }
+                                                onClick={async () => await deletePublication(publication.id)}
+                                                disabled={deleting}
+                                            />
+                                        </div>
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </Framer.motion.div>
+            )}
+            <Components.Button
+                disabled={!bundleName || publications.length < 2 || isLoading}
+                onClick={() => onSave({ name: bundleName, publications })}
+                title="Save"
+                variant="block"
+            />
+        </div>
+    );
+};
+
+export default PublicationBundleForm;

--- a/ui/src/components/index.tsx
+++ b/ui/src/components/index.tsx
@@ -75,6 +75,7 @@ export { default as PublicationCreationLinkedItems } from './Publication/Creatio
 export { default as PublicationCreationMainText } from './Publication/Creation/MainText';
 export { default as PublicationCreationResearchProcess } from './Publication/Creation/ResearchProcess';
 export { default as PublicationCreationStepTitle } from './Publication/Creation/StepTitle';
+export { default as PublicationBundleForm } from './PublicationBundle/PublicationBundleForm';
 export { default as PublicationLink } from './Publication/Link';
 export { default as PublicationPageCoAuthoringActions } from './Publication/PublicationPage/CoAuthoringActions';
 export { default as PublicationPageHeaderActions } from './Publication/PublicationPage/HeaderActions';

--- a/ui/src/config/urls.ts
+++ b/ui/src/config/urls.ts
@@ -169,12 +169,12 @@ const urls = {
         keywords: ['publication', 'bundle', 'export', 'share']
     },
 
-    editBundle: {
-        path: '/bundles/edit',
-        documentTitle: `Edit bundle - ${base.title}`,
-        title: 'Edit bundle',
-        canonical: `${base.host}/bundles/edit`,
-        description: 'Edit an existing bundle to update its contents or details.',
+    viewBundle: {
+        path: '/bundles',
+        documentTitle: `Publication bundle - ${base.title}`,
+        title: 'Publication bundle',
+        canonical: `${base.host}/bundles`,
+        description: 'View a publication bundle containing multiple publications.',
         keywords: ['publication', 'bundle', 'export', 'share']
     },
 

--- a/ui/src/config/urls.ts
+++ b/ui/src/config/urls.ts
@@ -151,12 +151,30 @@ const urls = {
     },
 
     // Bundles
+    viewBundles: {
+        path: '/bundles',
+        documentTitle: `Publication bundles - ${base.title}`,
+        title: 'Publication bundles',
+        canonical: `${base.host}/bundles`,
+        description: 'View and manage your publication bundles.',
+        keywords: ['publication', 'bundle', 'export', 'share']
+    },
+
     createBundle: {
         path: '/bundles/create',
         documentTitle: `Create new bundle - ${base.title}`,
         title: 'Create new bundle',
         canonical: `${base.host}/bundles/create`,
         description: 'Create a bundle to group multiple publications together.',
+        keywords: ['publication', 'bundle', 'export', 'share']
+    },
+
+    editBundle: {
+        path: '/bundles/edit',
+        documentTitle: `Edit bundle - ${base.title}`,
+        title: 'Edit bundle',
+        canonical: `${base.host}/bundles/edit`,
+        description: 'Edit an existing bundle to update its contents or details.',
         keywords: ['publication', 'bundle', 'export', 'share']
     },
 

--- a/ui/src/lib/interfaces.ts
+++ b/ui/src/lib/interfaces.ts
@@ -88,6 +88,22 @@ export interface Publication extends CorePublication {
     versions: PublicationVersion[];
 }
 
+export interface PublicationBundle {
+    id: string;
+    name: string;
+    createdAt: string;
+    updatedAt: string;
+    createdBy: string;
+    publications: {
+        authorFirstName: string;
+        authorLastName: string;
+        id: string;
+        publishedDate: string;
+        title: string;
+        type: Types.PublicationType;
+    }[];
+}
+
 type LinkedPublicationAuthor = Pick<CoAuthor, 'id' | 'linkedUser'> & { user: CoAuthor['user'] | null };
 export interface LinkedPublication {
     id: string;

--- a/ui/src/pages/bundles/[id].tsx
+++ b/ui/src/pages/bundles/[id].tsx
@@ -40,7 +40,7 @@ type Props = {
     token: string;
 };
 
-const EditBundle: NextPage<Props> = (props): JSX.Element => {
+const ViewBundle: NextPage<Props> = (props): JSX.Element => {
     const { bundle } = props;
     const [savingBundle, setSavingBundle] = React.useState(false);
 
@@ -88,12 +88,12 @@ const EditBundle: NextPage<Props> = (props): JSX.Element => {
     return (
         <>
             <Head>
-                <title>{Config.urls.editBundle.documentTitle}</title>
-                <meta name="description" content={Config.urls.editBundle.description} />
-                <meta name="og:title" content={Config.urls.editBundle.documentTitle} />
-                <meta name="og:description" content={Config.urls.editBundle.description} />
-                <meta name="keywords" content={Config.urls.editBundle.keywords.join(', ')} />
-                {bundle ? <link rel="canonical" href={`${Config.urls.editBundle.canonical}/${bundle.id}`} /> : null}
+                <title>{Config.urls.viewBundle.documentTitle}</title>
+                <meta name="description" content={Config.urls.viewBundle.description} />
+                <meta name="og:title" content={Config.urls.viewBundle.documentTitle} />
+                <meta name="og:description" content={Config.urls.viewBundle.description} />
+                <meta name="keywords" content={Config.urls.viewBundle.keywords.join(', ')} />
+                {bundle ? <link rel="canonical" href={`${Config.urls.viewBundle.canonical}/${bundle.id}`} /> : null}
             </Head>
             <Layouts.Standard fixedHeader={false}>
                 <section className="container mx-auto px-8 pb-10 pt-10 lg:gap-4 lg:pt-20">
@@ -126,4 +126,4 @@ const EditBundle: NextPage<Props> = (props): JSX.Element => {
     );
 };
 
-export default EditBundle;
+export default ViewBundle;

--- a/ui/src/pages/bundles/create.tsx
+++ b/ui/src/pages/bundles/create.tsx
@@ -1,15 +1,12 @@
-import { AxiosResponse, isAxiosError } from 'axios';
-import * as Framer from 'framer-motion';
+import React from 'react';
 import Head from 'next/head';
 import { NextPage } from 'next';
+import * as Router from 'next/router';
 import * as OutlineIcons from '@heroicons/react/24/outline';
-import React from 'react';
 
 import * as api from '@/api';
 import * as Components from '@/components';
 import * as Config from '@/config';
-import * as Contexts from '@/contexts';
-import * as Helpers from '@/helpers';
 import * as Interfaces from '@/interfaces';
 import * as Layouts from '@/layouts';
 import * as Stores from '@/stores';
@@ -22,101 +19,44 @@ export const getStaticProps: Types.GetStaticProps = async () => ({
 });
 
 const CreateBundle: NextPage = (): JSX.Element => {
-    const { setError } = Stores.usePublicationCreationStore((state) => ({ setError: state.setError }));
-    const setToast = Stores.useToastStore((state) => state.setToast);
-    const user = Stores.useAuthStore((state) => state.user);
-    const [bundleName, setBundleName] = React.useState<string>('');
-    const [deletionUpdate, setDeletionUpdate] = React.useState('');
-    const [deleting, setDeleting] = React.useState(false);
-    const [publications, setPublications] = React.useState<
-        Array<{
-            authorFirstName: string;
-            authorLastName: string;
-            id: string;
-            publishedDate: string;
-            title: string;
-            type: Types.PublicationType;
-        }>
-    >([]);
     const [savingBundle, setSavingBundle] = React.useState(false);
 
-    const confirmation = Contexts.useConfirmationModal();
+    const router = Router.useRouter();
+    const setToast = Stores.useToastStore((state) => state.setToast);
+    const user = Stores.useAuthStore((state) => state.user);
 
-    const addPublication = async (publicationId: string) => {
-        const getPublication: AxiosResponse<Interfaces.Publication> = await api.get(
-            `${Config.endpoints.publications}/${publicationId}`
-        );
-        const publication = getPublication.data;
-        const latestLiveVersion = publication.versions.find((version) => version.isLatestLiveVersion);
-        if (latestLiveVersion) {
-            setPublications((prev) => [
-                ...prev,
-                {
-                    authorFirstName: latestLiveVersion.user.firstName,
-                    authorLastName: latestLiveVersion.user.lastName,
-                    id: publication.id,
-                    publishedDate: latestLiveVersion.publishedDate || '',
-                    title: latestLiveVersion.title,
-                    type: publication.type
-                }
-            ]);
-        }
-    };
-
-    const deletePublication = async (publicationId: string) => {
-        const publication = publications.find((publication) => publication.id === publicationId);
-        const confirmed = await confirmation(
-            'Remove publication from bundle',
-            <p>
-                Are you sure you want to remove the publication{' '}
-                <span className="font-semibold">{publication?.title}</span> from the bundle?
-            </p>,
-            <OutlineIcons.TrashIcon className="h-8 w-8 text-grey-600" aria-hidden="true" />,
-            'Confirm'
-        );
-        if (confirmed) {
-            setDeleting(true);
-            setPublications((prev) => prev.filter((publication) => publication.id !== publicationId));
-            setDeleting(false);
-            setDeletionUpdate(`Publication ${publicationId} has been removed from the bundle.`);
-        }
-    };
-
-    const saveBundle = async () => {
+    const saveBundle = async (bundle: Pick<Interfaces.PublicationBundle, 'name' | 'publications'>) => {
         setSavingBundle(true);
         try {
             await api.post(
                 Config.endpoints.publicationBundles,
                 {
-                    name: bundleName,
-                    publicationIds: publications.map((publication) => publication.id)
+                    name: bundle.name,
+                    publicationIds: bundle.publications.map((publication) => publication.id)
                 },
                 user?.token
             );
-            setBundleName('');
-            setPublications([]);
             setToast({
                 visible: true,
                 title: 'Bundle created successfully',
-                message: `The bundle "${bundleName}" has been created with ${publications.length} publications.`,
+                message: `The bundle "${bundle.name}" has been created with ${bundle.publications.length} publications.`,
                 icon: <OutlineIcons.CheckCircleIcon className="h-6 w-6 text-teal-600" />,
                 dismiss: true
             });
+
+            router.push(Config.urls.viewBundles.path);
         } catch (err) {
-            const { message } = err as Interfaces.JSONResponseError;
-            setError(
-                isAxiosError(err) && typeof err.response?.data?.message === 'string'
-                    ? err.response.data.message
-                    : message
-            );
+            console.error('Error saving bundle:', err);
+            setToast({
+                visible: true,
+                title: 'Error creating bundle',
+                message: 'An error occurred while creating the bundle. Please try again.',
+                icon: <OutlineIcons.XCircleIcon className="h-6 w-6 text-red-600" />,
+                dismiss: true
+            });
         }
         setSavingBundle(false);
     };
-
-    const iconClasses = 'h-6 w-6 text-teal-600 transition-colors duration-500 dark:text-teal-400';
-    const thClasses =
-        'whitespace-pre py-3.5 px-3 sm:px-6 text-sm font-semibold text-grey-900 transition-colors duration-500 dark:text-grey-50';
-    const tdClasses = 'py-4 px-3 sm:px-6 text-sm text-grey-900 transition-colors duration-500 dark:text-white-50';
 
     return (
         <>
@@ -135,135 +75,7 @@ const CreateBundle: NextPage = (): JSX.Element => {
                         text="Save this bundle to create a shareable link"
                         className="font-montserrat text-lg font-medium text-grey-700 transition-colors duration-500 dark:text-grey-50"
                     />
-                    <div className="w-full xl:w-2/3 2xl:w-1/2 flex flex-col gap-8">
-                        <form className="flex flex-col gap-4">
-                            <label
-                                className="font-montserrat text-xl font-semibold text-grey-800 transition-colors duration-500 dark:text-white-100"
-                                htmlFor="bundle-name"
-                            >
-                                Name <Components.RequiredIndicator />
-                            </label>
-                            <input
-                                id="bundle-name"
-                                required
-                                type="text"
-                                value={bundleName}
-                                onChange={(e) => setBundleName(e.target.value)}
-                                className="block rounded-md border border-grey-100 bg-white-50 text-grey-800 shadow outline-0 focus:ring-2 focus:ring-yellow-400"
-                            />
-                            <label
-                                className="mt-4 font-montserrat text-xl font-semibold text-grey-800 transition-colors duration-500 dark:text-white-100"
-                                htmlFor="add-publications"
-                            >
-                                Add publications <Components.RequiredIndicator />
-                            </label>
-                            <Components.PublicationCombobox
-                                buttonText="Add to bundle"
-                                buttonCallback={async (publicationId) => addPublication(publicationId)}
-                                draftsOnly={false}
-                                excludedIds={publications.map((publication) => publication.id)}
-                                setError={setError}
-                            />
-                        </form>
-                        <div className="sr-only" aria-live="polite">
-                            {deletionUpdate}
-                        </div>
-                        {!!publications.length && (
-                            <Framer.motion.div
-                                initial={{ opacity: 0.5 }}
-                                animate={{ opacity: 1 }}
-                                className="flex flex-col overflow-hidden rounded-lg shadow ring-1 ring-black ring-opacity-5 dark:ring-transparent"
-                            >
-                                <table
-                                    className="min-w-full table-fixed divide-y divide-grey-100 dark:divide-teal-300"
-                                    aria-label="Bundled publications table"
-                                >
-                                    <thead className="bg-grey-50 transition-colors duration-500 dark:bg-grey-700">
-                                        <tr>
-                                            <th className={`text-left ${thClasses}`}>Publication</th>
-                                            <th className={thClasses}>View</th>
-                                            <th className={thClasses}>Delete</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody className="my-4 bg-white-50 transition-colors duration-500 dark:bg-grey-600">
-                                        {publications.map((publication) => (
-                                            <tr key={publication.id}>
-                                                <td className={`w-3/5 ${tdClasses}`}>
-                                                    <div className="space-y-2">
-                                                        <span className="font-montserrat text-sm font-medium text-teal-600 transition-colors duration-500 dark:text-teal-100">
-                                                            {Helpers.formatPublicationType(publication.type)}
-                                                        </span>
-                                                        <p className="text-grey-800 transition-colors duration-500 dark:text-white-50">
-                                                            {publication.title}
-                                                        </p>
-                                                        <div className="flex items-center space-x-2">
-                                                            <span className="text-xs text-grey-700 transition-colors duration-500 dark:text-white-100">
-                                                                <time suppressHydrationWarning>
-                                                                    {Helpers.formatDate(publication.publishedDate)}
-                                                                </time>
-                                                                ,
-                                                            </span>
-                                                            <span className="text-sm text-grey-700 transition-colors duration-500 dark:text-white-100">
-                                                                {Helpers.abbreviateUserName({
-                                                                    firstName: publication.authorFirstName,
-                                                                    lastName: publication.authorLastName
-                                                                })}
-                                                            </span>
-                                                        </div>
-                                                    </div>
-                                                </td>
-                                                <td className={`w-1/5 text-center font-medium ${tdClasses}`}>
-                                                    <div className="flex items-center justify-center">
-                                                        <Components.Link
-                                                            href={`${Config.urls.viewPublication.path}/${publication.id}`}
-                                                            openNew={true}
-                                                            ariaLabel={'Visit publication'}
-                                                            className="p-2"
-                                                        >
-                                                            <OutlineIcons.ArrowTopRightOnSquareIcon
-                                                                className={iconClasses}
-                                                            />
-                                                        </Components.Link>
-                                                    </div>
-                                                </td>
-                                                <td className={`w-1/5 text-center font-medium ${tdClasses}`}>
-                                                    <div className="flex items-center justify-center">
-                                                        <Components.IconButton
-                                                            className="p-2"
-                                                            title="Delete"
-                                                            icon={
-                                                                deleting ? (
-                                                                    <OutlineIcons.ArrowPathIcon
-                                                                        className={iconClasses + ' animate-spin'}
-                                                                        aria-hidden="true"
-                                                                    />
-                                                                ) : (
-                                                                    <OutlineIcons.TrashIcon
-                                                                        className={iconClasses}
-                                                                        aria-hidden="true"
-                                                                    />
-                                                                )
-                                                            }
-                                                            onClick={async () =>
-                                                                await deletePublication(publication.id)
-                                                            }
-                                                            disabled={deleting}
-                                                        />
-                                                    </div>
-                                                </td>
-                                            </tr>
-                                        ))}
-                                    </tbody>
-                                </table>
-                            </Framer.motion.div>
-                        )}
-                        <Components.Button
-                            disabled={!bundleName || publications.length < 2 || savingBundle}
-                            onClick={saveBundle}
-                            title="Save"
-                            variant="block"
-                        />
-                    </div>
+                    <Components.PublicationBundleForm onSave={saveBundle} isSaving={savingBundle} />
                 </section>
             </Layouts.Standard>
         </>

--- a/ui/src/pages/bundles/create.tsx
+++ b/ui/src/pages/bundles/create.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import Head from 'next/head';
-import * as Router from 'next/router';
 import { NextPage } from 'next';
 import * as Router from 'next/router';
 import * as OutlineIcons from '@heroicons/react/24/outline';

--- a/ui/src/pages/bundles/edit/[id].tsx
+++ b/ui/src/pages/bundles/edit/[id].tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import Head from 'next/head';
+import * as Router from 'next/router';
+import type { NextPage } from 'next';
+import * as OutlineIcons from '@heroicons/react/24/outline';
+
+import * as api from '@/api';
+import * as Components from '@/components';
+import * as Config from '@/config';
+import * as Helpers from '@/helpers';
+import * as Interfaces from '@/interfaces';
+import * as Layouts from '@/layouts';
+import * as Stores from '@/stores';
+import * as Types from '@/types';
+
+export const getServerSideProps: Types.GetServerSideProps = Helpers.withServerSession(async (context) => {
+    const token = Helpers.getJWT(context);
+    const id = context.params?.id as string;
+
+    let bundle: Interfaces.PublicationBundle | null = null;
+
+    try {
+        const response = await api.get(`${Config.endpoints.publicationBundles}/${id}`, token);
+        bundle = response.data;
+    } catch (err) {
+        console.log(err);
+    }
+
+    return {
+        props: {
+            bundle,
+            token,
+            protectedPage: true
+        }
+    };
+});
+
+type Props = {
+    bundle: Interfaces.PublicationBundle | null;
+    token: string;
+};
+
+const EditBundle: NextPage<Props> = (props): JSX.Element => {
+    const { bundle } = props;
+    const [savingBundle, setSavingBundle] = React.useState(false);
+
+    const router = Router.useRouter();
+    const setToast = Stores.useToastStore((state) => state.setToast);
+    const user = Stores.useAuthStore((state) => state.user);
+
+    const saveBundle = async (data: Pick<Interfaces.PublicationBundle, 'name' | 'publications'>) => {
+        if (!bundle) {
+            return;
+        }
+
+        setSavingBundle(true);
+        try {
+            await api.patch(
+                `${Config.endpoints.publicationBundles}/${bundle.id}`,
+                {
+                    name: data.name,
+                    publicationIds: data.publications.map((publication) => publication.id)
+                },
+                user?.token
+            );
+            setToast({
+                visible: true,
+                title: 'Bundle saved successfully',
+                message: `The bundle "${data.name}" has been updated with ${data.publications.length} publications.`,
+                icon: <OutlineIcons.CheckCircleIcon className="h-6 w-6 text-teal-600" />,
+                dismiss: true
+            });
+
+            router.push(Config.urls.viewBundles.path);
+        } catch (err) {
+            console.error('Error saving bundle:', err);
+            setToast({
+                visible: true,
+                title: 'Error creating bundle',
+                message: 'An error occurred while creating the bundle. Please try again.',
+                icon: <OutlineIcons.XCircleIcon className="h-6 w-6 text-red-600" />,
+                dismiss: true
+            });
+        }
+        setSavingBundle(false);
+    };
+
+    return (
+        <>
+            <Head>
+                <title>{Config.urls.editBundle.documentTitle}</title>
+                <meta name="description" content={Config.urls.editBundle.description} />
+                <meta name="og:title" content={Config.urls.editBundle.documentTitle} />
+                <meta name="og:description" content={Config.urls.editBundle.description} />
+                <meta name="keywords" content={Config.urls.editBundle.keywords.join(', ')} />
+                {bundle ? <link rel="canonical" href={`${Config.urls.editBundle.canonical}/${bundle.id}`} /> : null}
+            </Head>
+            <Layouts.Standard fixedHeader={false}>
+                <section className="container mx-auto px-8 pb-10 pt-10 lg:gap-4 lg:pt-20">
+                    {bundle ? (
+                        <>
+                            <Components.PageTitle text={bundle.name} className="mb-8" />
+                            <Components.PageSubTitle
+                                text=""
+                                // text={`Shareable link: ${ Config.urls.viewBundle.path }/${bundle.id}`}
+                                className="font-montserrat text-lg font-medium text-grey-700 transition-colors duration-500 dark:text-grey-50"
+                            />
+                            <Components.PublicationBundleForm
+                                bundle={bundle}
+                                onSave={saveBundle}
+                                isSaving={savingBundle}
+                            />
+                        </>
+                    ) : (
+                        <>
+                            <Components.PageTitle text="Bundle not found" className="mb-8" />
+                            <Components.PageSubTitle
+                                text="The bundle you are trying to edit does not exist or has been deleted."
+                                className="font-montserrat text-lg font-medium text-grey-700 transition-colors duration-500 dark:text-grey-50"
+                            />
+                        </>
+                    )}
+                </section>
+            </Layouts.Standard>
+        </>
+    );
+};
+
+export default EditBundle;

--- a/ui/src/pages/bundles/index.tsx
+++ b/ui/src/pages/bundles/index.tsx
@@ -238,7 +238,7 @@ function ViewBundlesResults(props: {
                             <td className={`w-1/4 hidden md:table-cell ${tdClasses}`}>
                                 <div className="flex items-center justify-center">
                                     <Components.Link
-                                        href={`${Config.urls.editBundle.path}/${bundle.id}`}
+                                        href={`${Config.urls.viewBundle.path}/${bundle.id}`}
                                         ariaLabel={'View bundle details'}
                                         className="p-2"
                                     >


### PR DESCRIPTION
The purpose of this PR was to add editing support for publication bundles. It re-uses the publication picker form from https://github.com/JiscSD/octopus/pull/817 (extracted in a shared component).
---

### Acceptance Criteria:
- Clicking on "view bundle" should redirect to the bundle edit page
- I can add & remove publications from my bundle
- Saving the changes redirects back to the bundles page and the updates are reflected on the main page too.

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

### Screenshots:
<img width="1279" alt="Screenshot 2025-07-09 at 14 51 27" src="https://github.com/user-attachments/assets/f4d68f09-8804-45cf-8c77-768c1f9f1e2c" />

