### PR TITLE
GEM-21 update/remove  jiscSD references

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # The codeowners for the Octopus repository are
-* @JiscSD/Octopus-Dev
+* @Jisc/Octopus-Dev

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Welcome! :tada::sparkles: and thank you for taking the time to contribute to thi
 
 Please take a moment to read through this document in order to make the contribution process as straightforward as possible.
 
-If you want to ask a question, please head on over to the project discussion area on Github: [Octopus Github discussions](https://github.com/JiscSD/octopus/discussions).
+If you want to ask a question, please head on over to the project discussion area on Github: [Octopus Github discussions](https://github.com/Jisc/octopus/discussions).
 
 Please adhere to our [Code of Conduct](CODE-OF-CONDUCT.md) when contributing to this repository.
 
@@ -24,7 +24,7 @@ Please adhere to our [Code of Conduct](CODE-OF-CONDUCT.md) when contributing to 
 
 ---
 
-If you spot a :bug: bug :bug: then feel free to [open an issue](https://github.com/JiscSD/octopus/issues).
+If you spot a :bug: bug :bug: then feel free to [open an issue](https://github.com/Jisc/octopus/issues).
 
 A helpful bug report should include:
 
@@ -39,7 +39,7 @@ A helpful bug report should include:
 
 ---
 
-If you have an :bulb: idea :bulb: for an enhancement or feature then feel free to [post an idea](https://github.com/JiscSD/octopus/discussions/categories/ideas).
+If you have an :bulb: idea :bulb: for an enhancement or feature then feel free to [post an idea](https://github.com/Jisc/octopus/discussions/categories/ideas).
 
 When posting, select the category as `Ideas` and then add a title and some content.
 
@@ -55,7 +55,7 @@ If you would like to submit any changes and contribute some code, please:
 2. create a new branch
 3. make changes
 4. commit/push your new branch
-5. [submit a PR for review](https://github.com/JiscSD/octopus/pulls)
+5. [submit a PR for review](https://github.com/Jisc/octopus/pulls)
 
 A draft pull request should be created as soon as the branch is created, with the label `work in progress`. Only once the PR is ready to be reviewed should you request a review on GitHub.  
 We use Pull request labels to specify when changes are made to the `UI`, the `API`, or `Documentation`.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
     - name: Get Help
-      url: https://github.com/JiscSD/octopus/discussions/new?category=help
+      url: https://github.com/Jisc/octopus/discussions/new?category=help
       about: If you can't get something to work the way you expect, open a question in our discussion forums.
     - name: Feature Request
-      url: https://github.com/JiscSD/octopus/discussions/new?category=ideas
+      url: https://github.com/Jisc/octopus/discussions/new?category=ideas
       about: "Suggest any ideas you have using our discussion forums."
     - name: Bug Report
-      url: https://github.com/JiscSD/octopus/issues/new?body=
+      url: https://github.com/Jisc/octopus/issues/new?body=
       about: If you've already asked for help with a problem and confirmed something is broken, create a bug report.

--- a/.github/workflows/api-build.yml
+++ b/.github/workflows/api-build.yml
@@ -3,7 +3,7 @@ on: [push]
 
 jobs:
   build:
-    if: github.repository == 'JiscSD/octopus'
+    if: github.repository != 'Jisc/octopus'
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
@@ -24,7 +24,7 @@ jobs:
         run: npx tsc --noemit
 
   prettier:
-    if: github.repository == 'JiscSD/octopus'
+    if: github.repository != 'Jisc/octopus'
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
@@ -45,7 +45,7 @@ jobs:
         run: npm run format:check
 
   eslint:
-    if: github.repository == 'JiscSD/octopus'
+    if: github.repository != 'Jisc/octopus'
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -11,7 +11,7 @@ jobs:
   api-tests: 
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    if: github.repository != 'Jisc/octopus' && ${{ !github.event.pull_request.draft }}
+    if: github.repository != 'Jisc/octopus' && !github.event.pull_request.draft
 
     steps:
       - name: Checkout

--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -11,7 +11,7 @@ jobs:
   api-tests: 
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    if: github.repository == 'JiscSD/octopus' && ${{ !github.event.pull_request.draft }}
+    if: github.repository != 'Jisc/octopus' && ${{ !github.event.pull_request.draft }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-int.yml
+++ b/.github/workflows/deploy-int.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   migrate_db:
-    if: github.repository == 'JiscSD/octopus'
+    if: github.repository != 'Jisc/octopus'
     name: Migrate Database
     uses: ./.github/workflows/migrate-db.yml
     with:
@@ -27,7 +27,7 @@ jobs:
       DATABASE_URL: ${{ secrets.DB_CONNECTION_INT }} # The entire connection string, including the RDS DNS, username, password and database
 
   deploy_api:
-    if: github.repository == 'JiscSD/octopus'
+    if: github.repository != 'Jisc/octopus'
     name: Deploy API
     runs-on: ubuntu-latest
     needs: migrate_db

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   migrate_db:
-    if: github.repository == 'JiscSD/octopus'
+    if: github.repository != 'Jisc/octopus'
     name: Migrate Database
     uses: ./.github/workflows/migrate-db.yml
     with:
@@ -27,7 +27,7 @@ jobs:
       DATABASE_URL: ${{ secrets.DB_CONNECTION_PROD }} # The entire connection string, including the RDS DNS, username, password and database
 
   deploy_api:
-    if: github.repository == 'JiscSD/octopus'
+    if: github.repository != 'Jisc/octopus'
     name: Deploy API
     runs-on: ubuntu-latest
     needs: migrate_db

--- a/.github/workflows/migrate-db.yml
+++ b/.github/workflows/migrate-db.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   migrate_db:
-    if: github.repository == 'JiscSD/octopus'
+    if: github.repository != 'Jisc/octopus'
     name: Migrate Database
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ui-tasks.yml
+++ b/.github/workflows/ui-tasks.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   prettier:
-    if: github.repository == 'JiscSD/octopus'
+    if: github.repository != 'Jisc/octopus'
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
@@ -34,7 +34,7 @@ jobs:
         run: npm run format:check
 
   eslint:
-    if: github.repository == 'JiscSD/octopus'
+    if: github.repository != 'Jisc/octopus'
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
@@ -55,7 +55,7 @@ jobs:
         run: npm run lint
 
   lighthouseci:
-    if: github.repository == 'JiscSD/octopus'
+    if: github.repository != 'Jisc/octopus'
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
@@ -82,7 +82,7 @@ jobs:
         run: lhci autorun
 
   ui-tests:
-    if: github.repository == 'JiscSD/octopus'
+    if: github.repository != 'Jisc/octopus'
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
@@ -103,7 +103,7 @@ jobs:
         run: npm run test
 
   typescript-lint:
-    if: github.repository == 'JiscSD/octopus'
+    if: github.repository != 'Jisc/octopus'
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="https://www.jisc.ac.uk/sites/all/themes/jisc_clean/img/jisc-logo.svg" align="right" width=50 height=50/><h1 align="left">Octopus</h1>
 
-![ui-tasks](https://github.com/JiscSD/octopus/actions/workflows/ui-tasks.yml/badge.svg)
+![ui-tasks](/actions/workflows/ui-tasks.yml/badge.svg)
 
 ---
 
@@ -194,7 +194,7 @@ Everyone interacting with this codebase should adhere to our [Code of Conduct](.
 
 Some code has been removed that is no longer needed for the ongoing operation of octopus, but is logged here for future reference:
 
-- Seed data scripts that were used to process the initial data used to populate the database. They were last included in [this commit](https://github.com/JiscSD/octopus/tree/fdd0fc5e0f673a1fe42c4cec0b74fe126be2225b/seed-data-scripts).
+- Seed data scripts that were used to process the initial data used to populate the database. They were last included in [this commit](/tree/fdd0fc5e0f673a1fe42c4cec0b74fe126be2225b/seed-data-scripts).
 
 ## Licence
 

--- a/api/docs/README.md
+++ b/api/docs/README.md
@@ -1,6 +1,6 @@
 # Octopus API documentation
 
-This directory contains the files needed to deploy a static [documentation page](https://jiscsd.github.io/octopus/) for the octopus API.
+This directory contains the files needed to deploy a static [documentation page](https://jisc.github.io/octopus/) for the octopus API.
 
 These are:
 

--- a/api/package.json
+++ b/api/package.json
@@ -7,7 +7,7 @@
     "license": "GPL-3.0-only",
     "repository": {
         "type": "git",
-        "url": "https://github.com/JiscSD/octopus/tree/main/api"
+        "url": "https://github.com/Jisc/octopus/tree/main/api"
     },
     "engines": {
         "node": "20.x"

--- a/api/src/config/application.ts
+++ b/api/src/config/application.ts
@@ -5,7 +5,7 @@ export default {
     author: 'Jisc',
     repository: {
         type: 'git',
-        url: 'https://github.com/JiscSD/octopus'
+        url: 'https://github.com/Jisc/octopus'
     },
     engines: {
         node: '20.x'

--- a/infra/create-app/main.tf
+++ b/infra/create-app/main.tf
@@ -49,6 +49,7 @@ module "oidc" {
   source       = "../modules/oidc"
   environment  = local.environment
   project_name = local.project_name
+  repoId       = var.repoId
 }
 
 module "s3" {
@@ -111,6 +112,7 @@ module "codepipeline" {
   source       = "../modules/codepipeline"
   environment  = local.environment
   project_name = local.project_name
+  repoId       = var.repoId
 }
 
 module "cloudwatch_alarms" {

--- a/infra/create-app/vars.tf
+++ b/infra/create-app/vars.tf
@@ -32,3 +32,8 @@ variable "rds_performance_insights_retention_period" {
 variable "elasticsearch_instance_size" {
   type = string
 }
+
+variable "repoId" {
+  type        = string
+  description = "The GitHub repository ID in the form owner/repo"
+}

--- a/infra/modules/codepipeline/codepipeline.tf
+++ b/infra/modules/codepipeline/codepipeline.tf
@@ -27,7 +27,7 @@ resource "aws_codepipeline" "script-runner-docker-image-codepipeline" {
       // options given here: https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference-CodestarConnectionSource.html#action-reference-CodestarConnectionSource-config
       configuration = {
         ConnectionArn        = data.aws_ssm_parameter.github_codestar_connection_arn.value
-        FullRepositoryId     = "JiscSD/octopus"
+        FullRepositoryId     = var.repoId
         BranchName           = var.environment
         OutputArtifactFormat = "CODE_ZIP"
       }

--- a/infra/modules/codepipeline/vars.tf
+++ b/infra/modules/codepipeline/vars.tf
@@ -5,3 +5,8 @@ variable "project_name" {
 variable "environment" {
   type = string
 }
+
+variable "repoId" {
+  type        = string
+  description = "The GitHub repository ID in the form owner/repo"
+}

--- a/infra/modules/oidc/main.tf
+++ b/infra/modules/oidc/main.tf
@@ -27,7 +27,7 @@ data "aws_iam_policy_document" "trust_github_oidc" {
     condition {
       test     = "StringLike"
       variable = "token.actions.githubusercontent.com:sub"
-      values   = ["repo:JiscSD/octopus:*"]
+      values   = ["${var.repoId}:*"]
     }
   }
 }

--- a/infra/modules/oidc/vars.tf
+++ b/infra/modules/oidc/vars.tf
@@ -6,3 +6,8 @@ variable "project_name" {
 variable "environment" {
   type = string
 }
+
+variable "repoId" {
+  type        = string
+  description = "The GitHub repository ID in the form owner/repo"
+}

--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -56,7 +56,7 @@ const nextConfig = {
             },
             {
                 source: '/documentation/api',
-                destination: 'https://jiscsd.github.io/octopus',
+                destination: 'https://jisc.github.io/octopus',
                 permanent: true
             }
         ];

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,7 +7,7 @@
     "license": "GPL-3.0-only",
     "repository": {
         "type": "git",
-        "url": "https://github.com/JiscSD/octopus/tree/main/ui"
+        "url": "https://github.com/Jisc/octopus/tree/main/ui"
     },
     "engines": {
         "node": "20.x"

--- a/ui/src/components/Footer/index.tsx
+++ b/ui/src/components/Footer/index.tsx
@@ -31,7 +31,7 @@ const Footer: React.FC<Props> = (props: Props): React.ReactElement => (
                 <h2 className="col-span-1 block font-montserrat text-4xl font-bold text-white-50 lg:mb-12">Octopus</h2>
                 <div className="col-span-1 flex space-x-4 pt-4 md:col-span-3 lg:col-span-3">
                     <Components.Link
-                        href="https://github.com/JiscSD/octopus"
+                        href="https://github.com/Jisc/octopus"
                         openNew={true}
                         ariaLabel="Github Repository"
                         className="h-fit"

--- a/ui/src/pages/faq.tsx
+++ b/ui/src/pages/faq.tsx
@@ -117,7 +117,7 @@ const faqContents = [
         content: `
             <p className='mb-2'>Yes. All research published on Octopus is made available under an open access license. Authors retain the copyright to their work.</p>
             <p className='mb-2'>Anyone can read publications without creating an account, but please check the license terms before you share, adapt, or build upon another&apos;s work.</p>
-            <p>The platform is published under the open source license GPLv3. The platform code is available via our public <a href='https://github.com/JiscSD/octopus' className='underline' target='_blank'>Github repository</a>. We invite any interested parties to participate in the ongoing development of the service and its features. See our <a href='${Config.urls.terms.path}' className='underline' target='_blank'>terms page</a> for more information.</p>
+            <p>The platform is published under the open source license GPLv3. The platform code is available via our public <a href='https://github.com/Jisc/octopus' className='underline' target='_blank'>Github repository</a>. We invite any interested parties to participate in the ongoing development of the service and its features. See our <a href='${Config.urls.terms.path}' className='underline' target='_blank'>terms page</a> for more information.</p>
         `
     },
     {


### PR DESCRIPTION
The purpose of this PR was...

* Update references to JiscSD to Jisc where makes sense
* Tweak readme paths to not need full repo path
* parameterize the github repo location in terraform
* change conditional in workflows to skip them on jisc/octopus

##### DONT MERGE until migrated to github enterprise ####


