### PR TITLE
OC-485 - Feedback

### DIFF
--- a/api/serverless-config-default.yml
+++ b/api/serverless-config-default.yml
@@ -362,12 +362,21 @@ functions:
     sendBulletinNotifications:
         handler: dist/src/components/notification/routes.sendBulletin
         events:
-            - schedule: cron(0 10 ? * MON *) # Every Monday at 10
             - http:
                 path: ${self:custom.versions.v1}/notifications/bulletin
                 method: POST
                 cors: true
-            
+    sendBulletinNotificationsCron:
+        handler: dist/src/components/notification/routes.sendBulletinCron
+        events:
+            - schedule: cron(0 10 ? * MON *) # Every Monday at 10
+    clearFailedNotifications:
+        handler: dist/src/components/notification/routes.clearFailed
+        events:
+            - http:
+                path: ${self:custom.versions.v1}/notifications/clearFailed
+                method: POST
+                cors: true
     # Verification
     requestVerification:
         handler: dist/src/components/verification/routes.requestCode

--- a/api/src/components/notification/controller.ts
+++ b/api/src/components/notification/controller.ts
@@ -1,10 +1,7 @@
 import * as I from 'interface';
-import * as Helpers from 'lib/helpers';
 import * as response from 'lib/response';
 import * as bulletinNotification from 'notification/bulletin';
 import * as notificationService from 'notification/service';
-
-const triggerScriptApiKey = Helpers.checkEnvVariable('TRIGGER_SCRIPT_API_KEY');
 
 export const create = async (data: {
     userId: string;
@@ -47,17 +44,9 @@ export const sendByType = async (
 };
 
 export const sendBulletin = async (
-    event: I.APIRequest<undefined, { force: string; apiKey: string }>
+    event: I.APIRequest<undefined, I.TriggerNotificationsQueryParams>
 ): Promise<I.JSONResponse> => {
-    // TODO:
-    // This is a temporary endpoint for sending bulletin notifications so that we can test it without waiting for the next scheduled run.
-    // This endpoint has to be triggered by the cron job only
-    const force = event.queryStringParameters?.force === 'true';
-    const apiKey = event.queryStringParameters?.apiKey;
-
-    if (triggerScriptApiKey && apiKey !== triggerScriptApiKey) {
-        return response.json(403, { message: 'Forbidden: Invalid API key.' });
-    }
+    const force = event.queryStringParameters?.force === true;
 
     try {
         const result = await sendByType(I.NotificationTypeEnum.BULLETIN, force);
@@ -72,6 +61,24 @@ export const sendBulletin = async (
 
         return response.json(500, {
             message: 'Failed to send bulletin notifications.',
+            error: error instanceof Error ? error.message : 'Unknown error'
+        });
+    }
+};
+
+export const clearFailedNotifications = async (): Promise<I.JSONResponse> => {
+    try {
+        const result = await notificationService.clearFailedNotifications();
+
+        return response.json(200, {
+            message: 'Failed notifications cleared successfully.',
+            data: result
+        });
+    } catch (error) {
+        console.error('Error clearing failed notifications:', error);
+
+        return response.json(500, {
+            message: 'Failed to clear failed notifications.',
             error: error instanceof Error ? error.message : 'Unknown error'
         });
     }

--- a/api/src/components/notification/routes.ts
+++ b/api/src/components/notification/routes.ts
@@ -1,4 +1,26 @@
+import middy from '@middy/core';
+import * as Helpers from 'lib/helpers';
+import * as middleware from 'middleware';
 import * as notificationController from 'notification/controller';
+import * as notificationSchema from 'notification/schema';
 
-export const getAll = notificationController.getAll;
-export const sendBulletin = notificationController.sendBulletin;
+const triggerScriptApiKey = Helpers.checkEnvVariable('TRIGGER_SCRIPT_API_KEY');
+
+export const getAll = middy(notificationController.getAll)
+    .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))
+    .use(middleware.authentication(false, false, triggerScriptApiKey))
+    .use(middleware.validator(notificationSchema.getAllNotifications, 'queryStringParameters'));
+
+export const sendBulletin = middy(notificationController.sendBulletin)
+    .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))
+    .use(middleware.authentication(false, false, triggerScriptApiKey))
+    .use(middleware.validator(notificationSchema.sendAllNotifications, 'queryStringParameters'));
+
+export const clearFailed = middy(notificationController.clearFailedNotifications)
+    .use(middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true }))
+    .use(middleware.authentication(false, false, triggerScriptApiKey))
+    .use(middleware.validator(notificationSchema.clearFailedNotifications, 'queryStringParameters'));
+
+export const sendBulletinCron = middy(notificationController.sendBulletin).use(
+    middleware.doNotWaitForEmptyEventLoop({ runOnError: true, runOnBefore: true, runOnAfter: true })
+);

