### PR TITLE
OC-1124: New publications not triggering notifications to authors of parent publications

### DIFF
--- a/api/src/components/notification/bulletin.ts
+++ b/api/src/components/notification/bulletin.ts
@@ -398,12 +398,7 @@ export const createBulletin = async (
         }
 
         case I.NotificationActionTypeEnum.PUBLICATION_VERSION_LINKED_PREDECESSOR: {
-            // We use the previous version because this is the one with the link
-            if (!previousPublishedVersion) {
-                break;
-            }
-
-            const usersToBeNotified = await userService.getUsersWithDirectLinkFromVersion(previousPublishedVersion.id);
+            const usersToBeNotified = await userService.getUsersWithDirectLinkFromVersion(currentPublishedVersion.id);
 
             entries = usersToBeNotified.map((user) => ({
                 userId: user.id,


### PR DESCRIPTION
The purpose of this PR was to fix a bug where the first version of a publication being published will not trigger a notification to be sent to the authors of any publications that are parents to the new one (above in the hierarchy). It also moves the notification logic under the `postPublishHook`

---

### Acceptance Criteria:

---

### Checklist:

- [x] Local manual testing conducted
- [ ] Automated tests added
- [ ] Documentation updated

---

### Tests:

---

### Screenshots:
