### PR TITLE
OC-483: Notifying peer reviewers of new versions

### DIFF
--- a/api/prisma/migrations/20250804101645_notification_bulletin_publication_peer_reviewed/migration.sql
+++ b/api/prisma/migrations/20250804101645_notification_bulletin_publication_peer_reviewed/migration.sql
@@ -1,0 +1,5 @@
+-- AlterEnum
+ALTER TYPE "NotificationActionTypeEnum" ADD VALUE 'PUBLICATION_VERSION_PEER_REVIEWED';
+
+-- AlterTable
+ALTER TABLE "UserSettings" ADD COLUMN     "enablePeerReviewNotifications" BOOLEAN NOT NULL DEFAULT true;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -50,6 +50,7 @@ model UserSettings {
     enableBookmarkVersionNotifications Boolean @default(true)
     enableBookmarkFlagNotifications    Boolean @default(true)
     enableVersionFlagNotifications     Boolean @default(true)
+    enablePeerReviewNotifications      Boolean @default(true)
     user                               User    @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
@@ -618,6 +619,7 @@ enum NotificationActionTypeEnum {
     PUBLICATION_BOOKMARK_RED_FLAG_RESOLVED
     PUBLICATION_BOOKMARK_RED_FLAG_COMMENTED
     PUBLICATION_VERSION_RED_FLAG_RAISED
+    PUBLICATION_VERSION_PEER_REVIEWED
 }
 
 enum NotificationStatusEnum {

--- a/api/src/components/publicationVersion/controller.ts
+++ b/api/src/components/publicationVersion/controller.ts
@@ -359,15 +359,25 @@ export const updateStatus = async (
             event.queryStringParameters.ariContactConsent
         );
 
-        await notificationBulletin.createBulletin(I.NotificationActionTypeEnum.PUBLICATION_BOOKMARK_VERSION_CREATED, {
-            title: publicationVersion.title || '',
-            versionOf: publicationVersion.versionOf
-        });
+        await Promise.all([
+            // Notify all users that bookmarked this publication version that a new version is now LIVE.
+            notificationBulletin.createBulletin(I.NotificationActionTypeEnum.PUBLICATION_BOOKMARK_VERSION_CREATED, {
+                title: publicationVersion.title || '',
+                versionOf: publicationVersion.versionOf
+            }),
 
-        await notificationBulletin.createBulletin(I.NotificationActionTypeEnum.PUBLICATION_VERSION_RED_FLAG_RAISED, {
-            title: publicationVersion.title || '',
-            versionOf: publicationVersion.versionOf
-        });
+            // Notify all users that red-flagged this publication version that a new version is now LIVE.
+            notificationBulletin.createBulletin(I.NotificationActionTypeEnum.PUBLICATION_VERSION_RED_FLAG_RAISED, {
+                title: publicationVersion.title || '',
+                versionOf: publicationVersion.versionOf
+            }),
+
+            // Notify all users that peer-reviewed this publication version that a new version is now LIVE.
+            notificationBulletin.createBulletin(I.NotificationActionTypeEnum.PUBLICATION_VERSION_PEER_REVIEWED, {
+                title: publicationVersion.title || '',
+                versionOf: publicationVersion.versionOf
+            })
+        ]);
 
         return response.json(200, { message: 'Publication is now LIVE.' });
     } catch (err) {

--- a/api/src/components/user/controller.ts
+++ b/api/src/components/user/controller.ts
@@ -257,7 +257,8 @@ export const getUserSettings = async (
             enableBookmarkNotifications: true,
             enableBookmarkVersionNotifications: true,
             enableBookmarkFlagNotifications: true,
-            enableVersionFlagNotifications: true
+            enableVersionFlagNotifications: true,
+            enablePeerReviewNotifications: true
         };
 
         return response.json(200, settings);

--- a/api/src/components/user/schema/updateSettings.ts
+++ b/api/src/components/user/schema/updateSettings.ts
@@ -14,13 +14,17 @@ const updateSettingsSchema: I.JSONSchemaType<I.User['settings']> = {
         },
         enableVersionFlagNotifications: {
             type: 'boolean'
+        },
+        enablePeerReviewNotifications: {
+            type: 'boolean'
         }
     },
     required: [
         'enableBookmarkNotifications',
         'enableBookmarkVersionNotifications',
         'enableBookmarkFlagNotifications',
-        'enableVersionFlagNotifications'
+        'enableVersionFlagNotifications',
+        'enablePeerReviewNotifications'
     ]
 };
 

--- a/api/src/components/user/service.ts
+++ b/api/src/components/user/service.ts
@@ -178,7 +178,8 @@ export const get = (id: string, isAccountOwner = false) =>
                     enableBookmarkNotifications: true,
                     enableBookmarkVersionNotifications: true,
                     enableBookmarkFlagNotifications: true,
-                    enableVersionFlagNotifications: true
+                    enableVersionFlagNotifications: true,
+                    enablePeerReviewNotifications: true
                 }
             },
             lastBulletinSentAt: true
@@ -540,6 +541,34 @@ export const getUsersWithOutstandingFlagsBeforeDate = async (
     });
 
     return usersWithRecentFlags;
+};
+
+export const getUsersWithPeerReviewsBeforeDate = async (publicationId: string, previousPublishedVersionDate: Date) => {
+    const usersWithPeerReviews = await client.prisma.user.findMany({
+        where: {
+            publicationVersions: {
+                some: {
+                    isLatestLiveVersion: true,
+                    publishedDate: {
+                        gte: previousPublishedVersionDate
+                    },
+                    publication: {
+                        type: 'PEER_REVIEW',
+                        linkedTo: {
+                            some: {
+                                publicationToId: publicationId
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        select: {
+            id: true
+        }
+    });
+
+    return usersWithPeerReviews;
 };
 
 export const getUserSettings = async (id: string) =>

--- a/api/src/lib/email.ts
+++ b/api/src/lib/email.ts
@@ -1012,6 +1012,13 @@ const NOTIFICATION_MESSAGES = {
         getLink: (url: string): string => `<a href="${url}">Click here to view the new version</a>`,
         getTextPlain: (title: string, url: string): string =>
             `The publication you raised a red flag on, ${title} has had a new version published. You can view the new version here: ${url}`
+    },
+    [I.NotificationActionTypeEnum.PUBLICATION_VERSION_PEER_REVIEWED]: {
+        getText: (title: string): string =>
+            `The publication you peer reviewed, <strong>${title}</strong> has had a new version published.`,
+        getLink: (url: string): string => `<a href="${url}">Click here to view the new version</a>`,
+        getTextPlain: (title: string, url: string): string =>
+            `The publication you peer reviewed, ${title} has had a new version published. You can view the new version here: ${url}`
     }
 };
 

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -320,6 +320,7 @@ export interface User {
         enableBookmarkVersionNotifications: boolean;
         enableBookmarkFlagNotifications: boolean;
         enableVersionFlagNotifications: boolean;
+        enablePeerReviewNotifications: boolean;
     } | null;
     lastBulletinSentAt?: Date | null;
 }

--- a/ui/src/lib/interfaces.ts
+++ b/ui/src/lib/interfaces.ts
@@ -231,6 +231,7 @@ export interface UserSettings {
     enableBookmarkVersionNotifications: boolean;
     enableBookmarkFlagNotifications: boolean;
     enableVersionFlagNotifications: boolean;
+    enablePeerReviewNotifications: boolean;
 }
 
 export interface SearchResults<T extends FlagByUser | Publication | PublicationVersion | PublicationBundle | User> {

--- a/ui/src/pages/notifications.tsx
+++ b/ui/src/pages/notifications.tsx
@@ -107,6 +107,14 @@ const Notifications: Types.NextPage<Props> = (props): React.ReactElement => {
         setLoading(false);
     };
 
+    const changePeerReviewNotifications = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const checked = e.target.checked;
+        const updatedSettings = {
+            ...userSettings,
+            enablePeerReviewNotifications: checked
+        };
+    };
+
     const changeVersionFlagNotifications = async (e: React.ChangeEvent<HTMLInputElement>) => {
         const checked = e.target.checked;
         const updatedSettings = {
@@ -205,6 +213,15 @@ const Notifications: Types.NextPage<Props> = (props): React.ReactElement => {
                             onChange={changeVersionFlagNotifications}
                             checked={userSettings.enableVersionFlagNotifications}
                             label="Enable notifications about publications I have red flagged"
+                            className={`mt-4 font-semibold w-fit ${loading ? 'cursor-wait' : ''}`}
+                        />
+                        <Components.Checkbox
+                            disabled={loading}
+                            id="version-peer-review-notifications"
+                            name="version-peer-review-notifications"
+                            onChange={changePeerReviewNotifications}
+                            checked={userSettings.enablePeerReviewNotifications}
+                            label="Enable notifications about publications I have peer reviewed"
                             className={`mt-4 font-semibold w-fit ${loading ? 'cursor-wait' : ''}`}
                         />
                     </fieldset>


### PR DESCRIPTION
This PR must be merged after https://github.com/JiscSD/octopus/pull/840

> [!IMPORTANT]  
> ~~Change the base from OC-484 to main before merging it in~~ DONE

---

The purpose of this PR was to add bulletin notifications for users who has conducted a peer review of a publication. This way they can see if any of the points raised are addressed, and to see if I they should conduct another peer review.

---

### Acceptance Criteria:
- When a new version is published, an email notification is sent to all users who have conducted a peer review of the publication’s previous version. If the peer review was of an older version, the notification is not sent. For example, if v1 was peer reviewed, and v3 has just been published, the notification is not sent.
- A top-level (not under the bookmarks section) checkbox is present on the /notifications page reading “Enable notifications about publications I have peer reviewed. This checkbox enables/disables whether the user receives notifications about new versions of publications they have peer reviewed
---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Screenshots:

<img width="1820" height="1119" alt="Screenshot 2025-08-04 at 15 23 39" src="https://github.com/user-attachments/assets/e9bbe3d0-0ddd-47ca-bfe0-6b8a2954767f" />