--- a/api/src/components/notification/schema/clearFailedNotifications.ts
+++ b/api/src/components/notification/schema/clearFailedNotifications.ts
@@ -1,0 +1,18 @@
+import * as I from 'interface';
+
+const clearFailedNotifications: I.JSONSchemaType<I.TriggerNotificationsQueryParams> = {
+    type: 'object',
+    properties: {
+        apiKey: {
+            type: 'string'
+        },
+        force: {
+            type: 'boolean',
+            nullable: true
+        }
+    },
+    additionalProperties: false,
+    required: ['apiKey']
+};
+
+export default clearFailedNotifications;

--- a/api/src/components/notification/schema/getAllNotifications.ts
+++ b/api/src/components/notification/schema/getAllNotifications.ts
@@ -1,0 +1,18 @@
+import * as I from 'interface';
+
+const getAllNotifications: I.JSONSchemaType<I.TriggerNotificationsQueryParams> = {
+    type: 'object',
+    properties: {
+        apiKey: {
+            type: 'string'
+        },
+        force: {
+            type: 'boolean',
+            nullable: true
+        }
+    },
+    additionalProperties: false,
+    required: ['apiKey']
+};
+
+export default getAllNotifications;

--- a/api/src/components/notification/schema/index.ts
+++ b/api/src/components/notification/schema/index.ts
@@ -1,0 +1,3 @@
+export { default as getAllNotifications } from './getAllNotifications';
+export { default as sendAllNotifications } from './sendAllNotifications';
+export { default as clearFailedNotifications } from './clearFailedNotifications';

--- a/api/src/components/notification/schema/sendAllNotifications.ts
+++ b/api/src/components/notification/schema/sendAllNotifications.ts
@@ -1,0 +1,18 @@
+import * as I from 'interface';
+
+const sendAllNotifications: I.JSONSchemaType<I.TriggerNotificationsQueryParams> = {
+    type: 'object',
+    properties: {
+        apiKey: {
+            type: 'string'
+        },
+        force: {
+            type: 'boolean',
+            nullable: true
+        }
+    },
+    additionalProperties: false,
+    required: ['apiKey']
+};
+
+export default sendAllNotifications;

--- a/api/src/components/notification/service.ts
+++ b/api/src/components/notification/service.ts
@@ -56,3 +56,8 @@ export const removeMany = (ids: string[]) =>
     client.prisma.notification.deleteMany({
         where: { id: { in: ids } }
     });
+
+export const clearFailedNotifications = () =>
+    client.prisma.notification.deleteMany({
+        where: { status: I.NotificationStatusEnum.FAILED }
+    });

--- a/api/src/lib/email.ts
+++ b/api/src/lib/email.ts
@@ -1022,19 +1022,19 @@ const NOTIFICATION_MESSAGES = {
     },
     [I.NotificationActionTypeEnum.PUBLICATION_VERSION_LINKED_PREDECESSOR]: {
         getText: (title: string): string =>
-            `The publication you are an author on, <strong>${title}</strong> has had a parent publication re-versioned.`,
-        getLink: (url: string): string =>
-            `<a href="${url}">Click here to view the new version of the parent publication</a>`,
-        getTextPlain: (title: string, url: string): string =>
-            `The publication you are an author on, ${title} has had a parent publication re-versioned. You can view the new version of the parent publication here: ${url}`
-    },
-    [I.NotificationActionTypeEnum.PUBLICATION_VERSION_LINKED_SUCCESSOR]: {
-        getText: (title: string): string =>
             `The publication you are an author on, <strong>${title}</strong> has had a child publication re-versioned.`,
         getLink: (url: string): string =>
             `<a href="${url}">Click here to view the new version of the child publication</a>`,
         getTextPlain: (title: string, url: string): string =>
             `The publication you are an author on, ${title} has had a child publication re-versioned. You can view the new version of the child publication here: ${url}`
+    },
+    [I.NotificationActionTypeEnum.PUBLICATION_VERSION_LINKED_SUCCESSOR]: {
+        getText: (title: string): string =>
+            `The publication you are an author on, <strong>${title}</strong> has had a parent publication re-versioned.`,
+        getLink: (url: string): string =>
+            `<a href="${url}">Click here to view the new version of the parent publication</a>`,
+        getTextPlain: (title: string, url: string): string =>
+            `The publication you are an author on, ${title} has had a parent publication re-versioned. You can view the new version of the parent publication here: ${url}`
     }
 };
 

--- a/api/src/lib/interface.ts
+++ b/api/src/lib/interface.ts
@@ -1124,6 +1124,11 @@ export interface TriggerAriArchivedCheckQueryParams {
     dryRun?: boolean;
 }
 
+export interface TriggerNotificationsQueryParams {
+    apiKey: string;
+    force?: boolean;
+}
+
 export interface LocalNotifyPubRouterPathParams {
     publicationId: string;
 }


### PR DESCRIPTION
The purpose of this PR was to implement the feedback after testing OC-485: The SUCCESSOR and PREDECESSOR linked applications had the messages reversed. I also included:

1. Separate the cron endpoint and the HTTP endpoint - this allows for applying different validation rules
2. Include a "clearFailedNotifications" endpoint
3. Use middy middleware for validating the notifications endpoints

---

### Acceptance Criteria:
- The notifications logic is not affected

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated
