### PR TITLE
OC-1045 - Fix missing publication name on bundle edit

### DIFF
--- a/api/src/components/publicationBundle/service.ts
+++ b/api/src/components/publicationBundle/service.ts
@@ -36,7 +36,25 @@ export const get = (id: string) =>
     client.prisma.publicationBundle.findUnique({
         where: { id },
         include: {
-            publications: true
+            publications: {
+                include: {
+                    versions: {
+                        where: {
+                            isLatestLiveVersion: true
+                        },
+                        select: {
+                            title: true,
+                            publishedDate: true,
+                            user: {
+                                select: {
+                                    firstName: true,
+                                    lastName: true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     });
 

--- a/ui/src/pages/bundles/[id].tsx
+++ b/ui/src/pages/bundles/[id].tsx
@@ -21,7 +21,22 @@ export const getServerSideProps: Types.GetServerSideProps = Helpers.withServerSe
 
     try {
         const response = await api.get(`${Config.endpoints.publicationBundles}/${id}`, token);
-        bundle = response.data;
+
+        // Augment bundle publications with latest live versions
+        bundle = { ...response.data, publications: [] };
+
+        for (const publication of response.data.publications) {
+            const latestLiveVersion = publication.versions[0];
+            if (!latestLiveVersion) continue;
+            bundle!.publications.push({
+                authorFirstName: latestLiveVersion.user.firstName,
+                authorLastName: latestLiveVersion.user.lastName,
+                id: publication.id,
+                publishedDate: latestLiveVersion.publishedDate || '',
+                title: latestLiveVersion.title,
+                type: publication.type
+            });
+        }
     } catch (err) {
         console.log(err);
     }


### PR DESCRIPTION
The purpose of this PR was to fix a bug related to editing publication bundles where the publication name is not shown

---

### Acceptance Criteria:
- The publication name and date is shown on edit
---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

