### PR TITLE
OC-1103: PDF generation not happening automatically

### DIFF
--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -107,7 +107,7 @@ services:
             - VALIDATION_CODE_EXPIRY=10
             - VALIDATION_CODE_ATTEMPTS=3
             - DATABASE_URL=postgresql://mydbuser:mydbpwd@api-test-db:5432/postgres?schema=public
-            - QUEUE_URL=http://localhost:4566/000000000000/science-octopus-pdf-queue-local
+            - QUEUE_URL=http://localhost:4566/000000000000/pdf-generation-queue-local-octopus
             - SQS_ENDPOINT=http://localstack:4566
             - LIST_USERS_API_KEY=123456789
             - TRIGGER_SCRIPT_API_KEY=123456789

--- a/api/prisma/seed.ts
+++ b/api/prisma/seed.ts
@@ -119,7 +119,7 @@ export const initialDevSeed = async (): Promise<void> => {
 
         // Create local PDF generation queue
         try {
-            await sqs.getQueue(`science-octopus-pdf-queue-${process.env.STAGE}`);
+            await sqs.getQueue(`pdf-generation-queue-${process.env.STAGE}-octopus`);
             console.log('PDF queue already exists');
         } catch (err) {
             await sqs.createQueue();

--- a/api/serverless-config-deploy.yml
+++ b/api/serverless-config-deploy.yml
@@ -3,4 +3,4 @@ functions:
     generatePDFsFromQueue:
         handler: dist/src/components/sqs/handler.generatePDFs
         events:
-            - sqs: 'arn:aws:sqs:${aws:region}:${aws:accountId}:science-octopus-pdf-queue-${self:provider.stage}'
+            - sqs: 'arn:aws:sqs:${aws:region}:${aws:accountId}:pdf-generation-queue-${self:provider.stage}-octopus'

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -81,7 +81,7 @@ provider:
           Resource: 'arn:aws:s3:::science-octopus-publishing-sitemaps-${self:provider.stage}'
           Action: 's3:ListBucket'
         - Effect: 'Allow'
-          Resource: 'arn:aws:sqs:${aws:region}:${aws:accountId}:science-octopus-pdf-queue-${self:provider.stage}'
+          Resource: 'arn:aws:sqs:${aws:region}:${aws:accountId}:pdf-generation-queue-${self:provider.stage}-octopus'
           Action:
               - 'lambda:CreateEventSourceMapping'
               - 'lambda:ListEventSourceMappings'

--- a/api/src/lib/sqs.ts
+++ b/api/src/lib/sqs.ts
@@ -22,7 +22,7 @@ const sqs = new SQS(config);
 export const createQueue = async (): Promise<AWS_SQS.CreateQueueResult> => {
     // create SQS locally for PDF message queue
     return sqs.createQueue({
-        QueueName: `science-octopus-pdf-queue-${process.env.STAGE}`,
+        QueueName: `pdf-generation-queue-${process.env.STAGE}-octopus`,
         Attributes: {
             DelaySeconds: '60',
             MessageRetentionPeriod: '86400'


### PR DESCRIPTION
The purpose of this PR was to fix the PDF auto-generation for publications, as it's no longer working. I think is related to the queue name change from here:

https://github.com/JiscSD/octopus/pull/798/commits/42cb834dc51705d17e58c7b7fa15b31fcf520944#diff-19dbbb03ef3c0e3c3d01c7a57a96a81683fb73fb2266bd707ba0dfb10ce54399L1-L2

---

### Acceptance Criteria:
- Create a new publication
- After generating it do not click the button to open the PDF. 
- Navigate directly to the PDF by adding the DOI code to this URL as follows: https://s3.eu-west-1.amazonaws.com/science-octopus-publishing-pdfs-int/XXXX-XXXX.pdf
---

### Checklist:

- [ ] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated
