### PR TITLE
OC-1111 - No interactive content in bundles/create

### DIFF
--- a/ui/src/pages/bundles/create.tsx
+++ b/ui/src/pages/bundles/create.tsx
@@ -77,7 +77,7 @@ const CreateBundle: NextPage = (): JSX.Element => {
                         text="Save this bundle to create a shareable link"
                         className="font-montserrat text-lg font-medium text-grey-700 transition-colors duration-500 dark:text-grey-50"
                     />
-                    <Components.PublicationBundleForm onSave={saveBundle} isSaving={savingBundle} editable={true}/>
+                    <Components.PublicationBundleForm onSave={saveBundle} isSaving={savingBundle} editable={true} />
                 </section>
             </Layouts.Standard>
         </>

--- a/ui/src/pages/bundles/create.tsx
+++ b/ui/src/pages/bundles/create.tsx
@@ -77,7 +77,7 @@ const CreateBundle: NextPage = (): JSX.Element => {
                         text="Save this bundle to create a shareable link"
                         className="font-montserrat text-lg font-medium text-grey-700 transition-colors duration-500 dark:text-grey-50"
                     />
-                    <Components.PublicationBundleForm onSave={saveBundle} isSaving={savingBundle} />
+                    <Components.PublicationBundleForm onSave={saveBundle} isSaving={savingBundle} editable={true}/>
                 </section>
             </Layouts.Standard>
         </>


### PR DESCRIPTION
The purpose of this PR was to fix a bug where bundles/create was not showing the form. This was introduced after a bad conflict merge.

---

### Acceptance Criteria:
- bundes/create shows the form
---

### Checklist:

- [X] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

---

### Screenshots:
