### PR TITLE
OC-1112: Rename Results & Real World Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,10 @@ There are eight publication types:
 - **Research Problem** - a neatly defined scientific problem.
 - **Rationale/Hypothesis** - an original hypothesis relating to an existing published Problem or the rationale for how you think the Problem could be addressed.
 - **Method** - a practical method of testing an existing published Rationale/Hypothesis.
-- **Results** - raw data or summarised results collected according to an existing published Method (can be linked to a data repository).
+- **Results/Sources** - raw data or summarised results collected according to an existing published Method (can be linked to a data repository).
 - **Analysis** - a statistical or thematic analysis of existing published Results.
 - **Interpretation** - a discussion around an existing published Analysis.
-- **Real World Application** - real world applications arising from an existing published Interpretation.
+- **Applications/Implications** - real world applications arising from an existing published Interpretation.
 - **Peer Review** - A considered, detailed review of any of the above kinds of publication.
 
 ### Links

--- a/api/docs/api.yml
+++ b/api/docs/api.yml
@@ -1605,7 +1605,11 @@ components:
         - PROBLEM = Research Problem
         - HYPOTHESIS = Rationale / Hypothesis
         - PROTOCOL = Method
-        - DATA = Results
+        - DATA = Results / Sources of Evidence
+        - ANALYSIS = Analysis
+        - INTERPRETATION = Interpretation
+        - REAL_WORLD_APPLICATION = Applications / Implications
+        - PEER_REVIEW = Peer Review
     PublicationUrlSlug:
       type: string
       description: Unused legacy field.

--- a/api/src/lib/helpers.ts
+++ b/api/src/lib/helpers.ts
@@ -19,15 +19,15 @@ export function sanitizeSearchQuery(searchQuery: string): string {
 /**
  * @description Format a publication type returned from the DB
  */
-export const formatPublicationType = (publicationType: I.PublicationType): string => {
+export const formatPublicationType = (publicationType: I.PublicationType, detailed = false): string => {
     const types = {
         PROBLEM: 'Research Problem',
         HYPOTHESIS: 'Rationale / Hypothesis',
         PROTOCOL: 'Method',
-        DATA: 'Results',
+        DATA: detailed ? 'Results / Sources of Evidence' : 'Results / Sources',
         ANALYSIS: 'Analysis',
         INTERPRETATION: 'Interpretation',
-        REAL_WORLD_APPLICATION: 'Real World Application',
+        REAL_WORLD_APPLICATION: 'Applications / Implications',
         PEER_REVIEW: 'Peer Review'
     };
 

--- a/e2e/tests/LoggedIn/publish.e2e.spec.ts
+++ b/e2e/tests/LoggedIn/publish.e2e.spec.ts
@@ -125,7 +125,7 @@ const methodPublication: PublicationTestType = {
 };
 
 const resultsPublication: PublicationTestType = {
-    pubType: 'Results',
+    pubType: 'Results / Sources',
     title: 'test title',
     author: Helpers.users.user1.fullName,
     text: 'main text',
@@ -151,7 +151,7 @@ const interpretationPublication: PublicationTestType = {
 };
 
 const realWorldApplicationPublication: PublicationTestType = {
-    pubType: 'Real World Application',
+    pubType: 'Applications / Implications',
     title: 'test title',
     author: Helpers.users.user1.fullName,
     text: 'main text'
@@ -398,8 +398,8 @@ test.describe('Publication flow', () => {
         await checkPublication(page, interpretationPublication, [Helpers.users.user1]);
     });
 
-    // Real world applications have no unique fields. Just test that we can make one successfully.
-    test('Create a real world application (standard publication)', async ({ browser }) => {
+    //  Applications/implications have no unique fields. Just test that we can make one successfully.
+    test('Create an application/implication (standard publication)', async ({ browser }) => {
         const page = await Helpers.users.getPageAsUser(browser);
         await Helpers.publicationCreation.createPublication(page, 'test title', 'REAL_WORLD_APPLICATION');
         await Helpers.publicationCreation.completeKeyInformationTab(page);

--- a/e2e/tests/LoggedOut/search.e2e.spec.ts
+++ b/e2e/tests/LoggedOut/search.e2e.spec.ts
@@ -48,7 +48,7 @@ test.describe('Publication search', () => {
                 response.url().includes('/publication-versions?limit=10&offset=0&authorType=individual') &&
                 response.ok()
         );
-        await page.getByRole('checkbox', { name: 'Results' }).click();
+        await page.getByRole('checkbox', { name: 'Results / Sources' }).click();
         await page.waitForResponse(
             (response) =>
                 response.url().includes('/publication-versions?type=DATA&limit=10&offset=0&authorType=individual') &&

--- a/e2e/tests/PageModel.ts
+++ b/e2e/tests/PageModel.ts
@@ -54,12 +54,12 @@ export const PageModel = {
         video: 'video',
         pubTypes: [
             'h3:text("Research Problem")',
-            'h3:text("Rationale/Hypothesis")',
+            'h3:text("Rationale / Hypothesis")',
             'h3:text("Methods")',
-            'h3:text("Results")',
+            'h3:text("Results / Sources")',
             'h3:text("Analysis")',
             'h3:text("Interpretation")',
-            'h3:text("Real World Application")'
+            'h3:text("Applications / Implications")',
         ]
     },
     browse: {

--- a/ui/src/components/Publication/Creation/LinkedItems/index.tsx
+++ b/ui/src/components/Publication/Creation/LinkedItems/index.tsx
@@ -204,16 +204,16 @@ const Links: React.FC = (): React.ReactElement => {
                 />
                 <p className={`mb-6 ${paragraphClasses}`}>
                     All publications in Octopus are linked to each other to form research chains, branching down from
-                    research problems to real world implementations.{' '}
+                    research problems to applications/implications.{' '}
                     {isProblem &&
                         ' For research problems, if there is no existing publication on the system that yours relates to, you can link to a research topic instead.'}
                 </p>
 
                 <p className={`mb-6 ${paragraphClasses}`}>
-                    Your {Helpers.formatPublicationType(type)} must be linked from at least one other{' '}
-                    {linkableEntityLabel} on Octopus. {Helpers.formatPublicationType(type)} can be linked from{' '}
+                    Your {Helpers.formatPublicationType(type, true)} must be linked from at least one other{' '}
+                    {linkableEntityLabel} on Octopus. {Helpers.formatPublicationType(type, true)} can be linked from{' '}
                     {linkablePublicationTypes.map((type, index) => {
-                        return `${Helpers.formatPublicationType(type)}${
+                        return `${Helpers.formatPublicationType(type, true)}${
                             index !== linkablePublicationTypes.length - 1
                                 ? ', '
                                 : isProblem

--- a/ui/src/components/Publication/SimpleResult/index.tsx
+++ b/ui/src/components/Publication/SimpleResult/index.tsx
@@ -76,7 +76,7 @@ const SimpleResult: React.FC<Props> = (props): React.ReactElement => {
         >
             <div className="flex flex-grow basis-1/5 flex-col sm:pr-5">
                 <p className="pb-5 font-bold text-pink-500 dark:text-pink-300">
-                    {Helpers.formatPublicationType(props.publication.type)}
+                    {Helpers.formatPublicationType(props.publication.type, true)}
                 </p>
                 <p className="flex-1 flex-grow pb-5 font-montserrat text-grey-800 transition-colors duration-500 dark:text-white-50">
                     {latestLiveVersion ? latestLiveVersion.title : latestVersion?.title}

--- a/ui/src/components/Publication/Visualization/index.tsx
+++ b/ui/src/components/Publication/Visualization/index.tsx
@@ -168,7 +168,7 @@ const Visualization: React.FC<VisualizationProps> = (props): React.ReactElement 
     return (
         <section className="container mb-8 px-8 pt-8 lg:pt-16">
             <div className="overflow-hidden" ref={visualizationHeaderRef}>
-                <div className="grid min-w-[1000px] grid-cols-7 gap-[2%]">
+                <div className="grid min-w-[1000px] grid-cols-7 gap-[2%] 3xl:gap-[1.75%]">
                     {filteredPublicationTypes.map((type) => (
                         <div key={type}>
                             <span className="block h-12 p-2 font-montserrat text-xs font-semibold text-grey-800 transition-colors duration-500 dark:text-white-50 xl:h-14 xl:text-sm 2xl:h-auto">
@@ -183,7 +183,7 @@ const Visualization: React.FC<VisualizationProps> = (props): React.ReactElement 
                     className="sm:scrollbar min-h-[16rem] overflow-x-auto overflow-y-hidden"
                     ref={visualizationWrapperRef}
                 >
-                    <div className="grid min-w-[1000px] grid-cols-7 gap-[2%]">
+                    <div className="grid min-w-[1000px] grid-cols-7 gap-[2%] 3xl:gap-[1.75%]">
                         {data && (
                             <Xwrapper>
                                 {filteredPublicationTypes.map((type) => (

--- a/ui/src/components/VisualPublicationFlow/index.tsx
+++ b/ui/src/components/VisualPublicationFlow/index.tsx
@@ -80,8 +80,8 @@ const VisualPublicationFlow: React.FC = (): React.ReactElement => (
         />
         <GridItem
             className="row-start-4 row-end-4 lg:col-start-2 lg:col-end-2"
-            title="Results"
-            content="Raw data or summarised results collected according to an existing published Method (can be linked to a data repository)."
+            title="Results / Sources"
+            content="Results can be raw data or summarised results collected according to an existing published Method (can be linked to a data repository). Sources refers to any existing evidence or material that are the object(s) of study for the research."
             icon={<OutlineIcons.LinkIcon className="h-5 w-5 text-white-50" />}
             position="LEFT"
         />
@@ -101,8 +101,8 @@ const VisualPublicationFlow: React.FC = (): React.ReactElement => (
         />
         <GridItem
             className="row-start-7 row-end-7 lg:col-start-1 lg:col-end-2"
-            title="Real World Application"
-            content="Real World Applications arising from an existing published Interpretation."
+            title="Applications / Implications"
+            content="Applications or implications arising from an existing published Interpretation."
             icon={<OutlineIcons.LinkIcon className="h-5 w-5 text-white-50" />}
             position="RIGHT"
         />

--- a/ui/src/components/VisualPublicationFlow/index.tsx
+++ b/ui/src/components/VisualPublicationFlow/index.tsx
@@ -66,7 +66,7 @@ const VisualPublicationFlow: React.FC = (): React.ReactElement => (
         />
         <GridItem
             className="row-start-2 row-end-2 lg:col-start-2 lg:col-end-2"
-            title="Rationale/Hypothesis"
+            title="Rationale / Hypothesis"
             content="An original hypothesis relating to an existing published Research Problem or the rationale for how you think the Research Problem could be addressed."
             icon={<OutlineIcons.LinkIcon className="h-5 w-5 text-white-50" />}
             position="LEFT"

--- a/ui/src/config/values.ts
+++ b/ui/src/config/values.ts
@@ -39,11 +39,11 @@ export const octopusInformation: Interfaces.OctopusInformation = {
         },
         DATA: {
             id: 'DATA',
-            label: 'Results',
+            label: 'Results/Sources of Evidence',
             inlineDescription:
-                'Raw data or summarised results collected according to an existing published Method (can be linked to a data repository).',
+                'Results can be raw data or summarised results collected according to an existing published Method (can be linked to a data repository). Sources refers to any existing evidence or material that are the object(s) of study for the research.',
             faqDescription:
-                'A &apos;results&apos; publication comprises raw data or summarised results collected according to an existing published &apos;method&apos;. It should describe the data or results themselves, without any analysis. It should provide details of the exact conditions under which the method was carried out and anything needed for an analysis or interpretation of the results. You can include links to the raw data files if they are in a specialist repository. Octopus is not a data repository itself.'
+                'A &apos;Results/Sources&apos; publication can be either the raw data or summarised results collected according to an existing published &apos;method&apos;, or any existing evidence or material that form the object(s) of study for the research. It should describe the data, sources or results themselves, without any analysis. For results, it should provide details of the exact conditions under which the method was carried out and anything needed for an analysis or interpretation of the results. You can include links to the raw data files if they are in a specialist repository. Octopus is not a data repository itself.'
         },
         ANALYSIS: {
             id: 'ANALYSIS',
@@ -61,10 +61,10 @@ export const octopusInformation: Interfaces.OctopusInformation = {
         },
         REAL_WORLD_APPLICATION: {
             id: 'REAL_WORLD_APPLICATION',
-            label: 'Real World Application',
-            inlineDescription: 'Real World Applications arising from an existing published Interpretation.',
+            label: 'Applications/Implications',
+            inlineDescription: 'Applications or implications arising from an existing published Interpretation.',
             faqDescription:
-                'A &apos;real world application&apos; publication describes how findings might have (or have had) an impact in the real world. This might be through a practical or policy application, and would be the appropriate publication type for case studies.'
+                'An &apos;Applications/Implications&apos; publication describes how findings might have (or have had) an impact in the real world or for others in the field of study. This might be through a practical or policy application, and would be the appropriate publication type for case studies.'
         },
         PEER_REVIEW: {
             id: 'PEER_REVIEW',

--- a/ui/src/layouts/BuildPublication.tsx
+++ b/ui/src/layouts/BuildPublication.tsx
@@ -700,7 +700,7 @@ const BuildPublication: React.FC<BuildPublicationProps> = (props) => {
                     <div className="mb-12 flex flex-wrap items-center justify-between gap-8">
                         <span className="block font-montserrat text-lg font-semibold text-teal-600 transition-colors duration-500 dark:text-teal-400">
                             {store.publicationVersion &&
-                                Helpers.formatPublicationType(store.publicationVersion.publication.type)}
+                                Helpers.formatPublicationType(store.publicationVersion.publication.type, true)}
                         </span>
                         <div aria-live="polite" className="sr-only">
                             {navigationAnnouncement}

--- a/ui/src/lib/helpers.tsx
+++ b/ui/src/lib/helpers.tsx
@@ -56,15 +56,15 @@ export const formatDateTime = (value: string, formatType?: 'short' | 'long'): st
 /**
  * @description Format a publication type returned from the DB
  */
-export const formatPublicationType = (publicationType: Types.PublicationType): string => {
+export const formatPublicationType = (publicationType: Types.PublicationType, detailed = false): string => {
     const types = {
         PROBLEM: 'Research Problem',
         HYPOTHESIS: 'Rationale / Hypothesis',
         PROTOCOL: 'Method',
-        DATA: 'Results',
+        DATA: detailed ? 'Results / Sources of Evidence' : 'Results / Sources',
         ANALYSIS: 'Analysis',
         INTERPRETATION: 'Interpretation',
-        REAL_WORLD_APPLICATION: 'Real World Application',
+        REAL_WORLD_APPLICATION: 'Applications / Implications',
         PEER_REVIEW: 'Peer Review'
     };
 

--- a/ui/src/pages/create.tsx
+++ b/ui/src/pages/create.tsx
@@ -154,7 +154,7 @@ const Create: Types.NextPage<PageProps> = (props): React.ReactElement => {
                         <SupportText>
                             Octopus has 8 publication types which closely align with the research process and move away
                             from the traditional research paper. These are linked to form a research chain, from initial
-                            Research Problem to Real World Application. You will no longer need to structure your
+                            Research Problem to Applications/Implications. You will no longer need to structure your
                             publications like a paper, with an abstract and introduction, as the publication chain
                             itself serves this role. You will be asked to write a very short description to aid
                             discovery.{' '}
@@ -180,12 +180,12 @@ const Create: Types.NextPage<PageProps> = (props): React.ReactElement => {
                         >
                             {props.publicationType ? (
                                 <option key={props.publicationType} value={props.publicationType}>
-                                    {Helpers.formatPublicationType(props.publicationType)}
+                                    {Helpers.formatPublicationType(props.publicationType, true)}
                                 </option>
                             ) : (
                                 Config.values.publicationTypes.map((type) => (
                                     <option key={type} value={type}>
-                                        {Helpers.formatPublicationType(type)}
+                                        {Helpers.formatPublicationType(type, true)}
                                     </option>
                                 ))
                             )}

--- a/ui/src/pages/octopus-aims.tsx
+++ b/ui/src/pages/octopus-aims.tsx
@@ -94,7 +94,7 @@ const AimsData: JumpTo[] = [
                 }
             },
             {
-                header: 'Real World Applications',
+                header: 'Applications/Implications',
                 content: {
                     problem:
                         'There is a lack of emphasis on real-world implementation and publication of specific case studies in the current publication process, as these are not deemed &apos;high impact&apos;.',

--- a/ui/src/pages/user-terms.tsx
+++ b/ui/src/pages/user-terms.tsx
@@ -1032,10 +1032,10 @@ const UserTerms: NextPage = (): React.ReactElement => (
                                 <li className="mb-2">Research Problem</li>
                                 <li className="mb-2">Rationale/Hypothesis</li>
                                 <li className="mb-2">Method</li>
-                                <li className="mb-2">Results</li>
+                                <li className="mb-2">Results/Sources</li>
                                 <li className="mb-2">Analysis</li>
                                 <li className="mb-2">Interpretation</li>
-                                <li className="mb-2">Real World Application</li>
+                                <li className="mb-2">Applications/Implications</li>
                                 <li className="mb-2">Peer Review</li>
                             </ul>
                             <span className="font-bold">The nature and purpose of the Processing</span>


### PR DESCRIPTION
The purpose of this PR was to make sure that **"Results"** should is renamed to **“Results/Sources”** and **“Real World Applications”** is renamed to **“Applications/Implications”.** In some areas, where additional explanation is needed, **“Results/Sources”** should be **“Results/Sources of evidence”** to provide further clarity

---

### Acceptance Criteria:
- “Results” is renamed to “Results/Sources” and “Real World Application” is renamed to “Applications/Implications” in the following places:
  - The publication page (inc. for previews/ co-author approvals of drafts)
  - The publication search page (inc. tiles and filters)
  - The browse page
  - Public author page
  - Notifications page
- “Results” is renamed to “Results/Sources of evidence” and “Real World Application” is renamed to “Applications/Implications” in the following places:
  - /create page publication selection dropdown
  - Publication edit page
  - The account page publications list
- Intro text is updated in "Linked items"
- Definition is updated in "/create"
- Text is updated in "/about"
- Text is updated in "/faq"
- Text is updated in "Author guide"

Other places:
- E-mail template (A researcher is working on one of your Areas of Research Interest)
- PDF generation
- E2E tests
- Swagger docs
- Project docs


---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [x] Documentation updated
