### PR TITLE
OC-1107: Add logging for nodemailer errors

### DIFF
--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -269,3 +269,15 @@ export const checkBooleanArgValue = (arg: string): void => {
         throw new Error(`"${arg}" must be "true" or "false"`);
     }
 };
+
+export function obfuscateEmail(email: string): string {
+    try {
+        const [name, domain] = email.split('@');
+
+        return `${name.substring(0, 3)}*****@${domain}`;
+    } catch (error) {
+        console.error('Error obfuscating email:', error);
+
+        return email;
+    }
+}


### PR DESCRIPTION
The purpose of this PR was to add logging on the nodemailer reponse. We have had several reports of emails intermittently failing to be received. Logging should be added to help us identify the cause behind these failures.

---

### Acceptance Criteria:
- Errors returned in nodemailer results are logged 
---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

---

### Screenshots:
