### PR TITLE
OC-1078 - Fix Notifications stack

### DIFF
--- a/api/serverless-config-default.yml
+++ b/api/serverless-config-default.yml
@@ -338,14 +338,14 @@ functions:
                 method: GET
                 cors: true
     # Notifications
-    getAll:
+    getAllNotifications:
         handler: dist/src/components/notification/routes.getAll
         events:
             - http:
                 path: ${self:custom.versions.v1}/notifications
                 method: GET
                 cors: true
-    sendBulletin:
+    sendBulletinNotifications:
         handler: dist/src/components/notification/routes.sendBulletin
         events:
             - schedule: cron(0 10 ? * MON *) # Every Monday at 10

--- a/infra/modules/bastion/main.tf
+++ b/infra/modules/bastion/main.tf
@@ -49,6 +49,8 @@ data "template_file" "install_software" {
 data "aws_ami" "amazon-linux-2023" {
   most_recent = true
 
+  owners = ["amazon"]
+
   filter {
     name   = "owner-alias"
     values = ["amazon"]

--- a/infra/modules/oidc/main.tf
+++ b/infra/modules/oidc/main.tf
@@ -54,6 +54,8 @@ data "aws_iam_policy_document" "deploy_backend_policy" {
       "ec2:RunInstances",
       "events:ListTargetsByRule",
       "events:DescribeRule",
+      "events:PutRule",
+      "events:RemoveTargets",
       "iam:CreateRole",
       "iam:DeleteRole",
       "iam:DeleteRolePolicy",

--- a/infra/modules/oidc/main.tf
+++ b/infra/modules/oidc/main.tf
@@ -55,6 +55,8 @@ data "aws_iam_policy_document" "deploy_backend_policy" {
       "events:ListTargetsByRule",
       "events:DescribeRule",
       "events:PutRule",
+      "events:DeleteRule",
+      "events:PutTargets",
       "events:RemoveTargets",
       "iam:CreateRole",
       "iam:DeleteRole",


### PR DESCRIPTION
The purpose of this PR was to fix the missing permissions for deploying the 2 new lambda functions (get notifications and send notification bulletin)

We merged https://github.com/JiscSD/octopus/pull/825 but the stack hasn't deployed successfully. So we added the missing permissions.