### PR TITLE
OC-1044 : Bundle shareable link - Show limit message only for editable bundles

### DIFF
--- a/ui/src/components/PublicationBundle/PublicationBundleForm.tsx
+++ b/ui/src/components/PublicationBundle/PublicationBundleForm.tsx
@@ -205,7 +205,7 @@ const PublicationBundleForm = (props: Props): JSX.Element => {
                         </table>
                     </Framer.motion.div>
                 )}
-                {invalidNumberOfPublications ? (
+                {editable && invalidNumberOfPublications ? (
                     <div className="first:rounded-lg rounded-b-lg bg-grey-50 px-6 py-4 text-left text-sm text-grey-900 dark:bg-grey-700 dark:text-white-50 sm:text-center">
                         <h4 className="text-lg dark:text-white-50">
                             <span className="font-semibold">


### PR DESCRIPTION
The purpose of this PR was to fix an UI problem where if a bundle has 30 publications, the "You have reached the limit of 30 publications" is shown for the other (non-author) users.
---

### Acceptance Criteria:
- The "You have reached the limit of 30 publications" or any other message is shown only for bundle authors
---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated
