### PR TITLE
OC-484 - Notifying red flaggers of new versions

### DIFF
--- a/api/prisma/migrations/20250801102233_notification_bulletin_publication_version_red_flag/migration.sql
+++ b/api/prisma/migrations/20250801102233_notification_bulletin_publication_version_red_flag/migration.sql
@@ -1,0 +1,5 @@
+-- AlterEnum
+ALTER TYPE "NotificationActionTypeEnum" ADD VALUE 'PUBLICATION_VERSION_RED_FLAG_RAISED';
+
+-- AlterTable
+ALTER TABLE "UserSettings" ADD COLUMN     "enableVersionFlagNotifications" BOOLEAN NOT NULL DEFAULT true;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -49,6 +49,7 @@ model UserSettings {
     enableBookmarkNotifications        Boolean @default(true)
     enableBookmarkVersionNotifications Boolean @default(true)
     enableBookmarkFlagNotifications    Boolean @default(true)
+    enableVersionFlagNotifications     Boolean @default(true)
     user                               User    @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
@@ -616,6 +617,7 @@ enum NotificationActionTypeEnum {
     PUBLICATION_BOOKMARK_RED_FLAG_RAISED
     PUBLICATION_BOOKMARK_RED_FLAG_RESOLVED
     PUBLICATION_BOOKMARK_RED_FLAG_COMMENTED
+    PUBLICATION_VERSION_RED_FLAG_RAISED
 }
 
 enum NotificationStatusEnum {

--- a/api/src/components/flag/controller.ts
+++ b/api/src/components/flag/controller.ts
@@ -162,7 +162,7 @@ export const createFlag = async (
             I.NotificationActionTypeEnum.PUBLICATION_BOOKMARK_RED_FLAG_RAISED,
             latestPublishedVersion,
             {
-                currentUserId: event.user.id,
+                excludeUserId: event.user.id,
                 flagId: flag.id
             }
         );
@@ -281,7 +281,7 @@ export const createFlagComment = async (
             I.NotificationActionTypeEnum.PUBLICATION_BOOKMARK_RED_FLAG_COMMENTED,
             latestPublishedVersion,
             {
-                currentUserId: event.user.id,
+                excludeUserId: event.user.id,
                 flagId: event.pathParameters.id
             }
         );
@@ -363,7 +363,7 @@ export const resolveFlag = async (
             I.NotificationActionTypeEnum.PUBLICATION_BOOKMARK_RED_FLAG_RESOLVED,
             latestPublishedVersion,
             {
-                currentUserId: event.user.id,
+                excludeUserId: event.user.id,
                 flagId: event.pathParameters.id
             }
         );

--- a/api/src/components/notification/bulletin.ts
+++ b/api/src/components/notification/bulletin.ts
@@ -252,13 +252,13 @@ const getUsersToBeNotified = async (
         ).includes(actionType)
     ) {
         usersToBeNotified = await userService.getBookmarkedUsers(publicationVersion.versionOf);
-        
+
         return usersToBeNotified;
     }
 
     if (actionType === I.NotificationActionTypeEnum.PUBLICATION_VERSION_RED_FLAG_RAISED) {
         usersToBeNotified = await userService.getRedFlagUsers(publicationVersion.versionOf);
-        
+
         return usersToBeNotified;
     }
 
@@ -279,7 +279,7 @@ const getPayload = (
     if (actionType === I.NotificationActionTypeEnum.PUBLICATION_BOOKMARK_VERSION_CREATED) {
         payload.title = publicationVersion.title ?? '';
         payload.url = Helpers.getPublicationUrl(publicationVersion.versionOf);
-        
+
         return payload;
     }
 

--- a/api/src/components/publicationVersion/controller.ts
+++ b/api/src/components/publicationVersion/controller.ts
@@ -2,7 +2,7 @@ import * as I from 'interface';
 import * as response from 'lib/response';
 import * as publicationVersionService from 'publicationVersion/service';
 import * as publicationService from 'publication/service';
-import * as notificationService from 'notification/service';
+import * as notificationBulletin from 'notification/bulletin';
 import * as coAuthorService from 'coAuthor/service';
 import * as userService from 'user/service';
 import * as Helpers from 'lib/helpers';
@@ -359,20 +359,15 @@ export const updateStatus = async (
             event.queryStringParameters.ariContactConsent
         );
 
-        // notify all users who bookmarked this publication about the new version
-        const bookmarkedUsers = await userService.getBookmarkedUsers(publicationVersion.versionOf);
+        await notificationBulletin.createBulletin(I.NotificationActionTypeEnum.PUBLICATION_BOOKMARK_VERSION_CREATED, {
+            title: publicationVersion.title || '',
+            versionOf: publicationVersion.versionOf
+        });
 
-        await notificationService.createMany(
-            bookmarkedUsers.map((user) => ({
-                userId: user.id,
-                type: I.NotificationTypeEnum.BULLETIN,
-                actionType: I.NotificationActionTypeEnum.PUBLICATION_BOOKMARK_VERSION_CREATED,
-                payload: {
-                    title: publicationVersion.title || '',
-                    url: Helpers.getPublicationUrl(publicationVersion.versionOf) || ''
-                }
-            }))
-        );
+        await notificationBulletin.createBulletin(I.NotificationActionTypeEnum.PUBLICATION_VERSION_RED_FLAG_RAISED, {
+            title: publicationVersion.title || '',
+            versionOf: publicationVersion.versionOf
+        });
 
         return response.json(200, { message: 'Publication is now LIVE.' });
     } catch (err) {

--- a/api/src/components/user/controller.ts
+++ b/api/src/components/user/controller.ts
@@ -256,7 +256,8 @@ export const getUserSettings = async (
         const settings = (await userService.getUserSettings(event.user.id)) ?? {
             enableBookmarkNotifications: true,
             enableBookmarkVersionNotifications: true,
-            enableBookmarkFlagNotifications: true
+            enableBookmarkFlagNotifications: true,
+            enableVersionFlagNotifications: true
         };
 
         return response.json(200, settings);

--- a/api/src/components/user/schema/updateSettings.ts
+++ b/api/src/components/user/schema/updateSettings.ts
@@ -11,9 +11,17 @@ const updateSettingsSchema: I.JSONSchemaType<I.User['settings']> = {
         },
         enableBookmarkFlagNotifications: {
             type: 'boolean'
+        },
+        enableVersionFlagNotifications: {
+            type: 'boolean'
         }
     },
-    required: ['enableBookmarkNotifications', 'enableBookmarkVersionNotifications', 'enableBookmarkFlagNotifications']
+    required: [
+        'enableBookmarkNotifications',
+        'enableBookmarkVersionNotifications',
+        'enableBookmarkFlagNotifications',
+        'enableVersionFlagNotifications'
+    ]
 };
 
 export default updateSettingsSchema;

--- a/api/src/components/user/service.ts
+++ b/api/src/components/user/service.ts
@@ -177,7 +177,8 @@ export const get = (id: string, isAccountOwner = false) =>
                 select: {
                     enableBookmarkNotifications: true,
                     enableBookmarkVersionNotifications: true,
-                    enableBookmarkFlagNotifications: true
+                    enableBookmarkFlagNotifications: true,
+                    enableVersionFlagNotifications: true
                 }
             },
             lastBulletinSentAt: true
@@ -509,6 +510,22 @@ export const getBookmarkedUsers = async (publicationId: string) => {
     });
 };
 
+export const getRedFlagUsers = async (publicationId: string) => {
+    return client.prisma.user.findMany({
+        where: {
+            PublicationFlags: {
+                some: {
+                    resolved: false,
+                    publicationId
+                }
+            }
+        },
+        select: {
+            id: true
+        }
+    });
+};
+
 export const getUserSettings = async (id: string) =>
     client.prisma.userSettings.findUnique({
         where: {
@@ -516,16 +533,17 @@ export const getUserSettings = async (id: string) =>
         }
     });
 
-export const updateUserSettings = async (id: string, settings: Prisma.UserSettingsUpdateInput) =>
+export const updateUserSettings = async (
+    id: string,
+    settings: Omit<Prisma.UserSettingsCreateManyInput, 'id' | 'userId'>
+) =>
     client.prisma.userSettings.upsert({
         where: {
             userId: id
         },
         update: settings,
         create: {
-            userId: id,
-            enableBookmarkNotifications: !!settings.enableBookmarkNotifications,
-            enableBookmarkVersionNotifications: !!settings.enableBookmarkVersionNotifications,
-            enableBookmarkFlagNotifications: !!settings.enableBookmarkFlagNotifications
+            ...settings,
+            userId: id
         }
     });

--- a/api/src/lib/email.ts
+++ b/api/src/lib/email.ts
@@ -1005,6 +1005,13 @@ const NOTIFICATION_MESSAGES = {
         getLink: (url: string): string => `<a href="${url}">Click here to view the comment</a>`,
         getTextPlain: (title: string, url: string): string =>
             `The publication you have bookmarked, ${title} has had a comment added to a red flag. You can view the comment here: ${url}`
+    },
+    [I.NotificationActionTypeEnum.PUBLICATION_VERSION_RED_FLAG_RAISED]: {
+        getText: (title: string): string =>
+            `The publication you raised a red flag on, <strong>${title}</strong> has had a new version published.`,
+        getLink: (url: string): string => `<a href="${url}">Click here to view the new version</a>`,
+        getTextPlain: (title: string, url: string): string =>
+            `The publication you raised a red flag on, ${title} has had a new version published. You can view the new version here: ${url}`
     }
 };
 

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -319,6 +319,7 @@ export interface User {
         enableBookmarkNotifications: boolean;
         enableBookmarkVersionNotifications: boolean;
         enableBookmarkFlagNotifications: boolean;
+        enableVersionFlagNotifications: boolean;
     } | null;
     lastBulletinSentAt?: Date | null;
 }

--- a/ui/src/lib/interfaces.ts
+++ b/ui/src/lib/interfaces.ts
@@ -230,6 +230,7 @@ export interface UserSettings {
     enableBookmarkNotifications: boolean;
     enableBookmarkVersionNotifications: boolean;
     enableBookmarkFlagNotifications: boolean;
+    enableVersionFlagNotifications: boolean;
 }
 
 export interface SearchResults<T extends FlagByUser | Publication | PublicationVersion | PublicationBundle | User> {

--- a/ui/src/pages/notifications.tsx
+++ b/ui/src/pages/notifications.tsx
@@ -107,13 +107,22 @@ const Notifications: Types.NextPage<Props> = (props): React.ReactElement => {
         setLoading(false);
     };
 
+    const changeVersionFlagNotifications = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const checked = e.target.checked;
+        const updatedSettings = {
+            ...userSettings,
+            enableVersionFlagNotifications: checked
+        };
+    };
+
     const changeBookmarkNotifications = async (e: React.ChangeEvent<HTMLInputElement>) => {
         const checked = e.target.checked;
         const updatedSettings = {
             ...userSettings,
             enableBookmarkVersionNotifications: checked,
             enableBookmarkFlagNotifications: checked,
-            enableBookmarkNotifications: checked
+            enableBookmarkNotifications: checked,
+            enableVersionFlagNotifications: checked
         };
         updateBookmarkNotificationsSettings(updatedSettings);
     };
@@ -188,6 +197,15 @@ const Notifications: Types.NextPage<Props> = (props): React.ReactElement => {
                             checked={userSettings.enableBookmarkFlagNotifications}
                             label="Receive notifications about red flags on bookmarked publications"
                             className={`mt-4 ml-8 w-fit ${loading ? 'cursor-wait' : ''}`}
+                        />
+                        <Components.Checkbox
+                            disabled={loading}
+                            id="version-flag-notifications"
+                            name="version-flag-notifications"
+                            onChange={changeVersionFlagNotifications}
+                            checked={userSettings.enableVersionFlagNotifications}
+                            label="Enable notifications about publications I have red flagged"
+                            className={`mt-4 font-semibold w-fit ${loading ? 'cursor-wait' : ''}`}
                         />
                     </fieldset>
                 </section>


### PR DESCRIPTION
The purpose of this PR was to add support for notifying all red flaggers when a new version is released.

---

### Acceptance Criteria:
- When a new version is published, an email notification is sent to all users who have raised an outstanding red flag against the publication.
- A top-level (not under the bookmarks section) checkbox is present on the /notifications page reading “Enable notifications about publications I have red flagged.

---

### TODO:
- [ ] add tests
- [ ] find a way to get only flags opened on the previous publication version, not all versions

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:
- TODO
---

### Screenshots:
- TODO